### PR TITLE
UX-346 lint rules for prop-types and react imports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,6 +27,13 @@
     "jsx-a11y/label-has-for": "off",
     "new-cap": "off",
     "no-plusplus": "off",
+    "no-restricted-syntax": ["error", {
+      "selector": "ImportDeclaration[source.value=\"prop-types\"] :matches(ImportSpecifier, ImportNamespaceSpecifier)",
+      "message": "Prefer `import PropTypes from \"prop-types\";`"
+    }, {
+      "selector": "ImportDeclaration[source.value=\"react\"] :matches(ImportSpecifier, ImportNamespaceSpecifier)",
+      "message": "Prefer accessing properties of `React` import, e.g. `React.Component`"
+    }],
     "no-underscore-dangle": "off",
     "prefer-destructuring": "off",
     "react/destructuring-assignment": "off",

--- a/packages/Popover/Popover.js
+++ b/packages/Popover/Popover.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React from "react";
 import memoizeOne from "memoize-one";
 import PropTypes from "prop-types";
 import throttle from "lodash.throttle";
@@ -79,7 +79,7 @@ const defaultProps = {
   getScrollContainer: null,
 };
 
-class Popover extends Component {
+class Popover extends React.Component {
   constructor(props) {
     super(props);
 

--- a/packages/Popover/components/Content/Content.js
+++ b/packages/Popover/components/Content/Content.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React from "react";
 import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
 import isCurrentTargetFocused from "../../helpers/isCurrentTargetFocused";
@@ -15,7 +15,7 @@ const defaultProps = {
   zIndex: 1,
 };
 
-class Content extends Component {
+class Content extends React.Component {
   handleMouseEvent = (isEager, onDelayedClose, onDelayedOpen) => event => {
     if (!isEager) return;
     if (event.type === "mouseover") {

--- a/packages/Popover/components/Trigger/Trigger.js
+++ b/packages/Popover/components/Trigger/Trigger.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import RawButton from "@paprika/raw-button";
 
@@ -8,7 +8,7 @@ const propTypes = {
   children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]).isRequired,
 };
 
-class Trigger extends Component {
+class Trigger extends React.Component {
   handleTriggerEvent = (isEager, isOpen, onClick, onDelayedClose, onDelayedOpen, onOpen) => event => {
     if (isEager && (event.type === "mouseover" || event.type === "focus")) {
       if (event.type === "mouseover") {

--- a/packages/Popover/stories/examples/Basic.js
+++ b/packages/Popover/stories/examples/Basic.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React from "react";
 import { text, number, select } from "@storybook/addon-knobs";
 import styled from "styled-components";
 import { CenteredStory } from "storybook/assets/styles/common.styles";
@@ -11,12 +11,12 @@ const Gap = styled.div`
 
 const sampleText = {
   short: "Lorem Hipsum",
-  long: `Lorem ipsum lumbersexual hot chicken austin readymade messenger bag aesthetic meh twee you probably havent 
-    heard of them 3 wolf moon listicle. Normcore ramps gastropub fanny pack pabst. Hashtag roof party pour-over food 
+  long: `Lorem ipsum lumbersexual hot chicken austin readymade messenger bag aesthetic meh twee you probably havent
+    heard of them 3 wolf moon listicle. Normcore ramps gastropub fanny pack pabst. Hashtag roof party pour-over food
     truck, crucifix try-hard godard biodiesel next level snackwave disrupt flexitarian.`,
 };
 
-export default class ExampleStory extends Component {
+export default class ExampleStory extends React.Component {
   render() {
     return (
       <CenteredStory>

--- a/packages/Popover/stories/examples/Controlled.js
+++ b/packages/Popover/stories/examples/Controlled.js
@@ -1,9 +1,9 @@
-import React, { Component } from "react";
+import React from "react";
 import { CenteredStory } from "storybook/assets/styles/common.styles";
 
 import Popover from "../../Popover";
 
-export default class ExampleStory extends Component {
+export default class ExampleStory extends React.Component {
   state = {
     isOpen: false,
   };

--- a/packages/Popover/stories/examples/PositioningElement.js
+++ b/packages/Popover/stories/examples/PositioningElement.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React from "react";
 import { select } from "@storybook/addon-knobs";
 import styled from "styled-components";
 import { CenteredStory } from "storybook/assets/styles/common.styles";
@@ -25,7 +25,7 @@ const PositioningElementStyled = styled.div`
 
 const getPositioningElement = () => document.querySelector("#another-div");
 
-export default class ExampleStory extends Component {
+export default class ExampleStory extends React.Component {
   render() {
     return (
       <CenteredStory>

--- a/packages/Popover/stories/examples/ScrollContainer.js
+++ b/packages/Popover/stories/examples/ScrollContainer.js
@@ -1,6 +1,6 @@
-import React, { Component } from "react";
+import React from "react";
 import { select, text, number } from "@storybook/addon-knobs";
-import { func } from "prop-types";
+import PropTypes from "prop-types";
 import styled from "styled-components";
 import { CenteredStory } from "storybook/assets/styles/common.styles";
 import Popover from "../../Popover";
@@ -55,10 +55,10 @@ const PopoverBox = ({ getScrollContainer }) => (
 );
 
 PopoverBox.propTypes = {
-  getScrollContainer: func.isRequired,
+  getScrollContainer: PropTypes.func.isRequired,
 };
 
-export default class ExampleStory extends Component {
+export default class ExampleStory extends React.Component {
   render() {
     return (
       <React.Fragment>

--- a/packages/Popover/stories/examples/Transformed.js
+++ b/packages/Popover/stories/examples/Transformed.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React from "react";
 import styled from "styled-components";
 import { CenteredStory } from "storybook/assets/styles/common.styles";
 import Popover from "../../Popover";
@@ -10,7 +10,7 @@ const TransformedStory = styled(CenteredStory)`
   height: 50vh;
 `;
 
-export default class ExampleStory extends Component {
+export default class ExampleStory extends React.Component {
   render() {
     return (
       <TransformedStory>

--- a/packages/Popover/stories/examples/WithTriggers.js
+++ b/packages/Popover/stories/examples/WithTriggers.js
@@ -1,5 +1,5 @@
 /* eslint-disable jsx-a11y/mouse-events-have-key-events */
-import React, { Component } from "react";
+import React from "react";
 import styled from "styled-components";
 import { CenteredStory } from "storybook/assets/styles/common.styles";
 import Popover from "../../Popover";
@@ -15,7 +15,7 @@ const Gap = styled.div`
   height: 50px;
 `;
 
-export default class ExampleStory extends Component {
+export default class ExampleStory extends React.Component {
   render() {
     return (
       <CenteredStory>

--- a/packages/TestingHelpers/windowHandles/index.js
+++ b/packages/TestingHelpers/windowHandles/index.js
@@ -1,8 +1,8 @@
-import React, { Component } from "react";
-import { func, object } from "prop-types";
+import React from "react";
+import PropTypes from "prop-types";
 import sinon from "sinon";
 
-class WindowHandles extends Component {
+class WindowHandles extends React.Component {
   constructor(props) {
     super(props);
     this.element = props.story();
@@ -49,9 +49,9 @@ class WindowHandles extends Component {
 }
 
 WindowHandles.propTypes = {
-  story: func.isRequired,
+  story: PropTypes.func.isRequired,
   // eslint-disable-next-line
-  config: object.isRequired,
+  config: PropTypes.object.isRequired,
 };
 
 export class Input {

--- a/packages/Tokens/TokenSquare.js
+++ b/packages/Tokens/TokenSquare.js
@@ -1,8 +1,8 @@
 import React from "react";
-import { string } from "prop-types";
+import PropTypes from "prop-types";
 
 const propTypes = {
-  color: string.isRequired,
+  color: PropTypes.string.isRequired,
 };
 
 export default function TokenSquare(props) {


### PR DESCRIPTION
### 🛠 Purpose

Automate import conventions to streamline code review process.

---

### ✏️ Notes to Reviewer

`no-restricted-syntax` by nature cannot be auto-fixable; it's a lighter-weight way of achieving this than creating a dedicated rule. We'd look into writing a rule if we were to apply this to a bigger codebase that would need auto-fixing (so the non-trivial effort of implementing auto-fix would be justified).

---

### 🖥 Screenshots
![image](https://user-images.githubusercontent.com/93752/56014553-9b3a5d80-5caa-11e9-901e-dcfe1c7f82ba.png)
![image](https://user-images.githubusercontent.com/93752/56014589-bb6a1c80-5caa-11e9-8e18-6463103a7fc1.png)

---
