### PR TITLE
PD-13298 Make CollapsibleChecklists.Group accept more props, to pass …

### DIFF
--- a/packages/CollapsibleChecklists/src/components/Group/Group.js
+++ b/packages/CollapsibleChecklists/src/components/Group/Group.js
@@ -72,7 +72,7 @@ function setIsIndeterminate(children, checkboxRef, isCheckedByDefault, isIndeter
 }
 
 function Group(props) {
-  const { children, isCheckedByDefault, isDisabled, isIndeterminateByDefault, onExpand, title } = props;
+  const { children, isCheckedByDefault, isDisabled, isIndeterminateByDefault, onExpand, title, ...moreProps } = props;
   const onChange = React.useContext(CollapsibleChecklistsContext);
   const [isCollapsed, setIsCollapsed] = React.useState(true);
   const checkboxRef = React.useRef({});
@@ -168,6 +168,7 @@ function Group(props) {
         }
         setIsCollapsed(!isCollapsed);
       }}
+      {...moreProps}
     >
       {modifiedChildren}
     </Collapsible>


### PR DESCRIPTION
Make CollapsibleChecklists.Group accept more props, to pass to the Collapsible.

### 🛠 Purpose

Where I'm using this component I want to pass in `aria-busy` when it is fetching the group's children via an API call.