### PR TITLE
XD-5802-Adding onError prop to DatePicker

### DIFF
--- a/packages/DatePicker/src/DatePicker.js
+++ b/packages/DatePicker/src/DatePicker.js
@@ -170,7 +170,7 @@ function DatePicker(props) {
     } else {
       setConfirmationResult("");
       setHasParsingError(true);
-      onDateParseError();
+      onDateParseError(inputtedString);
     }
   }
 

--- a/packages/DatePicker/src/DatePicker.js
+++ b/packages/DatePicker/src/DatePicker.js
@@ -209,7 +209,7 @@ function DatePicker(props) {
     handleChange(selectedDate);
   }
 
-  const hasError = extendedInputProps.hasError || hasParsingError;
+  const { hasError, ...moreExtendedInputProps } = extendedInputProps;
 
   return (
     <Popover
@@ -221,6 +221,7 @@ function DatePicker(props) {
       shouldKeepFocus
     >
       <Input
+        hasError={hasError || hasParsingError}
         icon={<CalendarIcon />}
         id={id}
         isDisabled={isDisabled}
@@ -232,8 +233,7 @@ function DatePicker(props) {
         onKeyUp={handleKeyUp}
         inputRef={inputRef}
         value={confirmationResult || inputtedString}
-        {...extendedInputProps}
-        hasError={hasError}
+        {...moreExtendedInputProps}
       />
 
       <Popover.Content>

--- a/packages/DatePicker/src/DatePicker.js
+++ b/packages/DatePicker/src/DatePicker.js
@@ -209,7 +209,7 @@ function DatePicker(props) {
     handleChange(selectedDate);
   }
 
-  const { hasError, ...moreExtendedInputProps } = extendedInputProps;
+  const hasError = extendedInputProps && extendedInputProps.hasError ? extendedInputProps.hasError : false;
 
   return (
     <Popover
@@ -221,7 +221,6 @@ function DatePicker(props) {
       shouldKeepFocus
     >
       <Input
-        hasError={hasError || hasParsingError}
         icon={<CalendarIcon />}
         id={id}
         isDisabled={isDisabled}
@@ -233,7 +232,8 @@ function DatePicker(props) {
         onKeyUp={handleKeyUp}
         inputRef={inputRef}
         value={confirmationResult || inputtedString}
-        {...moreExtendedInputProps}
+        {...extendedInputProps}
+        hasError={hasError || hasParsingError}
       />
 
       <Popover.Content>

--- a/packages/DatePicker/src/DatePicker.js
+++ b/packages/DatePicker/src/DatePicker.js
@@ -44,6 +44,9 @@ const propTypes = {
 
   /** Callback when date is selected or input. */
   onChange: PropTypes.func.isRequired,
+
+  /** Callback when input string is not correctly parsed as a date . */
+  onDateParseError: PropTypes.func,
 };
 
 const defaultProps = {
@@ -55,6 +58,7 @@ const defaultProps = {
   id: null,
   isDisabled: false,
   isReadOnly: false,
+  onDateParseError: () => {},
 };
 
 function DatePicker(props) {
@@ -71,6 +75,7 @@ function DatePicker(props) {
     isDisabled,
     isReadOnly,
     onChange,
+    onDateParseError,
   } = props;
 
   const formatDateProp = React.useCallback(
@@ -165,6 +170,7 @@ function DatePicker(props) {
     } else {
       setConfirmationResult("");
       setHasParsingError(true);
+      onDateParseError();
     }
   }
 

--- a/packages/DatePicker/src/DatePicker.js
+++ b/packages/DatePicker/src/DatePicker.js
@@ -27,9 +27,6 @@ const propTypes = {
   /** Selected date in moment object. */
   date: momentPropTypes.momentObj,
 
-  /** If the value of <input> is valid or not. Not required when wrapped with <FormElement>. */
-  hasError: PropTypes.bool,
-
   /** Date format used while displaying date. It should be human-friendly and spelled out, default is MMMM DD,YYYY */
   humanFormat: PropTypes.string,
 
@@ -45,20 +42,19 @@ const propTypes = {
   /** Callback when date is selected or input. */
   onChange: PropTypes.func.isRequired,
 
-  /** Callback when input string is not correctly parsed as a date . */
-  onDateParseError: PropTypes.func,
+  /** Errors callback */
+  onError: PropTypes.func,
 };
 
 const defaultProps = {
   children: null,
   dataFormat: "MM/DD/YYYY",
   date: null,
-  hasError: false,
   humanFormat: undefined,
   id: null,
   isDisabled: false,
   isReadOnly: false,
-  onDateParseError: () => {},
+  onError: () => {},
 };
 
 function DatePicker(props) {
@@ -69,13 +65,12 @@ function DatePicker(props) {
     children,
     dataFormat,
     date,
-    hasError,
     humanFormat = I18n.t("datePicker.confirmation_format"),
     id,
     isDisabled,
     isReadOnly,
     onChange,
-    onDateParseError,
+    onError,
   } = props;
 
   const formatDateProp = React.useCallback(
@@ -170,7 +165,7 @@ function DatePicker(props) {
     } else {
       setConfirmationResult("");
       setHasParsingError(true);
-      onDateParseError(inputtedString);
+      onError({ type: "input-parse", value: inputtedString });
     }
   }
 
@@ -214,6 +209,8 @@ function DatePicker(props) {
     handleChange(selectedDate);
   }
 
+  const hasError = extendedInputProps.hasError || hasParsingError;
+
   return (
     <Popover
       offset={8}
@@ -224,7 +221,6 @@ function DatePicker(props) {
       shouldKeepFocus
     >
       <Input
-        hasError={hasError || hasParsingError}
         icon={<CalendarIcon />}
         id={id}
         isDisabled={isDisabled}
@@ -237,6 +233,7 @@ function DatePicker(props) {
         inputRef={inputRef}
         value={confirmationResult || inputtedString}
         {...extendedInputProps}
+        hasError={hasError}
       />
 
       <Popover.Content>

--- a/packages/DatePicker/src/DatePicker.js
+++ b/packages/DatePicker/src/DatePicker.js
@@ -18,6 +18,8 @@ import { extractChildrenProps } from "./helpers";
 
 import { calendarPopoverStyles } from "./DatePicker.styles";
 
+const INPUT_PARSE_ERROR = "INPUT_PARSE";
+
 const propTypes = {
   children: PropTypes.node,
 
@@ -165,7 +167,7 @@ function DatePicker(props) {
     } else {
       setConfirmationResult("");
       setHasParsingError(true);
-      onError({ type: "input-parse", value: inputtedString });
+      onError({ type: INPUT_PARSE_ERROR, value: inputtedString });
     }
   }
 

--- a/packages/DatePicker/src/DatePicker.js
+++ b/packages/DatePicker/src/DatePicker.js
@@ -209,7 +209,7 @@ function DatePicker(props) {
     handleChange(selectedDate);
   }
 
-  const hasError = extendedInputProps && extendedInputProps.hasError ? extendedInputProps.hasError : false;
+  const hasError = extendedInputProps && extendedInputProps.hasError;
 
   return (
     <Popover

--- a/packages/DatePicker/src/components/DateInput/DateInput.js
+++ b/packages/DatePicker/src/components/DateInput/DateInput.js
@@ -11,12 +11,16 @@ const propTypes = {
 
   /** Size of input. */
   size: PropTypes.oneOf(ShirtSizes.DEFAULT),
+
+  /** If the value of <input> is valid or not. Not required when wrapped with <FormElement>. */
+  hasError: PropTypes.bool,
 };
 
 const defaultProps = {
   a11yText: null,
   placeholder: "",
   size: "medium",
+  hasError: false,
 };
 
 // shell component for enhancing development experience

--- a/packages/DatePicker/stories/DatePicker.stories.js
+++ b/packages/DatePicker/stories/DatePicker.stories.js
@@ -20,6 +20,7 @@ storiesOf("DatePicker", module)
     const inputProps = () => ({
       size: select("size", ["small", "medium", "large"], "medium"),
       placeholder: text("placeholder", ""),
+      hasError: boolean("hasError", false),
     });
     return (
       <Example locale="en" {...datePickerProps()}>

--- a/packages/DatePicker/test/DatePicker.spec.js
+++ b/packages/DatePicker/test/DatePicker.spec.js
@@ -6,13 +6,13 @@ import DatePicker from "../src";
 
 configure({ testIdAttribute: "data-pka-anchor" });
 
-function render(props = {}) {
+function render(props = {}, inputProps = {}) {
   const { onChange, ...moreProps } = props;
   const handleChange = onChange || (() => {});
   const rendered = renderReactTestingLibrary(
     <L10n>
       <DatePicker onChange={handleChange} {...moreProps}>
-        <DatePicker.Input data-pka-anchor="datepicker.input" />
+        <DatePicker.Input {...inputProps} data-pka-anchor="datepicker.input" />
       </DatePicker>
     </L10n>
   );
@@ -24,7 +24,7 @@ function render(props = {}) {
       rerender(
         <L10n>
           <DatePicker onChange={handleChange} {...moreProps} {...updatedProps}>
-            <DatePicker.Input data-pka-anchor="datepicker.input" />
+            <DatePicker.Input {...inputProps} data-pka-anchor="datepicker.input" />
           </DatePicker>
         </L10n>
       );
@@ -51,5 +51,11 @@ describe("DatePicker", () => {
     rerender({ date: moment("2019-03-01") });
 
     expect(getByTestId("datepicker.input").value).toEqual("March 01, 2019");
+  });
+
+  it("should render input as error state hasError", () => {
+    render({ date: moment("2019-01-02") }, { hasError: true });
+
+    expect(document.getElementsByClassName("form-input--has-error").length).toEqual(1);
   });
 });


### PR DESCRIPTION
### 🛠 Purpose

Allow the consuming application to know an invalid date string has been parsed in the component so that it can react accordingly displaying error messages if required. (Needed in results)

@nahumzs minor version bump required

### ✏️ Notes to Reviewer

---

### 🖥 Screenshots

---
 
 ### 📙 Storybook 
 <a href='http://storybooks.highbond-s3.com/paprika/XD-5802-add-date-picker-parse-error' target="_blank" rel="noopener">http://storybooks.highbond-s3.com/paprika/XD-5802-add-date-picker-parse-error</a>