### PR TITLE
PD-13509 fix side panel overlay with percentage width

### DIFF
--- a/packages/SidePanel/src/components/Group/Group.js
+++ b/packages/SidePanel/src/components/Group/Group.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
+import { zValue } from "@paprika/stylers/lib/helpers";
 import { extractChildren } from "../../helpers";
 import Overlay from "../Overlay";
 import { groupCSS } from "./Group.styles";
@@ -9,10 +10,12 @@ import useOffsetScroll from "../../hooks/useOffsetScroll";
 const propTypes = {
   children: PropTypes.node.isRequired,
   offsetY: PropTypes.number,
+  zIndex: PropTypes.number,
 };
 
 const defaultProps = {
   offsetY: 0,
+  zIndex: zValue(6),
 };
 
 export default function Group(props) {

--- a/packages/SidePanel/src/components/Group/Group.styles.js
+++ b/packages/SidePanel/src/components/Group/Group.styles.js
@@ -17,6 +17,7 @@ export const groupCSS = css`
     `;
   }}
 
+  /* Read more here: https://github.com/acl-services/paprika/pull/239#discussion_r336679762 */
   > div[role="dialog"] {
     visibility: visible;
   }

--- a/packages/SidePanel/src/components/Group/Group.styles.js
+++ b/packages/SidePanel/src/components/Group/Group.styles.js
@@ -7,6 +7,7 @@ export const groupCSS = css`
   justify-content: flex-end;
   position: fixed;
   right: 0;
+  visibility: hidden;
   width: 100%;
   z-index: ${props => props.zIndex};
 
@@ -15,4 +16,8 @@ export const groupCSS = css`
       top: ${props.offsetY}px;
     `;
   }}
+
+  > div[role="dialog"] {
+    visibility: visible;
+  }
 `;

--- a/packages/SidePanel/stories/SidePanel.Group.stories.js
+++ b/packages/SidePanel/stories/SidePanel.Group.stories.js
@@ -57,8 +57,8 @@ storiesOf("SidePanel / SidePanel.Group", module).add("SidePanel.Group has offset
     <Nav />
     <TextLine repeat={100} />
     <SidePanel.Group offsetY={40}>
-      <SidePanel.Group.Overlay />
-      <SidePanel onClose={onClose} isOpen width={300}>
+      <SidePanel.Group.Overlay onClose={onClose} />
+      <SidePanel onClose={onClose} isOpen width="50%">
         <SidePanel.Header>
           <Heading level={2}>With Header</Heading>
         </SidePanel.Header>


### PR DESCRIPTION
### 🛠 Purpose

---

### ✏️ Notes to Reviewer
---
- Make it so that the Group and Overlay component has the same z-index
- Make it so that the Overlay is clickable even if the Group has a width of 100%

### 🖥 Screenshots

---
![Screen Shot 2019-10-18 at 2 19 15 PM](https://user-images.githubusercontent.com/19940076/67129016-4b38d800-f1b2-11e9-8aaa-e054605de029.png)
