### PR TITLE
PD-13509 add zindex for overlay

### DIFF
--- a/packages/SidePanel/src/components/Overlay/Overlay.styles.js
+++ b/packages/SidePanel/src/components/Overlay/Overlay.styles.js
@@ -9,4 +9,5 @@ export const overlayCSS = css`
   position: fixed;
   top: 0;
   width: 100%;
+  z-index: ${props => props.zIndex};
 `;


### PR DESCRIPTION
### 🛠 Purpose
- zindex was missed in overlay styles
---

### ✏️ Notes to Reviewer

---

### 🖥 Screenshots

---
