### PR TITLE
AN-7724 Add operations prop in Collapsible

### DIFF
--- a/packages/Collapsible/src/Collapsible.js
+++ b/packages/Collapsible/src/Collapsible.js
@@ -1,34 +1,42 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+
 import React from "react";
 import PropTypes from "prop-types";
+import classNames from "class-names";
 import RightArrowIcon from "@paprika/icon/lib/ArrowRight";
 import DownArrowIcon from "@paprika/icon/lib/ArrowDown";
 import useI18n from "@paprika/l10n/lib/useI18n";
 import RawButton from "@paprika/raw-button";
-import collapsibleStyles from "./Collapsible.styles";
+import collapsibleStyles, { operationsWrapperStyles } from "./Collapsible.styles";
 
 const propTypes = {
   a11yText: PropTypes.string,
   children: PropTypes.node,
+  hasOnlyIconToggle: PropTypes.bool,
   iconAlign: PropTypes.oneOf(["left", "right"]),
   iconCollapse: PropTypes.node,
   iconExpand: PropTypes.node,
   isCollapsed: PropTypes.bool,
   isDisabled: PropTypes.bool,
-  hasOnlyIconToggle: PropTypes.bool,
   label: PropTypes.node.isRequired,
   onClick: PropTypes.func,
+
+  /** Elements we'll put on the right of collapsible header. Only operational buttons are recommended. */
+  operations: PropTypes.node,
 };
 
 const defaultProps = {
   a11yText: null,
   children: null,
+  hasOnlyIconToggle: false,
   iconAlign: "left",
   iconCollapse: <RightArrowIcon />,
   iconExpand: <DownArrowIcon />,
   isCollapsed: true,
   isDisabled: false,
-  hasOnlyIconToggle: false,
   onClick: () => {},
+  operations: null,
 };
 
 const Collapsible = props => {
@@ -49,8 +57,21 @@ const Collapsible = props => {
     props.onClick(event);
   };
 
+  const renderOperations = () => {
+    const { operations } = props;
+    const handleClickOperations = e => {
+      e.stopPropagation();
+    };
+
+    return operations ? (
+      <span css={operationsWrapperStyles} onClick={handleClickOperations}>
+        {operations}
+      </span>
+    ) : null;
+  };
+
   const renderDefaultCollapsible = () => {
-    const { a11yText, label, isCollapsed, isDisabled, iconAlign } = props;
+    const { a11yText, iconAlign, isCollapsed, isDisabled, label } = props;
 
     return (
       <RawButton
@@ -60,6 +81,7 @@ const Collapsible = props => {
         isDisabled={isDisabled}
         onClick={handleClickCollapse}
       >
+        {renderOperations()}
         <span data-pka-anchor="collapsible.icon" className={`collapsible--icon-${iconAlign}`} aria-hidden="true">
           {collapsedIcon[+isCollapsed]}
         </span>
@@ -69,14 +91,17 @@ const Collapsible = props => {
   };
 
   const renderCollapsibleByIcon = () => {
-    const { a11yText, label, isCollapsed, isDisabled, iconAlign } = props;
+    const { a11yText, iconAlign, isCollapsed, isDisabled, label } = props;
 
     return (
       <div data-pka-anchor="collapsible.heading">
+        {renderOperations()}
         <RawButton
           ariaLabel={a11yText || I18n.t("collapsible.a11yText")}
           aria-expanded={!isCollapsed}
-          className="collapsible__label collapsible__label--is-toggle-icon-only"
+          className={classNames("collapsible__label", "collapsible__label--is-toggle-icon-only", {
+            "collapsible__label--is-float-right": iconAlign === "right",
+          })}
           isDisabled={isDisabled}
           onClick={handleClickCollapse}
         >

--- a/packages/Collapsible/src/Collapsible.styles.js
+++ b/packages/Collapsible/src/Collapsible.styles.js
@@ -22,6 +22,10 @@ const collapsibleStyles = css`
 
   .collapsible__label--is-toggle-icon-only {
     width: auto;
+
+    &.collapsible__label--is-float-right {
+      float: right;
+    }
   }
 
   [data-pka-anchor="collapsible.icon"] svg {
@@ -40,6 +44,10 @@ const collapsibleStyles = css`
     display: ${({ isCollapsed }) => (isCollapsed ? "none" : "block")};
     width: 100%;
   }
+`;
+
+export const operationsWrapperStyles = css`
+  float: right;
 `;
 
 export default collapsibleStyles;

--- a/packages/Collapsible/stories/Collapsible.stories.js
+++ b/packages/Collapsible/stories/Collapsible.stories.js
@@ -3,7 +3,9 @@ import { storiesOf } from "@storybook/react";
 import { withKnobs } from "@storybook/addon-knobs";
 
 import BasicStory from "./examples/Basic";
+import CollapsibleWithOperationsStory from "./examples/WithOperations";
 
 storiesOf("Collapsible", module)
   .addDecorator(withKnobs)
-  .add("Basic", () => <BasicStory />);
+  .add("Basic", () => <BasicStory />)
+  .add("WithOperations", () => <CollapsibleWithOperationsStory />);

--- a/packages/Collapsible/stories/examples/WithOperations.js
+++ b/packages/Collapsible/stories/examples/WithOperations.js
@@ -1,0 +1,53 @@
+import React from "react";
+import { Story, Rule } from "storybook/assets/styles/common.styles";
+import RawButton from "@paprika/raw-button";
+import TrashbinIcon from "@paprika/icon/lib/Trashbin";
+import Collapsible from "../../src";
+
+const CollapsibleWithOperationsStory = () => {
+  const noop = () => {};
+  const operations = (
+    <React.Fragment>
+      <a href="http://wegalvanize.com">View</a>
+      <RawButton onClick={noop}>
+        <TrashbinIcon />
+      </RawButton>
+    </React.Fragment>
+  );
+
+  return (
+    <Story>
+      <Collapsible isCollapsed label="Icon align left" iconAlign="left" onClick={noop} operations={operations}>
+        content
+      </Collapsible>
+      <Rule />
+      <Collapsible isCollapsed label="Icon align right" iconAlign="right" onClick={noop} operations={operations}>
+        content
+      </Collapsible>
+      <Rule />
+      <Collapsible
+        hasOnlyIconToggle
+        iconAlign="left"
+        isCollapsed
+        label="HasOnlyIconToggle and Icon align left"
+        onClick={noop}
+        operations={operations}
+      >
+        content
+      </Collapsible>
+      <Rule />
+      <Collapsible
+        hasOnlyIconToggle
+        iconAlign="right"
+        isCollapsed
+        label="HasOnlyIconToggle and Icon align right"
+        onClick={noop}
+        operations={operations}
+      >
+        content
+      </Collapsible>
+    </Story>
+  );
+};
+
+export default CollapsibleWithOperationsStory;

--- a/packages/Collapsible/tests/Collapsible.spec.js
+++ b/packages/Collapsible/tests/Collapsible.spec.js
@@ -79,4 +79,10 @@ describe("Collapsible", () => {
     const { container } = renderComponent({ iconExpand });
     expect(container.querySelector(".custom-expand")).toBeVisible();
   });
+
+  it("should render operations", () => {
+    const operations = <span>operations</span>;
+    const { getByText } = renderComponent({ operations });
+    expect(getByText(/operations/i)).toBeVisible();
+  });
 });


### PR DESCRIPTION
### 🛠 Purpose

Add `operations` prop in `<Collapsible />` for some cases like this :
![image](https://user-images.githubusercontent.com/38733362/62240989-0fe5f480-b38d-11e9-938e-ef80fe8e825b.png)
Confirmed with @johnpeele this will be a common case

### ✏️ Notes to Reviewer

---

### 🖥 Screenshots

![image](https://user-images.githubusercontent.com/38733362/62240873-d57c5780-b38c-11e9-93e8-d0537ecc0ab7.png)

