### PR TITLE
Pd 13695 fix token colour

### DIFF
--- a/packages/Tokens/src/tokens.yaml
+++ b/packages/Tokens/src/tokens.yaml
@@ -106,13 +106,13 @@ highlight:
       box-shadow: 0 0 0 1px $color--blue, 0 0 0 3px $color--blue-lighten-30
       inset-box-shadow: inset 0 0 0 1px $color--blue, inset 0 0 0 3px $color--blue-lighten-30
   text:
-    added:
+    green:
       background: $color--green-lighten-50
       font: $color--green-darken-20
-    removed:
+    orange:
       background: $color--orange-lighten-40
       font: $color--orange-darken-20
-    selected:
+    yellow:
       background: '#f7f3ba'
       font: $color--yellow-darken-40
 #

--- a/packages/Tokens/src/tokens.yaml
+++ b/packages/Tokens/src/tokens.yaml
@@ -108,7 +108,7 @@ highlight:
   text:
     added:
       background: $color--green-lighten-50
-      font: $color--green-lighten-20
+      font: $color--green-darken-20
     removed:
       background: $color--orange-lighten-40
       font: $color--orange-darken-20


### PR DESCRIPTION
### 🛠 Purpose

---

- The token rename, is because added / selected / removed doesn't make sense in citation mode. We should make it a bit more generic and most simple way is just to use the colour.

- Modified one token from lighten -> darken

### ✏️ Notes to Reviewer

---

### 🖥 Screenshots

---
