### PR TITLE
UX-480 Popover tooltip fixes 🐐

### DIFF
--- a/packages/DropdownMenu/test/dropdownMenu.cypress.js
+++ b/packages/DropdownMenu/test/dropdownMenu.cypress.js
@@ -5,10 +5,10 @@ describe("<DropdownMenu />", () => {
 
   it("should show hide dropdown content when when clicking trigger", () => {
     cy.getByTestId("dropdown-menu__trigger").click();
-    cy.getByTestId("popover-content").should("be.visible");
+    cy.getByTestId("popover.content").should("be.visible");
     cy.wait(100).then(() => {
       cy.getByTestId("dropdown-menu__trigger").click();
-      cy.getByTestId("popover-content").should("not.be.visible");
+      cy.getByTestId("popover.content").should("not.be.visible");
     });
   });
 

--- a/packages/ListBox/test/helpers/selectors.js
+++ b/packages/ListBox/test/helpers/selectors.js
@@ -4,7 +4,7 @@ const selectors = {
   filtersClearButton: "[data-pka-anchor='clear-filters-button']",
   filterSelectTableList: "[data-pka-anchor='table-list']",
   noResults: "[data-pka-anchor='no-results']",
-  popover: "[data-pka-anchor='popover-content']",
+  popover: "[data-pka-anchor='popover.content']",
   popoverList: "[data-pka-anchor='styled-list']",
   trigger: "[data-pka-anchor='listbox-trigger']",
 };

--- a/packages/ListBox/test/specs/multi/ListBox.multi.spec.js
+++ b/packages/ListBox/test/specs/multi/ListBox.multi.spec.js
@@ -33,10 +33,10 @@ function renderComponent(props = {}, children = childrenContent) {
       fireEvent.click(rendered.getByText(/jupiter/i));
     },
     expectDropdownIsHidden: () => {
-      expect(rendered.getByTestId("popover-content").getAttribute("aria-hidden")).toBeTruthy();
+      expect(rendered.getByTestId("popover.content").getAttribute("aria-hidden")).toBeTruthy();
     },
     expectDropdownIsNotHidden: () => {
-      expect(rendered.getByTestId("popover-content").getAttribute("aria-hidden")).toMatch(/false/i);
+      expect(rendered.getByTestId("popover.content").getAttribute("aria-hidden")).toMatch(/false/i);
     },
   };
 }
@@ -127,7 +127,7 @@ describe("Listbox multi select", () => {
       isInline: true,
     });
 
-    expect(queryByTestId("popover-content")).toBeNull();
+    expect(queryByTestId("popover.content")).toBeNull();
   });
 
   it("should focus on option container as soon as the Popover is open", done => {
@@ -139,7 +139,7 @@ describe("Listbox multi select", () => {
     // ends we can improve this test :/
 
     setTimeout(() => {
-      expect(document.activeElement).toBe(getByTestId("popover-content"));
+      expect(document.activeElement).toBe(getByTestId("popover.content"));
       done();
     }, 350);
   });
@@ -151,7 +151,7 @@ describe("Listbox multi select", () => {
     ]);
 
     openSelect();
-    expect(document.activeElement).not.toBe(getByTestId("popover-content"));
+    expect(document.activeElement).not.toBe(getByTestId("popover.content"));
   });
 
   it("placeholder should display default label when no option is selected", () => {

--- a/packages/ListBox/test/specs/single/ListBox.single.spec.js
+++ b/packages/ListBox/test/specs/single/ListBox.single.spec.js
@@ -25,10 +25,10 @@ function renderComponent(props = {}, children = childrenContent) {
       fireEvent.click(rendered.getByText(/jupiter/i));
     },
     popoverIsHidden: () => {
-      expect(rendered.getByTestId("popover-content").getAttribute("aria-hidden")).toBeTruthy();
+      expect(rendered.getByTestId("popover.content").getAttribute("aria-hidden")).toBeTruthy();
     },
     popoverIsVisible: () => {
-      expect(rendered.getByTestId("popover-content").getAttribute("aria-hidden")).toMatch(/false/i);
+      expect(rendered.getByTestId("popover.content").getAttribute("aria-hidden")).toMatch(/false/i);
     },
   };
 }
@@ -110,7 +110,7 @@ describe("Listbox single select", () => {
       isInline: true,
     });
 
-    expect(queryByTestId("popover-content")).toBeNull();
+    expect(queryByTestId("popover.content")).toBeNull();
   });
 
   it("should focus on option container as soon as the Popover is open", done => {
@@ -118,7 +118,7 @@ describe("Listbox single select", () => {
 
     openSelect();
     setTimeout(() => {
-      expect(document.activeElement).toBe(getByTestId("popover-content"));
+      expect(document.activeElement).toBe(getByTestId("popover.content"));
       done();
     }, 350);
   });
@@ -136,7 +136,7 @@ describe("Listbox single select", () => {
 
     // NOT BEST PRACTICE: fix later, this is due the timer I had to put on the ListBox becaue the PopoverTimer
     setTimeout(() => {
-      expect(document.activeElement).not.toBe(getByTestId("popover-content"));
+      expect(document.activeElement).not.toBe(getByTestId("popover.content"));
       done();
     }, 350);
   });

--- a/packages/Popover/src/Popover.js
+++ b/packages/Popover/src/Popover.js
@@ -98,7 +98,6 @@ class Popover extends React.Component {
     this.$tip = null; // this ref comes from a callback of the <Tip /> component
 
     const portalNode = document.createElement("div");
-    // portalNode.setAttribute("data-paprika-type", "Popover");
     this.$portal = document.body.appendChild(portalNode);
 
     this.state = {
@@ -416,7 +415,7 @@ class Popover extends React.Component {
     return (
       <ThemeContext.Provider value={isDark}>
         <PopoverContext.Provider value={contextValue}>
-          <PopoverStyled {...moreProps} ref={this.$popover}>
+          <PopoverStyled data-pka-anchor="popover" {...moreProps} ref={this.$popover}>
             {this.props.children}
           </PopoverStyled>
         </PopoverContext.Provider>

--- a/packages/Popover/src/components/Card/Card.js
+++ b/packages/Popover/src/components/Card/Card.js
@@ -6,7 +6,11 @@ import CardStyled from "./Card.styles";
 function Card({ children }) {
   const isDark = React.useContext(ThemeContext);
 
-  return <CardStyled isDark={isDark}>{children}</CardStyled>;
+  return (
+    <CardStyled isDark={isDark} data-pka-anchor="popover.card">
+      {children}
+    </CardStyled>
+  );
 }
 
 Card.displayName = "Popover.Card";

--- a/packages/Popover/src/components/Content/Content.js
+++ b/packages/Popover/src/components/Content/Content.js
@@ -82,10 +82,9 @@ const Content = React.forwardRef((props, ref) => {
   /* eslint-disable jsx-a11y/mouse-events-have-key-events */
   return ReactDOM.createPortal(
     <ContentStyled
-      {...moreProps}
       aria-hidden={!isOpen}
       data-component-name="PopoverContent"
-      data-pka-anchor="popover-content"
+      data-pka-anchor="popover.content"
       ref={handleRef}
       isOpen={isOpen}
       onBlur={handleBlur}
@@ -94,6 +93,7 @@ const Content = React.forwardRef((props, ref) => {
       style={contentStyles}
       tabIndex={isOpen ? 0 : -1}
       zIndex={content.zIndex}
+      {...moreProps}
     >
       {children}
     </ContentStyled>,

--- a/packages/Popover/src/components/Tip/Tip.js
+++ b/packages/Popover/src/components/Tip/Tip.js
@@ -14,6 +14,8 @@ const defaultProps = {
 };
 
 function Tip(props) {
+  const { zIndex, ...moreProps } = props;
+
   const isDark = React.useContext(ThemeContext);
   const { content, tip, refTip, isOpen, portalElement } = React.useContext(PopoverContext);
   const borderColor = isDark ? tokens.color.black : tokens.border.color;
@@ -21,11 +23,13 @@ function Tip(props) {
 
   return ReactDOM.createPortal(
     <TipStyled
-      ref={refTip}
       isOpen={isOpen}
+      data-pka-anchor="popover.tip"
+      ref={refTip}
       rotate={tip.rotate}
       style={{ left: tip.x, top: tip.y }}
-      zIndex={props.zIndex || content.zIndex}
+      zIndex={zIndex || content.zIndex}
+      {...moreProps}
     >
       <svg height="100%" width="100%" viewBox="0 0 12 12" version="1.1" xmlns="http://www.w3.org/2000/svg">
         <polygon points="0 12 12 12 6 6" fill={borderColor} />

--- a/packages/Popover/src/components/Tip/Tip.styles.js
+++ b/packages/Popover/src/components/Tip/Tip.styles.js
@@ -7,6 +7,7 @@ export const TipStyled = styled.div`
   height: ${stylers.spacer(2)};
   line-height: ${stylers.spacer(2)};
   opacity: ${props => (props.isOpen ? 1 : 0)};
+  pointer-events: none;
   position: fixed;
   transform: rotate(${props => props.rotate || "0"}deg);
   transition: opacity ${consts.transition} ease, visibility ${consts.transition} ease;

--- a/packages/Popover/src/components/Trigger/Trigger.js
+++ b/packages/Popover/src/components/Trigger/Trigger.js
@@ -49,7 +49,7 @@ function Trigger(props) {
     return (
       <RawButton
         a11yText={a11yText}
-        data-pka-anchor="popover-trigger"
+        data-pka-anchor="popover.trigger"
         onMouseOver={handleTriggerEvent}
         onMouseOut={handleTriggerEvent}
         onFocus={handleTriggerEvent}
@@ -63,7 +63,7 @@ function Trigger(props) {
   return (
     <RawButton
       a11yText={a11yText}
-      data-pka-anchor="popover-trigger"
+      data-pka-anchor="popover.trigger"
       onClick={handleTriggerEvent}
       onBlur={shouldKeepFocus ? handleTriggerEvent : null}
     >

--- a/packages/Popover/tests/helpers/selectors.js
+++ b/packages/Popover/tests/helpers/selectors.js
@@ -1,6 +1,6 @@
 const selectors = {
-  popover: "[data-pka-anchor='popover-content']",
-  popoverTrigger: "[data-pka-anchor='popover-trigger']",
+  popover: "[data-pka-anchor='popover.content']",
+  popoverTrigger: "[data-pka-anchor='popover.trigger']",
 };
 
 export default selectors;


### PR DESCRIPTION
### 🛠 Purpose
Don't let the `<Tip>` fire point events (`onMouseOver`, `onMouseOut`, `focus`) which will close the "tooltip" (`isEager`) version.

### ✏️ Notes
- Also added some `data-pka-anchor` attributes throughout `<Popover>`.
- **💥 [BREAKING CHANGE]:** Adjusted `data-pka-anchor` values to use a `.` delimiter instead of a `-`, for consistency (ex `popover-trigger` → `popover.trigger`)

