### PR TITLE
Dropdown tweaks, Tab focus, Buttons as spans, create Cypress test

### DIFF
--- a/packages/DropdownMenu/package.json
+++ b/packages/DropdownMenu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paprika/dropdown-menu",
-  "version": "0.1.2",
+  "version": "0.1.1",
   "description": "DropdownMenu component",
   "author": "@paprika",
   "license": "MIT",

--- a/packages/DropdownMenu/package.json
+++ b/packages/DropdownMenu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paprika/dropdown-menu",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "DropdownMenu component",
   "author": "@paprika",
   "license": "MIT",

--- a/packages/DropdownMenu/src/DropdownMenu.js
+++ b/packages/DropdownMenu/src/DropdownMenu.js
@@ -58,10 +58,11 @@ const DropdownMenu = props => {
 
   const renderTrigger = () => {
     const triggerComponent = props.renderTrigger(getTriggerStateAndHelpers);
-    return React.cloneElement(triggerComponent, {
-      triggerRef,
-      menuRefId: menuRefId.current,
-    });
+    return () =>
+      React.cloneElement(triggerComponent, {
+        triggerRef,
+        menuRefId: menuRefId.current,
+      });
   };
 
   const renderContent = () => {

--- a/packages/DropdownMenu/src/DropdownMenu.js
+++ b/packages/DropdownMenu/src/DropdownMenu.js
@@ -44,7 +44,7 @@ const DropdownMenu = props => {
     setIsOpen(true);
   };
 
-  const getTriggerStateAndHelpers = {
+  const triggerProps = {
     isOpen,
     handleOpenMenu,
   };
@@ -57,7 +57,9 @@ const DropdownMenu = props => {
   const menuRefId = React.useRef(uuid());
 
   const renderTrigger = () => {
-    const triggerComponent = props.renderTrigger(getTriggerStateAndHelpers);
+    const triggerComponent = props.renderTrigger(triggerProps);
+    // wrapping the returned item in a function to avoid needing to tab twice
+    // https://github.com/acl-services/paprika/issues/126
     return () =>
       React.cloneElement(triggerComponent, {
         triggerRef,

--- a/packages/DropdownMenu/src/components/Confirmation/Confirmation.js
+++ b/packages/DropdownMenu/src/components/Confirmation/Confirmation.js
@@ -42,10 +42,16 @@ const Confirmation = props => {
             <div className="dropdown-menu__confirmation-header">{heading}</div>
             {description && <div className="dropdown-menu__confirmation-description">{description}</div>}
             <div className="dropdown-menu__confirmation-footer">
-              <Button ref={confirmRef} kind={confirmButtonType} size={buttonSize} onClick={onConfirm}>
+              <Button
+                isSemantic={false}
+                ref={confirmRef}
+                kind={confirmButtonType}
+                size={buttonSize}
+                onClick={onConfirm}
+              >
                 {confirmLabel}
               </Button>
-              <Button kind="minor" size={buttonSize} onClick={onCancel}>
+              <Button isSemantic={false} kind="minor" size={buttonSize} onClick={onCancel}>
                 {I18n.t("actions.cancel")}
               </Button>
             </div>

--- a/packages/DropdownMenu/stories/cypress.stories.js
+++ b/packages/DropdownMenu/stories/cypress.stories.js
@@ -1,0 +1,6 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+
+import DropdownMenuExample from "./examples/DropdownMenuExample";
+
+storiesOf("dropdownmenu / cypress", module).add("dropdownmenu test", () => <DropdownMenuExample />);

--- a/packages/DropdownMenu/stories/examples/DropdownMenuExample.js
+++ b/packages/DropdownMenu/stories/examples/DropdownMenuExample.js
@@ -6,7 +6,7 @@ const DropdownMenuExample = () => {
     <DropdownMenu
       align="bottom"
       renderTrigger={({ isOpen, handleOpenMenu }) => (
-        <DropdownMenu.Trigger data-qa-anchor="trigger-data-anchor" isOpen={isOpen} handleOpenMenu={handleOpenMenu}>
+        <DropdownMenu.Trigger data-qa-anchor="dropdown-menu__trigger" isOpen={isOpen} handleOpenMenu={handleOpenMenu}>
           Trigger
         </DropdownMenu.Trigger>
       )}

--- a/packages/DropdownMenu/test/dropdownMenu.cypress.js
+++ b/packages/DropdownMenu/test/dropdownMenu.cypress.js
@@ -1,0 +1,26 @@
+describe("<DropdownMenu />", () => {
+  beforeEach(() => {
+    cy.visitStorybook("dropdownmenu-cypress--dropdownmenu-test");
+  });
+
+  it("should show hide dropdown content when when clicking trigger", () => {
+    cy.getByTestId("dropdown-menu__trigger").click();
+    cy.getByTestId("popover-content").should("be.visible");
+    cy.wait(100).then(() => {
+      cy.getByTestId("dropdown-menu__trigger").click();
+      cy.getByTestId("popover-content").should("not.be.visible");
+    });
+  });
+
+  it("should retain trigger focus when the dropdown is closed", () => {
+    cy.getByTestId("dropdown-menu__trigger").click();
+    cy.wait(100).then(() => {
+      cy.getByTestId("dropdown-menu__trigger").click();
+      cy.getByTestId("dropdown-menu__trigger").then(triggerElement => {
+        cy.focused().then(e => {
+          expect(triggerElement.get(0) === e.get(0)).equal(true);
+        });
+      });
+    });
+  });
+});

--- a/packages/DropdownMenu/test/dropdownMenu.spec.js
+++ b/packages/DropdownMenu/test/dropdownMenu.spec.js
@@ -60,27 +60,12 @@ describe("DropdownMenu", () => {
     expect(getByText(/edit/i)).not.toBeVisible();
   });
 
-  it("should hide dropdown menu when trigger is clicked", () => {
-    const { getAllByText } = renderComponent();
-    triggerComponent.click();
-    expect(getAllByText(/Edit/)[0]).toBeVisible();
-    triggerComponent.click();
-    expect(getAllByText(/Edit/)[0]).not.toBeVisible();
-  });
-
   it("should hide dropdown when item is clicked", () => {
     triggerComponent.click();
     expect(getByText(/edit/i)).toBeVisible();
     getByText(/edit/i).click();
     expect(triggerComponent).toBeVisible();
     expect(getByText(/edit/i)).not.toBeVisible();
-  });
-
-  it("retain trigger focus when the dropdown is closed", () => {
-    triggerComponent.click();
-    expect(getByText(/edit/i)).toBeVisible();
-    triggerComponent.click();
-    expect(document.activeElement).toBe(triggerComponent);
   });
 
   describe("replacement popover", () => {


### PR DESCRIPTION
### 🛠 Purpose

Ensure tabbing into trigger button only takes one tab action
Convert failing spec tests (because of above change) to cypress test
Ensure confirmation panel buttons render as <spans> so that consuming application styles doesn't override them.

### ✏️ Notes to Reviewer

This is a minor bugfix on the component - Please bump to `0.1.2`

### 🖥 Screenshots

Before
![doubleTabDropdown](https://user-images.githubusercontent.com/4040102/61891929-9ac37c80-aebf-11e9-8e3d-1645e2735927.gif)
After
![singleTabDropdown](https://user-images.githubusercontent.com/4040102/61891930-9ac37c80-aebf-11e9-96b6-82e7fbfd05d2.gif)

