### PR TITLE
fixing searching issue by branch name

### DIFF
--- a/scripts/storybookLink.js
+++ b/scripts/storybookLink.js
@@ -49,7 +49,7 @@ async function updateIssueBodyWithLink(issueNumber, body) {
 async function getIssueNumberAndBody() {
   try {
     const issueFetched = await octokit.search.issuesAndPullRequests({
-      q: `${SEMAPHORE_GIT_BRANCH} repo:${owner}/${repo}`,
+      q: `head:${SEMAPHORE_GIT_BRANCH} repo:${owner}/${repo}`,
     });
     const { number, body } = issueFetched.data.items[0];
 


### PR DESCRIPTION
### 🛠 Purpose
This should fix the problem when the issue name is not the branch name. This will always add the storybook link at the bottom of this description. 

---

### ✏️ Notes to Reviewer

---

### 🖥 Screenshots

---
 
 ### 📙 Storybook 
 <a href='http://storybooks.highbond-s3.com/paprika/UX-499-storybook-link-patch' target="_blank" rel="noopener">http://storybooks.highbond-s3.com/paprika/UX-499-storybook-link-patch</a>