### PR TITLE
ux-586-datepicker-prevent acl-ui3 style overrides

### DIFF
--- a/packages/DatePicker/src/components/Calendar/Calendar.js
+++ b/packages/DatePicker/src/components/Calendar/Calendar.js
@@ -135,6 +135,7 @@ function Calendar(props) {
       <Button
         css={monthHeaderButtonStyles}
         isDropdown
+        isSemantic={false}
         kind="flat"
         onClick={() => {
           handleClickHeader(month);

--- a/packages/DatePicker/src/components/ShortcutPanel/ShortcutPanel.js
+++ b/packages/DatePicker/src/components/ShortcutPanel/ShortcutPanel.js
@@ -119,11 +119,11 @@ function ShortcutPanel(props) {
         </div>
         <div css={yearListStyles}>
           <div css={columnHeaderStyles} isYear>
-            <Button.Icon onClick={handleClickPrev} kind="minor" size="small">
+            <Button.Icon isSemantic={false} onClick={handleClickPrev} kind="minor" size="small">
               <ArrowLeft color={tokens.textColor.icon} />
             </Button.Icon>
             {I18n.t("datePicker.year")}
-            <Button.Icon onClick={handleClickNext} kind="minor" size="small">
+            <Button.Icon isSemantic={false} onClick={handleClickNext} kind="minor" size="small">
               <ArrowRight color={tokens.textColor.icon} />
             </Button.Icon>
           </div>
@@ -131,10 +131,22 @@ function ShortcutPanel(props) {
         </div>
       </div>
       <div css={actionBarStyles}>
-        <Button kind="primary" onClick={handleConfirm} size="small" data-pka-anchor="datepicker.calendar.apply">
+        <Button
+          isSemantic={false}
+          kind="primary"
+          onClick={handleConfirm}
+          size="small"
+          data-pka-anchor="datepicker.calendar.apply"
+        >
           {I18n.t("actions.apply")}
         </Button>
-        <Button kind="minor" onClick={onCancel} size="small" data-pka-anchor="datepicker.calendar.cancel">
+        <Button
+          isSemantic={false}
+          kind="minor"
+          onClick={onCancel}
+          size="small"
+          data-pka-anchor="datepicker.calendar.cancel"
+        >
           {I18n.t("actions.cancel")}
         </Button>
       </div>

--- a/packages/DatePicker/src/components/ShortcutPanel/ShortcutPanel.styles.js
+++ b/packages/DatePicker/src/components/ShortcutPanel/ShortcutPanel.styles.js
@@ -47,7 +47,7 @@ export const columnHeaderStyles = css`
 
 export const containerStyles = css`
   ${stylers.fontSize(-1)};
-
+  background-color: ${tokens.color.white}
   border: 1px solid ${tokens.border.color};
   border-radius: ${tokens.border.radius};
   box-sizing: border-box;
@@ -77,6 +77,12 @@ export const containerStyles = css`
     margin: 0;
     overflow: hidden;
     padding: 5px ${tokens.spaceLg} ${tokens.spaceSm} ${tokens.spaceLg};
+
+    /* prevent acl-ui3 label style overrides */
+    input[type="radio"] + label {
+      display: flex;
+      margin: auto;
+    }
   }
 `;
 


### PR DESCRIPTION
### 🛠 Purpose

Use the Paprika dropdown in a module that also uses acl-ui 3 buttons. Eg in results questionnaires.

Some styles are being overridden by acl-ui 3 styles.

Fixes include
Ensure Paprika buttons are non-semantic
Ensure component has a background colour
Ensure label is displaying correct styles for flex layout


## Screenshots / Gifs / Codepens
Before:
![image](https://user-images.githubusercontent.com/4040102/65460691-54c75e00-de07-11e9-8838-0e9d075a420f.png)

![image](https://user-images.githubusercontent.com/4040102/65461070-10888d80-de08-11e9-9f63-3fa7b10870a7.png)

---
 
 ### 📙 Storybook 
 <a href='http://storybooks.highbond-s3.com/paprika/ux-586-datepicker-prevent-aclui-style-overrides' target="_blank" rel="noopener">http://storybooks.highbond-s3.com/paprika/ux-586-datepicker-prevent-aclui-style-overrides</a>