### PR TITLE
PD-12487 Expand children when select group

### DIFF
--- a/packages/CollapsibleChecklists/src/components/Group/Group.js
+++ b/packages/CollapsibleChecklists/src/components/Group/Group.js
@@ -15,7 +15,7 @@ const propTypes = {
 const defaultProps = {
   children: [],
   isDisabled: false,
-  onExpand: () => {},
+  onExpand: null,
 };
 
 function useIsIndeterminate(checkboxRef) {
@@ -75,14 +75,17 @@ function Group(props) {
   }
 
   function expandGroupAndToggleChildren() {
-    if (isCollapsed && onExpand) {
+    if (isCollapsed) {
       setIsCollapsed(false);
-      onExpand();
-      // Note that if `onExpand` makes an API call to update the Group's children, toggleChildren() will NOT select them. The
-      // consumer will need to click on the checkbox again after the API has completed to select them.
-      // Making `onExpand` return a Promise, then running `toggleChildren()` after the Promise has resolved doesn't work
-      // either; we believe because in the React process, the next line that runs is the one below - where the children have
-      // not changed in memory.
+
+      if (onExpand) {
+        onExpand();
+        // Note that if `onExpand` makes an API call to update the Group's children, toggleChildren() will NOT select them. The
+        // consumer will need to click on the checkbox again after the API has completed to select them.
+        // Making `onExpand` return a Promise, then running `toggleChildren()` after the Promise has resolved doesn't work
+        // either; we believe because in the React process, the next line that runs is the one below - where the children have
+        // not changed in memory.
+      }
     }
 
     toggleChildren();

--- a/packages/CollapsibleChecklists/src/components/Group/Group.js
+++ b/packages/CollapsibleChecklists/src/components/Group/Group.js
@@ -74,6 +74,20 @@ function Group(props) {
     onChange(childItemsToChange);
   }
 
+  function expandGroupAndToggleChildren() {
+    if (isCollapsed && onExpand) {
+      setIsCollapsed(false);
+      onExpand();
+      // Note that if `onExpand` makes an API call to update the Group's children, toggleChildren() will NOT select them. The
+      // consumer will need to click on the checkbox again after the API has completed to select them.
+      // Making `onExpand` return a Promise, then running `toggleChildren()` after the Promise has resolved doesn't work
+      // either; we believe because in the React process, the next line that runs is the one below - where the children have
+      // not changed in memory.
+    }
+
+    toggleChildren();
+  }
+
   /* eslint-disable jsx-a11y/label-has-associated-control */
   const label = (
     <React.Fragment>
@@ -83,7 +97,7 @@ function Group(props) {
           checked={allAreChecked}
           type="checkbox"
           disabled={isDisabled}
-          onChange={toggleChildren}
+          onChange={expandGroupAndToggleChildren}
         />
         {title}
       </label>


### PR DESCRIPTION
### 🛠 Purpose

As per AC, when click on a Group's checkbox, it should expand to reveal the children.
It will also select the children (but it already does that).

### ✏️ Notes to Reviewer
After expanding it will also fire`props.onExpand()`.

Note that if `onExpand` makes an API call to update the Group's children, the children will NOT get selected. The consumer will need to click on the checkbox again after the API has completed to select them.


### 🖥 Screenshots
This illustrates what happens when 

![clicky](https://user-images.githubusercontent.com/23224777/61833980-f263d880-ae2a-11e9-8e12-c24d51262b30.gif)

