### PR TITLE
AN-7841 Add moreProps for form element description and error

### DIFF
--- a/packages/FormElement/src/components/Description/Description.js
+++ b/packages/FormElement/src/components/Description/Description.js
@@ -13,10 +13,10 @@ const defaultProps = {
 };
 
 function Description(props) {
-  const { children, ariaDescriptionId } = props;
+  const { children, ariaDescriptionId, ...moreProps } = props;
 
   return (
-    <div id={ariaDescriptionId} css={descriptionStyles} data-pka-anchor="formElement.description">
+    <div id={ariaDescriptionId} css={descriptionStyles} data-pka-anchor="formElement.description" {...moreProps}>
       {children}
     </div>
   );

--- a/packages/FormElement/src/components/ErrorMessage/ErrorMessage.js
+++ b/packages/FormElement/src/components/ErrorMessage/ErrorMessage.js
@@ -14,12 +14,12 @@ const defaultProps = {
 };
 
 function ErrorMessage(props) {
-  const { children } = props;
+  const { children, ...moreProps } = props;
 
   if (!children) return null;
 
   return (
-    <div css={errorMessageStyles} data-pka-anchor="formElement.error">
+    <div css={errorMessageStyles} data-pka-anchor="formElement.error" {...moreProps}>
       <ExclamationCircleIcon css={iconStyles} />
       {children}
     </div>


### PR DESCRIPTION
### 🛠 Purpose

AN needs to pass in testing id for tests in `FormElement.Decription` and `FormElement.Error`, we didn't support that before.

### ✏️ Notes to Reviewer



### 🖥 Screenshots

---
