### PR TITLE
UX-346 detect unused eslint-disable directives

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "docz:dev": "cd documentation && yarn docz:dev",
     "jest:watch": "yarn jest --watch",
     "lint:fix": "yarn lint --fix",
-    "lint": "eslint packages",
+    "lint": "eslint packages --report-unused-disable-directives",
     "postinstall": "cd documentation && yarn",
     "prepare": "lerna run pretranspile && yarn transpile",
     "prettier:format": "yarn prettier -- --write",

--- a/packages/Popover/src/components/Trigger/Trigger.js
+++ b/packages/Popover/src/components/Trigger/Trigger.js
@@ -31,7 +31,6 @@ class Trigger extends React.Component {
 
           if (typeof this.props.children !== "function") {
             /* issue https://github.com/acl-services/paprika/issues/33 */
-            /* eslint-disable jsx-a11y/mouse-events-have-key-events */
             return isEager ? (
               <RawButton
                 data-qa-anchor="popover-trigger"

--- a/packages/TestingHelpers/src/windowHandles/index.js
+++ b/packages/TestingHelpers/src/windowHandles/index.js
@@ -37,7 +37,6 @@ class WindowHandles extends React.Component {
       window[this.element.type.name] = this.windowProps;
     }
 
-    // eslint-disable-next-line
     for (const key of Object.keys(this.props.config)) {
       this.props.config[key].apply(this, key);
     }
@@ -62,7 +61,7 @@ export class Input {
   apply(wrapper, key) {
     // eslint-disable-next-line
     wrapper.childProps[key] =
-      wrapper.isPropUndefinedOrDefault(key) && typeof this.initialValue !== "undefined" // eslint-disable-line
+      wrapper.isPropUndefinedOrDefault(key) && typeof this.initialValue !== "undefined"
         ? this.initialValue
         : wrapper.element.props[key];
     Object.defineProperty(wrapper.windowProps, key, {


### PR DESCRIPTION
### 🛠 Purpose
A redundant `eslint-disable` directive is actually somewhat dangerous. After the original reason it was added for is gone, the directive may be masking other issues that have appeared within the same piece of code, without anyone ever noticing.

For VS Code integration, go to `Eslint: Options` => `Edit in settings.json` and add
```
"eslint.options": {
  "reportUnusedDisableDirectives": true
}
```
---

### ✏️ Notes to Reviewer

---

### 🖥 Screenshots
![image](https://user-images.githubusercontent.com/93752/56836476-35161480-682c-11e9-8eb8-d31a79be6f93.png)

![image](https://user-images.githubusercontent.com/93752/56836483-3e06e600-682c-11e9-963b-c326062c71ba.png)

---
