### PR TITLE
PD-13719 make overflow hidden important

### DIFF
--- a/packages/SidePanel/src/components/LockBodyScroll.js
+++ b/packages/SidePanel/src/components/LockBodyScroll.js
@@ -2,7 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 
 function LockBodyScroll() {
-  return ReactDOM.createPortal(<style type="text/css">{`body { overflow: hidden; }`}</style>, document.head);
+  return ReactDOM.createPortal(<style type="text/css">{`body { overflow: hidden !important; }`}</style>, document.head);
 }
 
 export default LockBodyScroll;


### PR DESCRIPTION
### 🛠 Purpose
- Resolves https://github.com/acl-services/paprika/issues/277
- make lock body scroll overflow hidden !important to fight with inline css conflicts
---

### ✏️ Notes to Reviewer
---
- there is some inline css overflow auto in projects... that conflicts with this, so need to make it !important

### 🖥 Screenshots

---
