### PR TITLE
UX-437 Add react-testing-library tests for RawButton 🐐

### DIFF
--- a/packages/RawButton/test/RawButton.spec.js
+++ b/packages/RawButton/test/RawButton.spec.js
@@ -25,10 +25,10 @@ describe("RawButton", () => {
   it("should render with default props", () => {
     const { getByText, getByRole, container } = renderComponent();
 
-    expect(getByText(/happy button/i)).toBeVisible();
-    expect(getByRole("button")).toBeVisible();
-    expect(container.querySelector('[tabindex="0"]')).toBeVisible();
-    expect(container.querySelector('[aria-disabled="false"]')).toBeVisible();
+    expect(getByText(/happy button/i)).toBeInTheDocument();
+    expect(getByRole("button")).toBeInTheDocument();
+    expect(container.querySelector('[tabindex="0"]')).toBeInTheDocument();
+    expect(container.querySelector('[aria-disabled="false"]')).toBeInTheDocument();
   });
 
   it("should render with custom props", () => {
@@ -41,11 +41,11 @@ describe("RawButton", () => {
     };
     const { getByRole, container } = renderComponent(customProps);
 
-    expect(container.querySelector('[aria-label="include me"]')).toBeVisible();
-    expect(container.querySelector('[class*="shiny-button"]')).toBeVisible();
-    expect(container.querySelector('[aria-disabled="true"]')).toBeVisible();
-    expect(getByRole("listitem")).toBeVisible();
-    expect(container.querySelector('[tabindex="-1"]')).toBeVisible();
+    expect(container.querySelector('[aria-label="include me"]')).toBeInTheDocument();
+    expect(container.querySelector('[class*="shiny-button"]')).toBeInTheDocument();
+    expect(container.querySelector('[aria-disabled="true"]')).toBeInTheDocument();
+    expect(getByRole("listitem")).toBeInTheDocument();
+    expect(container.querySelector('[tabindex="-1"]')).toBeInTheDocument();
   });
 
   it("should fire onClick callback when clicked", () => {

--- a/packages/RawButton/test/RawButton.spec.js
+++ b/packages/RawButton/test/RawButton.spec.js
@@ -22,7 +22,7 @@ function renderComponent(props = {}) {
 }
 
 describe("RawButton", () => {
-  it("should render with default props", () => {
+  it("Renders with default props", () => {
     const { getByText, getByRole, container } = renderComponent();
 
     expect(getByText(/happy button/i)).toBeInTheDocument();
@@ -31,22 +31,22 @@ describe("RawButton", () => {
     expect(container.querySelector('[aria-disabled="false"]')).toBeInTheDocument();
   });
 
-  it("should render with custom props", () => {
+  it("Renders with custom props", () => {
     const customProps = {
-      a11yText: "include me",
+      a11yText: "button which is happy",
       isDisabled: true,
       role: "listitem",
       tabIndex: -1,
     };
-    const { getByRole, container } = renderComponent(customProps);
+    const { getByLabelText, getByRole, container } = renderComponent(customProps);
 
-    expect(container.querySelector('[aria-label="include me"]')).toBeInTheDocument();
+    expect(getByLabelText("button which is happy")).toBeInTheDocument();
     expect(container.querySelector('[aria-disabled="true"]')).toBeInTheDocument();
     expect(getByRole("listitem")).toBeInTheDocument();
     expect(container.querySelector('[tabindex="-1"]')).toBeInTheDocument();
   });
 
-  it("should fire onClick callback when clicked", () => {
+  it("Fires onClick callback when clicked", () => {
     const onClick = jest.fn();
     const { getByText } = renderComponent({ onClick });
     fireEvent.click(getByText(/happy button/i));
@@ -54,7 +54,7 @@ describe("RawButton", () => {
     expect(onClick).toHaveBeenCalled();
   });
 
-  it("should fire onClick callback when keypressed", () => {
+  it("Fires onClick callback when keypressed", () => {
     const onClick = jest.fn();
     const { getByText } = renderComponent({ onClick });
     const buttonElement = getByText(/happy button/i);
@@ -64,7 +64,7 @@ describe("RawButton", () => {
     expect(onClick).toHaveBeenCalledTimes(2);
   });
 
-  it("should not fire onClick callback when disabled", () => {
+  it("Does not fire onClick callback when disabled", () => {
     const onClick = jest.fn();
     const { getByText } = renderComponent({ onClick, isDisabled: true });
     const buttonElement = getByText(/happy button/i);
@@ -75,7 +75,7 @@ describe("RawButton", () => {
     expect(onClick).not.toHaveBeenCalled();
   });
 
-  it("should propagate click events by default", () => {
+  it("Propagates click events by default", () => {
     const onClick = jest.fn();
     const bubbledClick = jest.fn();
     const { getByText } = render(
@@ -89,7 +89,7 @@ describe("RawButton", () => {
     expect(bubbledClick).toHaveBeenCalled();
   });
 
-  it("should not propagate click events when canPropagate=false", () => {
+  it("Does not propagate click events when canPropagate=false", () => {
     const onClick = jest.fn();
     const bubbledClick = jest.fn();
     const { getByText } = render(
@@ -105,7 +105,7 @@ describe("RawButton", () => {
     expect(bubbledClick).not.toHaveBeenCalled();
   });
 
-  it("should be focussable via ref", () => {
+  it("Is focussable via ref", () => {
     const buttonRef = React.createRef();
     renderComponent({ ref: buttonRef });
     buttonRef.current.focus();
@@ -113,7 +113,7 @@ describe("RawButton", () => {
     expect(document.activeElement.getAttribute("role")).toEqual("button");
   });
 
-  it("should be focussable via callback ref", () => {
+  it("Is focussable via callback ref", () => {
     let buttonRef;
     const setRef = component => {
       buttonRef = component;

--- a/packages/RawButton/test/RawButton.spec.js
+++ b/packages/RawButton/test/RawButton.spec.js
@@ -34,7 +34,6 @@ describe("RawButton", () => {
   it("should render with custom props", () => {
     const customProps = {
       a11yText: "include me",
-      className: "shiny-button",
       isDisabled: true,
       role: "listitem",
       tabIndex: -1,
@@ -42,7 +41,6 @@ describe("RawButton", () => {
     const { getByRole, container } = renderComponent(customProps);
 
     expect(container.querySelector('[aria-label="include me"]')).toBeInTheDocument();
-    expect(container.querySelector('[class*="shiny-button"]')).toBeInTheDocument();
     expect(container.querySelector('[aria-disabled="true"]')).toBeInTheDocument();
     expect(getByRole("listitem")).toBeInTheDocument();
     expect(container.querySelector('[tabindex="-1"]')).toBeInTheDocument();

--- a/packages/RawButton/test/RawButton.spec.js
+++ b/packages/RawButton/test/RawButton.spec.js
@@ -1,0 +1,128 @@
+/* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
+
+import React from "react";
+import { render, fireEvent } from "react-testing-library";
+import RawButton from "../src";
+
+const noop = () => {};
+
+const pressEnter = { key: "Enter" };
+const pressSpace = { key: " " };
+
+function renderComponent(props = {}) {
+  const defaultProps = {
+    onClick: noop,
+  };
+
+  return render(
+    <RawButton {...defaultProps} {...props}>
+      {props.children || "happy button"}
+    </RawButton>
+  );
+}
+
+describe("RawButton", () => {
+  it("should render with default props", () => {
+    const { getByText, getByRole, container } = renderComponent();
+
+    expect(getByText(/happy button/i)).toBeVisible();
+    expect(getByRole("button")).toBeVisible();
+    expect(container.querySelector('[tabindex="0"]')).toBeVisible();
+    expect(container.querySelector('[aria-disabled="false"]')).toBeVisible();
+  });
+
+  it("should render with custom props", () => {
+    const customProps = {
+      a11yText: "include me",
+      className: "shiny-button",
+      isDisabled: true,
+      role: "listitem",
+      tabIndex: -1,
+    };
+    const { getByRole, container } = renderComponent(customProps);
+
+    expect(container.querySelector('[aria-label="include me"]')).toBeVisible();
+    expect(container.querySelector('[class*="shiny-button"]')).toBeVisible();
+    expect(container.querySelector('[aria-disabled="true"]')).toBeVisible();
+    expect(getByRole("listitem")).toBeVisible();
+    expect(container.querySelector('[tabindex="-1"]')).toBeVisible();
+  });
+
+  it("should fire onClick callback when clicked", () => {
+    const onClick = jest.fn();
+    const { getByText } = renderComponent({ onClick });
+    fireEvent.click(getByText(/happy button/i));
+
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it("should fire onClick callback when keypressed", () => {
+    const onClick = jest.fn();
+    const { getByText } = renderComponent({ onClick });
+    const buttonElement = getByText(/happy button/i);
+    fireEvent.keyUp(buttonElement, pressEnter);
+    fireEvent.keyUp(buttonElement, pressSpace);
+
+    expect(onClick).toHaveBeenCalledTimes(2);
+  });
+
+  it("should not fire onClick callback when disabled", () => {
+    const onClick = jest.fn();
+    const { getByText } = renderComponent({ onClick, isDisabled: true });
+    const buttonElement = getByText(/happy button/i);
+    fireEvent.click(buttonElement);
+    fireEvent.keyUp(buttonElement, pressEnter);
+    fireEvent.keyUp(buttonElement, pressSpace);
+
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("should propagate click events by default", () => {
+    const onClick = jest.fn();
+    const bubbledClick = jest.fn();
+    const { getByText } = render(
+      <div onClick={bubbledClick}>
+        <RawButton onClick={onClick}>happy button</RawButton>
+      </div>
+    );
+    const buttonElement = getByText(/happy button/i);
+    fireEvent.click(buttonElement);
+
+    expect(bubbledClick).toHaveBeenCalled();
+  });
+
+  it("should not propagate click events when canPropagate=false", () => {
+    const onClick = jest.fn();
+    const bubbledClick = jest.fn();
+    const { getByText } = render(
+      <div onClick={bubbledClick}>
+        <RawButton onClick={onClick} canPropagate={false}>
+          happy button
+        </RawButton>
+      </div>
+    );
+    const buttonElement = getByText(/happy button/i);
+    fireEvent.click(buttonElement);
+
+    expect(bubbledClick).not.toHaveBeenCalled();
+  });
+
+  it("should be focussable via ref", () => {
+    const buttonRef = React.createRef();
+    renderComponent({ ref: buttonRef });
+    buttonRef.current.focus();
+
+    expect(document.activeElement.getAttribute("role")).toEqual("button");
+  });
+
+  it("should be focussable via callback ref", () => {
+    let buttonRef;
+    const setRef = component => {
+      buttonRef = component;
+    };
+    renderComponent({ ref: setRef });
+    buttonRef.focus();
+
+    expect(document.activeElement.getAttribute("role")).toEqual("button");
+  });
+});


### PR DESCRIPTION
### 🛠 Purpose
Add `react-testing-library` "unit" tests for `<RawButton>`.

### ✏️ Notes to Reviewer
✓ Renders with default props
✓ Renders with custom props
✓ Fires onClick callback when clicked
✓ Fires onClick callback when keypressed
✓ Does not fire onClick callback when disabled
✓ Propagates click events by default
✓ Does not propagate click events when canPropagate=false
✓ Is focussable via ref
✓ Is focussable via callback ref

