### PR TITLE
XD-5802-Prevent DatePicker calendar flicker on close

### DIFF
--- a/packages/DatePicker/src/DatePicker.js
+++ b/packages/DatePicker/src/DatePicker.js
@@ -173,13 +173,13 @@ function DatePicker(props) {
   }
 
   function handleInputBlur() {
-    if (calendarRef.current) {
-      window.requestAnimationFrame(() => {
+    window.requestAnimationFrame(() => {
+      if (calendarRef.current) {
         if (!isElementContainsFocus(calendarRef.current)) {
           handleInputConfirm();
         }
-      });
-    }
+      }
+    });
   }
 
   function handleInputChange(e) {

--- a/packages/DatePicker/src/DatePicker.js
+++ b/packages/DatePicker/src/DatePicker.js
@@ -129,7 +129,11 @@ function DatePicker(props) {
   }
 
   function handleClosePopover() {
-    if (!isElementContainsFocus(calendarRef.current) && !isElementContainsFocus(inputRef.current)) {
+    if (
+      calendarRef.current &&
+      !isElementContainsFocus(calendarRef.current) &&
+      !isElementContainsFocus(inputRef.current)
+    ) {
       if (!hasParsingError) {
         setConfirmationResult(formatDateProp(humanFormat));
         setInputtedString(formatDateProp(dataFormat));
@@ -169,11 +173,13 @@ function DatePicker(props) {
   }
 
   function handleInputBlur() {
-    window.requestAnimationFrame(() => {
-      if (!isElementContainsFocus(calendarRef.current)) {
-        handleInputConfirm();
-      }
-    });
+    if (calendarRef.current) {
+      window.requestAnimationFrame(() => {
+        if (!isElementContainsFocus(calendarRef.current)) {
+          handleInputConfirm();
+        }
+      });
+    }
   }
 
   function handleInputChange(e) {
@@ -233,17 +239,19 @@ function DatePicker(props) {
         {...extendedInputProps}
       />
 
-      <Popover.Content>
-        <div css={calendarPopoverStyles} data-pka-anchor="datepicker.calendar" ref={calendarRef}>
-          <Calendar
-            date={date}
-            isVisible={shouldShowCalendar}
-            onSelect={handleSelect}
-            possibleDate={debouncedPossibleDate}
-            resetPossibleDate={handleResetPossibleDate}
-          />
-        </div>
-      </Popover.Content>
+      {shouldShowCalendar ? (
+        <Popover.Content>
+          <div css={calendarPopoverStyles} data-pka-anchor="datepicker.calendar" ref={calendarRef}>
+            <Calendar
+              date={date}
+              isVisible={shouldShowCalendar}
+              onSelect={handleSelect}
+              possibleDate={debouncedPossibleDate}
+              resetPossibleDate={handleResetPossibleDate}
+            />
+          </div>
+        </Popover.Content>
+      ) : null}
     </Popover>
   );
 }


### PR DESCRIPTION
### 🛠 Purpose

Prevent flicker of Datepicker calendar on close.

### ✏️ Notes to Reviewer

Giphy captures below not showing flicker very well, better to run locally in storybook to see change

---

### 🖥 Screenshots
Context action (closing calendar)
![flicker-before](https://user-images.githubusercontent.com/4040102/65713573-5040b680-e04e-11e9-9da8-95aee4ddcf1e.
 
 ### 📙 Storybook 
 <a href='http://storybooks.highbond-s3.com/paprika/xd-5802-datepicker-prevent-flicker' target="_blank" rel="noopener">http://storybooks.highbond-s3.com/paprika/xd-5802-datepicker-prevent-flicker</a>