### PR TITLE
XD-5802-Ensure input works even with no date provided

### DIFF
--- a/packages/DatePicker/src/DatePicker.js
+++ b/packages/DatePicker/src/DatePicker.js
@@ -94,7 +94,7 @@ function DatePicker(props) {
 
   // Effect
   React.useEffect(() => {
-    if (date && prevDate && date.isSame(prevDate, "day")) return;
+    if ((!date && !prevDate) || (date && prevDate && date.isSame(prevDate, "day"))) return;
     setInputtedString(formatDateProp(dataFormat));
     setConfirmationResult(formatDateProp(humanFormat));
   }, [dataFormat, date, prevDate, formatDateProp, humanFormat]);


### PR DESCRIPTION
### 🛠 Purpose

Previously date picker input was being reset if date object is null.

### ✏️ Notes to Reviewer

---

### 🖥 Screenshots

---
 
 ### 📙 Storybook 
 <a href='http://storybooks.highbond-s3.com/paprika/XD-5802-date-picker-no-date-bug' target="_blank" rel="noopener">http://storybooks.highbond-s3.com/paprika/XD-5802-date-picker-no-date-bug</a>