### PR TITLE
UX-346 Fix Button styling 🐐

### DIFF
--- a/packages/Button/src/CloseButton.styles.js
+++ b/packages/Button/src/CloseButton.styles.js
@@ -1,12 +1,14 @@
+import { css } from "styled-components";
+
 import tokens from "@paprika/tokens";
 import stylers from "@paprika/stylers";
 
-const darkStyles = `
+const darkStyles = css`
   transition: background-color 0.2s ease-out;
 
   &:hover {
     background-color: ${stylers.alpha(tokens.color.white, 0.2)};
-    
+
     .button__icon {
       color: ${tokens.color.white};
     }
@@ -28,12 +30,12 @@ const darkStyles = `
   }
 `;
 
-const closeButtonStyles = props => `
+const closeButtonStyles = css`
   .button__icon {
     color: ${tokens.textColor.icon};
   }
 
-  ${props.isDark ? darkStyles : ""}
+  ${({ isDark }) => (isDark ? darkStyles : "")}
 `;
 
 export default closeButtonStyles;

--- a/packages/Button/src/IconButton.js
+++ b/packages/Button/src/IconButton.js
@@ -1,11 +1,23 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { ShirtSizes } from "@paprika/helpers/lib/customPropTypes";
 import iconButtonStyles from "./IconButton.styles";
 import Button from "./Button";
 
 const IconPropTypes = {
   /** Body content of the button (an icon). */
   children: PropTypes.node.isRequired,
+
+  /** The visual style of the button. */
+  kind: PropTypes.oneOf(["default", "primary", "secondary", "destructive", "flat", "minor", "link"]),
+
+  /** Size of the button (font size, min-height, padding, etc). */
+  size: PropTypes.oneOf(ShirtSizes.DEFAULT),
+};
+
+const IconDefaultProps = {
+  kind: "default",
+  size: "medium",
 };
 
 const IconButton = React.forwardRef((props, ref) => {
@@ -20,5 +32,6 @@ const IconButton = React.forwardRef((props, ref) => {
 
 IconButton.displayName = "IconButton";
 IconButton.propTypes = IconPropTypes;
+IconButton.defaultProps = IconDefaultProps;
 
 export default IconButton;

--- a/packages/Button/src/IconButton.styles.js
+++ b/packages/Button/src/IconButton.styles.js
@@ -1,22 +1,23 @@
+import { css } from "styled-components";
 import tokens from "@paprika/tokens";
 import stylers from "@paprika/stylers";
 
 const iconButtonSizes = {
-  small: `
+  small: css`
     ${stylers.fontSize(-2)};
     height: ${stylers.spacer(3)}; 
     line-height: ${stylers.spacer(3) - 2};  
     padding: 0; 
     width: ${stylers.spacer(3)}; 
   }`,
-  medium: `
+  medium: css`
     ${stylers.fontSize(1)};
     height: ${stylers.spacer(4)}; 
     line-height: ${stylers.spacer(4) - 2};  
     padding: 0; 
     width: ${stylers.spacer(4)}; 
   }`,
-  large: `
+  large: css`
     ${stylers.fontSize(3)};
     height: ${stylers.spacer(5)}; 
     line-height: ${stylers.spacer(5) - 2};  
@@ -25,11 +26,11 @@ const iconButtonSizes = {
   }`,
 };
 
-const minorStyles = `
+const minorStyles = css`
   transition: background-color 0.2s ease-out;
-  
+
   &:hover {
-    background-color: ${stylers.alpha(tokens.color.black, 0.1)}; 
+    background-color: ${stylers.alpha(tokens.color.black, 0.1)};
   }
 
   &:active {
@@ -37,9 +38,9 @@ const minorStyles = `
   }
 `;
 
-const iconButtonStyles = props => `
-  ${iconButtonSizes[props.size]}
-  ${props.kind === "minor" ? minorStyles : ""}
+const iconButtonStyles = css`
+  ${({ size }) => iconButtonSizes[size]}
+  ${({ kind }) => (kind === "minor" ? minorStyles : "")}
 
   .button__icon {
     color: inherit;


### PR DESCRIPTION
### 🛠 Purpose
Resolve styling regression with `<Button.Icon>` and `<Button.Close>`.

### ✍ Notes
- Refactored some `.styles.js` files to use the styled-components `css` helper, to contribute to https://github.com/acl-services/paprika/issues/98

### 🖥 Screenshots
Screener regression that was fixed:
![Screen Shot 2019-06-26 at 8 42 30 PM](https://user-images.githubusercontent.com/14944896/60232990-4fcc3000-9853-11e9-8368-c8e27c59d35d.png)
