### PR TITLE
AN-8115 Adding space before form element optional label for edge cases

### DIFF
--- a/packages/L10n/src/locales-js/de.js
+++ b/packages/L10n/src/locales-js/de.js
@@ -56,8 +56,8 @@ const locales = {
         "next": "Nächste Seite"
       },
       "formElement": {
-        "optional": "(optional)",
-        "required": "(erforderlich)"
+        "optional": " (optional)",
+        "required": " (erforderlich)"
       },
       "prevNextArrowButton": {
         "arrowup": "Auf",

--- a/packages/L10n/src/locales-js/en.js
+++ b/packages/L10n/src/locales-js/en.js
@@ -59,8 +59,8 @@ const locales = {
         "next": "Next page"
       },
       "formElement": {
-        "optional": "(optional)",
-        "required": "(required)",
+        "optional": " (optional)",
+        "required": " (required)",
         "aria_info_circle": "Information"
       },
       "prevNextArrowButton": {

--- a/packages/L10n/src/locales-js/es.js
+++ b/packages/L10n/src/locales-js/es.js
@@ -56,8 +56,8 @@ const locales = {
         "next": "Siguiente página"
       },
       "formElement": {
-        "optional": "(opcional)",
-        "required": "(requerido)"
+        "optional": " (opcional)",
+        "required": " (requerido)"
       },
       "prevNextArrowButton": {
         "arrowup": "arriba",

--- a/packages/L10n/src/locales-js/fr.js
+++ b/packages/L10n/src/locales-js/fr.js
@@ -56,8 +56,8 @@ const locales = {
         "next": "Page suivante"
       },
       "formElement": {
-        "optional": "(facultatif)",
-        "required": "(requis)"
+        "optional": " (facultatif)",
+        "required": " (requis)"
       },
       "prevNextArrowButton": {
         "arrowup": "haut",

--- a/packages/L10n/src/locales-js/pl.js
+++ b/packages/L10n/src/locales-js/pl.js
@@ -56,8 +56,8 @@ const locales = {
         "next": "Następna strona"
       },
       "formElement": {
-        "optional": "(opcjonalny)",
-        "required": "(wymagane)"
+        "optional": " (opcjonalny)",
+        "required": " (wymagane)"
       },
       "prevNextArrowButton": {
         "arrowup": "w górę",

--- a/packages/L10n/src/locales-js/pt.js
+++ b/packages/L10n/src/locales-js/pt.js
@@ -56,8 +56,8 @@ const locales = {
         "next": "Próxima página"
       },
       "formElement": {
-        "optional": "(opcional)",
-        "required": "(obrigatório)"
+        "optional": " (opcional)",
+        "required": " (obrigatório)"
       },
       "prevNextArrowButton": {
         "arrowup": "para cima",

--- a/packages/L10n/src/locales/de.yml
+++ b/packages/L10n/src/locales/de.yml
@@ -44,8 +44,8 @@ de:
       prev: Vorherige Seite
       next: Nächste Seite
     formElement:
-      optional: (optional)
-      required: (erforderlich)
+      optional: " (optional)"
+      required: " (erforderlich)"
     prevNextArrowButton:
       arrowup: Auf
       arrowdown: Ab

--- a/packages/L10n/src/locales/en.yml
+++ b/packages/L10n/src/locales/en.yml
@@ -47,8 +47,8 @@ en:
       prev: Previous page
       next: Next page
     formElement:
-      optional: (optional)
-      required: (required)
+      optional: " (optional)"
+      required: " (required)"
       aria_info_circle: Information
     prevNextArrowButton:
       arrowup: up

--- a/packages/L10n/src/locales/es.yml
+++ b/packages/L10n/src/locales/es.yml
@@ -44,8 +44,8 @@ es:
       prev: Página anterior
       next: Siguiente página
     formElement:
-      optional: (opcional)
-      required: (requerido)
+      optional: " (opcional)"
+      required: " (requerido)"
     prevNextArrowButton:
       arrowup: arriba
       arrowdown: abajo

--- a/packages/L10n/src/locales/fr.yml
+++ b/packages/L10n/src/locales/fr.yml
@@ -44,8 +44,8 @@ fr:
       prev: Page précédente
       next: Page suivante
     formElement:
-      optional: (facultatif)
-      required: (requis)
+      optional: " (facultatif)"
+      required: " (requis)"
     prevNextArrowButton:
       arrowup: haut
       arrowdown: bas

--- a/packages/L10n/src/locales/pl.yml
+++ b/packages/L10n/src/locales/pl.yml
@@ -44,8 +44,8 @@ pl:
       prev: Poprzednia strona
       next: Następna strona
     formElement:
-      optional: (opcjonalny)
-      required: (wymagane)
+      optional: " (opcjonalny)"
+      required: " (wymagane)"
     prevNextArrowButton:
       arrowup: w górę
       arrowdown: w dół

--- a/packages/L10n/src/locales/pt.yml
+++ b/packages/L10n/src/locales/pt.yml
@@ -44,8 +44,8 @@ pt:
       prev: Página anterior
       next: Próxima página
     formElement:
-      optional: (opcional)
-      required: (obrigatório)
+      optional: " (opcional)"
+      required: " (obrigatório)"
     prevNextArrowButton:
       arrowup: para cima
       arrowdown: para baixo


### PR DESCRIPTION
### 🛠 Purpose

Sometimes the label is an extremely long string like this:
![image](https://user-images.githubusercontent.com/38733362/67980117-f26a3600-fbda-11e9-8b2d-5de966a5097d.png)
We can avoid the label cut-off by adding a space before `optional` `required` label.
Note: Japanese and Chinese don't need this cause they'll be broke up naturally.

### ✏️ Notes to Reviewer

**Patch update**

### 🖥 Screenshots

Before:
![image](https://user-images.githubusercontent.com/38733362/67981441-eb90f280-fbdd-11e9-98bc-6a72bb3b9dc5.png)


After:
![image](https://user-images.githubusercontent.com/38733362/67981575-314dbb00-fbde-11e9-9ece-463599774a91.png)


