### PR TITLE
UX-437 Add react-testing-library tests for Button 🐐

### DIFF
--- a/packages/Button/test/Button.spec.js
+++ b/packages/Button/test/Button.spec.js
@@ -1,0 +1,118 @@
+/* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
+
+import React from "react";
+import { render, fireEvent } from "react-testing-library";
+import Button from "../src";
+
+const noop = () => {};
+
+function renderComponent(props = {}) {
+  const defaultProps = {
+    onClick: noop,
+  };
+
+  return render(
+    <Button {...defaultProps} {...props}>
+      {props.children || "happy button"}
+    </Button>
+  );
+}
+
+describe("Button", () => {
+  it("Renders with default props", () => {
+    const { getByText, container } = renderComponent();
+    expect(getByText(/happy button/i)).toBeInTheDocument();
+    expect(container.querySelector("button")).toBeInTheDocument();
+    expect(container.querySelector('[type="button"]')).toBeInTheDocument();
+    expect(container.querySelector('[tabindex="0"]')).toBeInTheDocument();
+  });
+
+  it("Renders a span when isSemantic=false", () => {
+    const { container } = renderComponent({ isSemantic: false });
+
+    expect(container.querySelector("span[role=button]")).toBeInTheDocument();
+  });
+
+  it("Renders with custom props", () => {
+    const customProps = {
+      a11yText: "button which is happy",
+      isDisabled: true,
+      isSubmit: true,
+      role: "listitem",
+      tabIndex: -1,
+    };
+    const { getByLabelText, getByRole, container } = renderComponent(customProps);
+
+    expect(getByLabelText("button which is happy")).toBeInTheDocument();
+    expect(getByRole("listitem")).toBeInTheDocument();
+    expect(container.querySelector("[disabled]")).toBeInTheDocument();
+    expect(container.querySelector('[type="submit"]')).toBeInTheDocument();
+    expect(container.querySelector('[tabindex="-1"]')).toBeInTheDocument();
+  });
+
+  it("Fires onClick callback when clicked", () => {
+    const onClick = jest.fn();
+    const { getByText } = renderComponent({ onClick });
+    fireEvent.click(getByText(/happy button/i));
+
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it("Does not fire onClick callback when disabled", () => {
+    const onClick = jest.fn();
+    const { getByText } = renderComponent({ onClick, isDisabled: true });
+    const buttonElement = getByText(/happy button/i);
+    fireEvent.click(buttonElement);
+
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("Propagates click events by default", () => {
+    const onClick = jest.fn();
+    const bubbledClick = jest.fn();
+    const { getByText } = render(
+      <div onClick={bubbledClick}>
+        <Button onClick={onClick}>happy button</Button>
+      </div>
+    );
+    const buttonElement = getByText(/happy button/i);
+    fireEvent.click(buttonElement);
+
+    expect(bubbledClick).toHaveBeenCalled();
+  });
+
+  it("Does not propagate click events when canPropagate=false", () => {
+    const onClick = jest.fn();
+    const bubbledClick = jest.fn();
+    const { getByText } = render(
+      <div onClick={bubbledClick}>
+        <Button onClick={onClick} canPropagate={false}>
+          happy button
+        </Button>
+      </div>
+    );
+    const buttonElement = getByText(/happy button/i);
+    fireEvent.click(buttonElement);
+
+    expect(bubbledClick).not.toHaveBeenCalled();
+  });
+
+  it("Is focussable via ref", () => {
+    const buttonRef = React.createRef();
+    renderComponent({ ref: buttonRef });
+    buttonRef.current.focus();
+
+    expect(document.activeElement.tagName.toLowerCase()).toEqual("button");
+  });
+
+  it("Is focussable via callback ref", () => {
+    let buttonRef;
+    const setRef = component => {
+      buttonRef = component;
+    };
+    renderComponent({ ref: setRef });
+    buttonRef.focus();
+
+    expect(document.activeElement.tagName.toLowerCase()).toEqual("button");
+  });
+});

--- a/packages/RawButton/test/RawButton.spec.js
+++ b/packages/RawButton/test/RawButton.spec.js
@@ -34,15 +34,20 @@ describe("RawButton", () => {
   it("Renders with custom props", () => {
     const customProps = {
       a11yText: "button which is happy",
-      isDisabled: true,
       role: "listitem",
       tabIndex: -1,
     };
     const { getByLabelText, getByRole, container } = renderComponent(customProps);
 
     expect(getByLabelText("button which is happy")).toBeInTheDocument();
-    expect(container.querySelector('[aria-disabled="true"]')).toBeInTheDocument();
     expect(getByRole("listitem")).toBeInTheDocument();
+    expect(container.querySelector('[tabindex="-1"]')).toBeInTheDocument();
+  });
+
+  it("Renders properly with isDisabled=true", () => {
+    const { container } = renderComponent({ isDisabled: true });
+
+    expect(container.querySelector('[aria-disabled="true"]')).toBeInTheDocument();
     expect(container.querySelector('[tabindex="-1"]')).toBeInTheDocument();
   });
 


### PR DESCRIPTION
### 🛠 Purpose
Add `react-testing-library` "unit" tests for `<Button>`.

### ✏️ Notes to Reviewer
- Very similar approach to tests for `<RawButton>` (https://github.com/acl-services/paprika/pull/73)
- Adjusted `<RawButton>` tests to better cover `isDisabled` scenario.

✓ Renders with default props
✓ Renders a span when isSemantic=false
✓ Renders with custom props
✓ Fires onClick callback when clicked
✓ Does not fire onClick callback when disabled
✓ Propagates click events by default
✓ Does not propagate click events when canPropagate=false
✓ Is focussable via ref
✓ Is focussable via callback ref


