### PR TITLE
UX-467 Add some basic documentation for RawButton and Button 🐐

### DIFF
--- a/packages/Button/readme.md
+++ b/packages/Button/readme.md
@@ -8,7 +8,7 @@ It is rendered as a `<button>` element by default, but can also be rendered as a
 
 ### Installation
 
-`> npm install @paprika/button`
+`> npm install --save @paprika/button`
 or
 `> yarn add @paprika/button`
 

--- a/packages/Button/readme.md
+++ b/packages/Button/readme.md
@@ -1,0 +1,65 @@
+## Button
+
+The `<Button>` component is a fully accessible button intended for use typically as a skeuomorphic button, but many visual styles (kinds) are available.
+
+For buttons with a label that is only an icon, the `<Button.Icon>` component is provided. For typical close buttons, `<Button.Close>` is provided.
+
+It is rendered as a `<button>` element by default, but can also be rendered as a generic `<span>`, via the `<RawButton>` if global CSS conflicts are an issue (when `isSemantic` prop is set to `false`).
+
+### Installation
+
+`> npm install @paprika/button`
+or
+`> yarn add @paprika/button`
+
+### Usage
+
+For a basic button
+
+```js
+import Button from "@paprika/button";
+
+<Button onClick={clickHandler}>Button label</Button>;
+```
+
+Or a button
+
+```js
+import Button from "@paprika/button";
+import InfoIcon from "@paprika/icon/lib/InfoCircle";
+
+<Button.Icon onClick={clickHandler}>
+  <InfoIcon />
+</Button.Icon>;
+```
+
+```js
+import Button from "@paprika/button";
+
+<Button.Close onClick={clickHandler} />;
+```
+
+### Props
+
+- `a11yText`
+- `canPropagate`
+- `children`
+- `icon`
+- `isActive`
+- `isDisabled`
+- `isDropdown`
+- `isFullWidth`
+- `isPending`
+- `isSemantic`
+- `isSubmit`
+- `kind` `["default", "primary", "secondary", "destructive", "flat", "minor", "link"]`
+- `onClick` (required)
+- `role`
+- `size` `["small", "medium", "large"]`
+- `tabIndex`
+
+#### Button.Close
+
+- `isDark`
+
+[More detail about these props](https://github.com/acl-services/paprika/blob/master/packages/Button/src/Button.js)

--- a/packages/Button/src/Button.js
+++ b/packages/Button/src/Button.js
@@ -7,21 +7,52 @@ import { ShirtSizes } from "@paprika/helpers/lib/customPropTypes";
 import buttonStyles, { iconStyles } from "./Button.styles";
 
 const propTypes = {
+  /** Descriptive a11y text for assistive technologies. By default, text from children node will be used. */
   a11yText: PropTypes.string,
+
+  /** If click events are allowed to propagate up the DOM tree. */
   canPropagate: PropTypes.bool,
+
+  /** Body content of the button. */
   children: PropTypes.node,
+
+  /** An icon to be included to the left of children content. */
   icon: PropTypes.node,
+
+  /** If the button is in an "active" or "selected" state. */
   isActive: PropTypes.bool,
+
+  /** If the button is disabled. */
   isDisabled: PropTypes.bool,
+
+  /** If the button includes a down arrow to the right of children content. */
   isDropdown: PropTypes.bool,
+
+  /** If the width of the button should span it's parent container (100%). */
   isFullWidth: PropTypes.bool,
+
+  /** If the button should render in a pending state (with a spinner icon). */
   isPending: PropTypes.bool,
+
+  /** If it will be rendered as a <button> element. If false, a <span> will be rendered via an accessible <RawButton>. */
   isSemantic: PropTypes.bool,
+
+  /** If the type attribute should "submit", instead of the default "button". */
   isSubmit: PropTypes.bool,
+
+  /** The visual style of the button. */
   kind: PropTypes.oneOf(["default", "primary", "secondary", "destructive", "flat", "minor", "link"]),
+
+  /** Callback to be executed when the button is clicked or activated by keyboard. Typically required. */
   onClick: PropTypes.func,
+
+  /** Value for role attribute to override the default of "button". */
   role: PropTypes.string,
+
+  /** Size of the button (font size, min-height, padding, etc). */
   size: PropTypes.oneOf(ShirtSizes.DEFAULT),
+
+  /** Value for tabindex attribute to override the default of 0. */
   tabIndex: PropTypes.number,
 };
 

--- a/packages/Button/src/CloseButton.js
+++ b/packages/Button/src/CloseButton.js
@@ -5,7 +5,10 @@ import closeButtonStyles from "./CloseButton.styles";
 import IconButton from "./IconButton";
 
 const propTypes = {
+  /** Descriptive a11y text for assistive technologies. By default, text from children node will be used. */
   a11yText: PropTypes.string,
+
+  /** If the close button will be rendered on a dark background and will use inverted colours. */
   isDark: PropTypes.bool,
 };
 

--- a/packages/Button/src/IconButton.js
+++ b/packages/Button/src/IconButton.js
@@ -4,6 +4,7 @@ import iconButtonStyles from "./IconButton.styles";
 import Button from ".";
 
 const IconPropTypes = {
+  /** Body content of the button (an icon). */
   children: PropTypes.node.isRequired,
 };
 

--- a/packages/RawButton/readme.md
+++ b/packages/RawButton/readme.md
@@ -6,7 +6,7 @@ For accessibility, the `role="button"`, `tabIndex="0"`, and `aria-disabled="fals
 
 ### Installation
 
-`> npm install @paprika/raw-button`
+`> npm install --save @paprika/raw-button`
 or
 `> yarn add @paprika/raw-button`
 

--- a/packages/RawButton/readme.md
+++ b/packages/RawButton/readme.md
@@ -1,0 +1,32 @@
+## RawButton
+
+The `<RawButton>` component is a fully accessible button, rendered with almost no styling as a generic `<span>` element. It is intended for use any time click actions are needed for a UI element that is not visually represented as a skeuomorphic button.
+
+For accessibility, the `role="button"`, `tabIndex="0"`, and `aria-disabled="false"` attributes are added by default, but can be overridden. An `aria-label` can be included via the `a11yText` prop, a visual focus ring is applied, and keyboard listeners are included that will fire the `onClick` function when the user activates the component with an `enter` or `space` keypress.
+
+### Installation
+
+`> npm install @paprika/raw-button`
+or
+`> yarn add @paprika/raw-button`
+
+### Usage
+
+```js
+import RawButton from "@paprika/raw-button";
+
+<RawButton onClick={clickHandler}>Visible click target</RawButton>;
+```
+
+### Props
+
+- `a11yText`
+- `canPropagate`
+- `children` (required)
+- `hasInsetFocusStyle`
+- `isDisabled`
+- `onClick` (required)
+- `tabIndex`
+- `role`
+
+[More detail about these props](https://github.com/acl-services/paprika/blob/master/packages/RawButton/src/RawButton.js)

--- a/packages/RawButton/src/RawButton.js
+++ b/packages/RawButton/src/RawButton.js
@@ -5,21 +5,34 @@ import PropTypes from "prop-types";
 import rawButtonStyles from "./RawButton.styles";
 
 const propTypes = {
+  /** Descriptive a11y text for assistive technologies. By default, text from children node will be used. */
   a11yText: PropTypes.string,
+
+  /** If click events are allowed to propagate up the DOM tree. */
   canPropagate: PropTypes.bool,
+
+  /** Body content of the button. */
   children: PropTypes.node.isRequired,
-  className: PropTypes.string,
+
+  /** If the visual focus ring should be displayed with an inset style. */
   hasInsetFocusStyle: PropTypes.bool,
+
+  /** If the button is disabled. */
   isDisabled: PropTypes.bool,
+
+  /** Callback to be executed when the button is clicked or activated by keyboard. Typically required. */
   onClick: PropTypes.func,
-  tabIndex: PropTypes.number,
+
+  /** Value for role attribute to override the default of "button". */
   role: PropTypes.string,
+
+  /** Value for tabindex attribute to override the default of 0. */
+  tabIndex: PropTypes.number,
 };
 
 const defaultProps = {
   a11yText: null,
   canPropagate: true,
-  className: null,
   isDisabled: false,
   hasInsetFocusStyle: false,
   onClick: () => {},


### PR DESCRIPTION
### 🛠 Purpose
Add prop descriptions and `readme.md` files for both the `<RawButton>` and `<Button>`.


### ✏️ Notes to Reviewer
- Also removed unneeded `className` prop from `<RawButton>`.

