### PR TITLE
Pd 13298 popover focus

### DIFF
--- a/packages/Popover/src/Popover.js
+++ b/packages/Popover/src/Popover.js
@@ -102,7 +102,6 @@ class Popover extends React.Component {
     this.$portal = document.body.appendChild(portalNode);
 
     this.focusableElements = [];
-    this.originalTabIndexes = [];
     this.triggerFocusIndex = null;
 
     this.state = {
@@ -341,21 +340,10 @@ class Popover extends React.Component {
     return false;
   };
 
-  restoreTabIndexes = () => {
-    this.focusableElements.forEach(focusableElement => {
-      if (focusableElement !== this.$trigger && !this.elementIsDescendentOfPopover(focusableElement)) {
-        focusableElement.tabIndex = this.originalTabIndexes.shift(); // eslint-disable-line no-param-reassign
-      }
-    });
-  };
-
-  removeTabIndexes = () => {
+  getPopoverTriggerFocusIndex = () => {
     this.focusableElements.forEach((focusableElement, index) => {
       if (focusableElement === this.$trigger) {
         this.triggerFocusIndex = index;
-      } else if (!this.elementIsDescendentOfPopover(focusableElement)) {
-        this.originalTabIndexes.push(focusableElement.tabIndex);
-        focusableElement.tabIndex = -1; // eslint-disable-line no-param-reassign
       }
     });
   };
@@ -365,7 +353,7 @@ class Popover extends React.Component {
     //       find the first focusable element like button, input, etc?
     //       can focus automatically
     if (!this.props.shouldKeepFocus && !this.props.isEager && this.isOpen() && event.propertyName === "visibility") {
-      this.removeTabIndexes();
+      this.getPopoverTriggerFocusIndex();
       event.target.focus();
     }
   };
@@ -415,13 +403,11 @@ class Popover extends React.Component {
   close() {
     // NOTE: Even if uncontrolled, the app may want to be notified when closed via the onClose callback
     if (this.props.onClose !== null) {
-      this.restoreTabIndexes();
       this.props.onClose();
     }
 
     if (this.props.isOpen === null) {
       this.setState({ isOpen: false });
-      this.restoreTabIndexes();
       this.removeListeners();
     }
   }

--- a/packages/Popover/src/Popover.js
+++ b/packages/Popover/src/Popover.js
@@ -7,9 +7,7 @@ import tokens from "@paprika/tokens";
 import { AlignTypes } from "@paprika/helpers/lib/customPropTypes";
 import isInsideBoundaries from "./helpers/isInsideBoundaries";
 import { getContentCoordinates, getTipCoordinates } from "./helpers/getPosition";
-// import { isActiveElementPopover } from "./helpers/isActiveElementPopover";
 import getBoundingClientRect from "./helpers/getBoundingClientRect";
-
 import PopoverContext, { ThemeContext } from "./PopoverContext";
 import Content from "./components/Content/Content";
 import Card from "./components/Card/Card";
@@ -30,7 +28,7 @@ const focusableElementSelector =
   'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"]), [role="button"]';
 let focusableElements;
 const originalTabIndexes = [];
-let triggerFocusIndex = -1;
+let triggerFocusIndex;
 
 // TODO: To handle cases where there are multiple scrolling containers, we need to implement
 //       getScrollContainer as oneOfType([func, arrayOf(func)])
@@ -180,8 +178,6 @@ class Popover extends React.Component {
     // about setState for Popovers and Tooltips in ComponentDidMount
     // https://reactjs.org/docs/react-component.html#componentdidmount
 
-    focusableElements = document.querySelectorAll(focusableElementSelector);
-
     if (this.isOpen()) {
       this.addListeners();
       this.setVisibilityAndPosition();
@@ -190,6 +186,7 @@ class Popover extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (this.isOpen() && !this.hasListeners) {
+      focusableElements = document.querySelectorAll(focusableElementSelector);
       this.addListeners();
     }
 
@@ -422,9 +419,6 @@ class Popover extends React.Component {
 
       // NOTE: If we don't prevent the focusing back to the trigger while using focus and mouseover prop
       //       will created a bug looping over opening and closing constantly.
-      // if (!this.props.shouldKeepFocus && !this.props.isEager && this.$trigger && !isActiveElementPopover()) {
-      //   this.$trigger.focus();
-      // }
       this.restoreTabIndexes();
       this.removeListeners();
     }

--- a/packages/Popover/src/Popover.js
+++ b/packages/Popover/src/Popover.js
@@ -304,29 +304,25 @@ class Popover extends React.Component {
 
   handleKeyDown = event => {
     if (event.key === "Tab" && this.isOpen() && this.$trigger) {
-      if (event.shiftKey && this.focusIsOnFirstFocusableElementInPopover()) {
+      const isFocusOnFirst = this.focusIsOnCertainElementInPopover("first") || document.activeElement === this.$content;
+      const isFocusOnLast = this.focusIsOnCertainElementInPopover("last");
+
+      if (event.shiftKey && isFocusOnFirst) {
         event.preventDefault();
-        this.focusableElements[this.triggerFocusIndex].focus(); // this closes the popover, which restores tabIndexes
-      } else if (!event.shiftKey && this.focusIsOnLastFocusableElementInPopover()) {
+        this.restoreTabIndexes();
+        focusableElements[triggerFocusIndex].focus();
+      } else if (!event.shiftKey && isFocusOnLast) {
         event.preventDefault();
-        this.focusableElements[this.triggerFocusIndex + 1].focus(); // this closes the popover, which restores tabIndexes
+        this.restoreTabIndexes();
+        focusableElements[triggerFocusIndex + 1].focus();
       }
     }
   };
 
-  focusIsOnFirstFocusableElementInPopover = () => {
-    return this.focusIsOnCertainElementInPopover("first");
-  };
-
-  focusIsOnLastFocusableElementInPopover = () => {
-    return this.focusIsOnCertainElementInPopover("last");
-  };
-
   focusIsOnCertainElementInPopover = which => {
-    const popoverContent = document.querySelector("[data-pka-anchor='popover.content']"); // TODO: use react
-    const focusableElementsInPopover = popoverContent.querySelectorAll(focusableElementSelector);
-
+    const focusableElementsInPopover = this.$content.querySelectorAll(focusableElementSelector);
     const index = which === "first" ? 0 : focusableElementsInPopover.length - 1;
+
     return document.activeElement === focusableElementsInPopover[index];
   };
 
@@ -418,9 +414,6 @@ class Popover extends React.Component {
 
     if (this.props.isOpen === null) {
       this.setState({ isOpen: false });
-
-      // NOTE: If we don't prevent the focusing back to the trigger while using focus and mouseover prop
-      //       will created a bug looping over opening and closing constantly.
       this.restoreTabIndexes();
       this.removeListeners();
     }

--- a/packages/Popover/src/Popover.js
+++ b/packages/Popover/src/Popover.js
@@ -315,11 +315,9 @@ class Popover extends React.Component {
 
       if (event.shiftKey && isFocusOnFirst) {
         event.preventDefault();
-        this.restoreTabIndexes();
         this.focusableElements[this.triggerFocusIndex].focus();
       } else if (!event.shiftKey && isFocusOnLast) {
         event.preventDefault();
-        this.restoreTabIndexes();
         this.focusableElements[this.triggerFocusIndex + 1].focus();
       }
     }
@@ -346,7 +344,7 @@ class Popover extends React.Component {
   restoreTabIndexes = () => {
     this.focusableElements.forEach(focusableElement => {
       if (focusableElement !== this.$trigger && !this.elementIsDescendentOfPopover(focusableElement)) {
-        focusableElement.tabIndex = this.originalTabIndexes.reverse().pop(); // eslint-disable-line no-param-reassign
+        focusableElement.tabIndex = this.originalTabIndexes.shift(); // eslint-disable-line no-param-reassign
       }
     });
   };
@@ -416,7 +414,10 @@ class Popover extends React.Component {
 
   close() {
     // NOTE: Even if uncontrolled, the app may want to be notified when closed via the onClose callback
-    if (this.props.onClose !== null) this.props.onClose();
+    if (this.props.onClose !== null) {
+      this.restoreTabIndexes();
+      this.props.onClose();
+    }
 
     if (this.props.isOpen === null) {
       this.setState({ isOpen: false });

--- a/packages/Popover/src/Popover.js
+++ b/packages/Popover/src/Popover.js
@@ -310,11 +310,11 @@ class Popover extends React.Component {
       if (event.shiftKey && isFocusOnFirst) {
         event.preventDefault();
         this.restoreTabIndexes();
-        focusableElements[triggerFocusIndex].focus();
+        this.focusableElements[this.triggerFocusIndex].focus();
       } else if (!event.shiftKey && isFocusOnLast) {
         event.preventDefault();
         this.restoreTabIndexes();
-        focusableElements[triggerFocusIndex + 1].focus();
+        this.focusableElements[this.triggerFocusIndex + 1].focus();
       }
     }
   };
@@ -420,6 +420,7 @@ class Popover extends React.Component {
   }
 
   isOpen() {
+    this.focusableElements = document.querySelectorAll(focusableElementSelector);
     return this.props.isOpen !== null ? this.props.isOpen : this.state.isOpen;
   }
 

--- a/packages/Popover/src/Popover.js
+++ b/packages/Popover/src/Popover.js
@@ -180,13 +180,19 @@ class Popover extends React.Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (!this.props.isOpen && nextProps.isOpen) {
-      this.open();
+  static getDerivedStateFromProps(nextProps, prevState) {
+    if (!prevState.isOpen && nextProps.isOpen) {
+      return { isOpen: true };
     }
+
+    return null;
   }
 
   componentDidUpdate(prevProps) {
+    if (!prevProps.isOpen && this.props.isOpen) {
+      this.open();
+    }
+
     if (this.isOpen() && !this.hasListeners) {
       this.focusableElements = document.querySelectorAll(focusableElementSelector);
       this.addListeners();

--- a/packages/Popover/src/Popover.js
+++ b/packages/Popover/src/Popover.js
@@ -26,7 +26,8 @@ import PopoverStyled from "./Popover.styles";
 const openDelay = 350;
 const closeDelay = 150;
 const throttleDelay = 20;
-const focusableElementSelector = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+const focusableElementSelector =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"]), [role="button"]';
 let focusableElements;
 const originalTabIndexes = [];
 let triggerFocusIndex = -1;

--- a/packages/Popover/src/components/Content/Content.js
+++ b/packages/Popover/src/components/Content/Content.js
@@ -100,7 +100,7 @@ const Content = React.forwardRef((props, ref) => {
       onMouseOut={handleMouseEvent}
       onMouseOver={handleMouseEvent}
       style={contentStyles}
-      tabIndex={isOpen ? 0 : -1}
+      tabIndex="-1"
       zIndex={content.zIndex}
       {...moreProps}
     >

--- a/packages/Popover/stories/Popover.stories.js
+++ b/packages/Popover/stories/Popover.stories.js
@@ -7,6 +7,7 @@ import WithTriggers from "./examples/WithTriggers";
 import PositioningElement from "./examples/PositioningElement";
 import ScrollContainer from "./examples/ScrollContainer";
 import Transformed from "./examples/Transformed";
+import FocusTest from "./examples/FocusTest";
 import A11y from "./examples/A11y";
 import Cypress, { propHandles } from "./examples/Cypress";
 import Screener from "./examples/Screener";
@@ -21,7 +22,9 @@ storiesOf("Popover", module)
   .add("With Scroll Container", ScrollContainer)
   .add("With Dynamic Content", DynamicContent);
 
-storiesOf("Popover/Dev", module).add("Has container with a CSS transform", () => <Transformed />);
+storiesOf("Popover/Dev", module)
+  .add("Has container with a CSS transform", () => <Transformed />)
+  .add("Testing Focus Management", () => <FocusTest />);
 
 storiesOf("Popover/Automation Tests", module)
   .add("Accessibility", () => <A11y />)

--- a/packages/Popover/stories/examples/Basic.js
+++ b/packages/Popover/stories/examples/Basic.js
@@ -18,9 +18,10 @@ export const popoverProps = () => ({
   offset: number("offset", 12),
 });
 
+/* eslint-disable jsx-a11y/tabindex-no-positive */
 const ExampleStory = () => (
   <CenteredStory>
-    <input />
+    <input tabIndex="3" />
     <Gap />
     <Popover {...popoverProps()}>
       <Popover.Trigger>
@@ -43,5 +44,6 @@ const ExampleStory = () => (
     <input />
   </CenteredStory>
 );
+/* eslint-enable jsx-a11y/tabindex-no-positive */
 
 export default () => <ExampleStory />;

--- a/packages/Popover/stories/examples/Basic.js
+++ b/packages/Popover/stories/examples/Basic.js
@@ -2,20 +2,13 @@ import React from "react";
 import { text, number, select } from "@storybook/addon-knobs";
 import styled from "styled-components";
 import { CenteredStory } from "storybook/assets/styles/common.styles";
-import Button from "@paprika/button";
+import InfoCircleIcon from "@paprika/icon/lib/InfoCircle";
 import Popover from "../../src";
 
 const Gap = styled.div`
   display: inline-block;
   width: 100px;
 `;
-
-const sampleText = {
-  short: "Lorem Hipsum",
-  long: `Lorem ipsum lumbersexual hot chicken austin readymade messenger bag aesthetic meh twee you probably havent
-    heard of them 3 wolf moon listicle. Normcore ramps gastropub fanny pack pabst. Hashtag roof party pour-over food
-    truck, crucifix try-hard godard biodiesel next level snackwave disrupt flexitarian.`,
-};
 
 export const popoverProps = () => ({
   align: select("align", ["bottom", "top", "right", "left"], "bottom"),
@@ -27,27 +20,27 @@ export const popoverProps = () => ({
 
 const ExampleStory = () => (
   <CenteredStory>
+    <input />
+    <Gap />
     <Popover {...popoverProps()}>
       <Popover.Trigger>
-        <Button>Open Popover</Button>
+        <InfoCircleIcon />
       </Popover.Trigger>
       <Popover.Content>
-        <Popover.Card>{sampleText.long}</Popover.Card>
+        <Popover.Card>
+          <p>
+            Some copy with a{" "}
+            <a href="http://www.google.ca" target="_blank" rel="noopener noreferrer">
+              link
+            </a>
+          </p>
+          <button type="button">Submit</button>
+        </Popover.Card>
       </Popover.Content>
       <Popover.Tip />
     </Popover>
-
     <Gap />
-
-    <Popover {...popoverProps()} isDark isEager>
-      <Popover.Trigger>
-        <Button kind="minor">Open Tooltip</Button>
-      </Popover.Trigger>
-      <Popover.Content>
-        <Popover.Card>{sampleText.short}</Popover.Card>
-      </Popover.Content>
-      <Popover.Tip />
-    </Popover>
+    <input />
   </CenteredStory>
 );
 

--- a/packages/Popover/stories/examples/Basic.js
+++ b/packages/Popover/stories/examples/Basic.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { text, number, select } from "@storybook/addon-knobs";
+import { boolean, text, number, select } from "@storybook/addon-knobs";
 import styled from "styled-components";
 import { CenteredStory } from "storybook/assets/styles/common.styles";
 import InfoCircleIcon from "@paprika/icon/lib/InfoCircle";
@@ -16,6 +16,8 @@ export const popoverProps = () => ({
   maxWidth: text("maxWidth", "320"),
   minWidth: text("minWidth", "0"),
   offset: number("offset", 12),
+  shouldKeepFocus: boolean("shouldKeepFocus", false),
+  isEager: boolean("isEager", false),
 });
 
 /* eslint-disable jsx-a11y/tabindex-no-positive */

--- a/packages/Popover/stories/examples/Basic.js
+++ b/packages/Popover/stories/examples/Basic.js
@@ -1,8 +1,8 @@
 import React from "react";
-import { boolean, text, number, select } from "@storybook/addon-knobs";
+import { text, number, select } from "@storybook/addon-knobs";
 import styled from "styled-components";
 import { CenteredStory } from "storybook/assets/styles/common.styles";
-import InfoCircleIcon from "@paprika/icon/lib/InfoCircle";
+import Button from "@paprika/button";
 import Popover from "../../src";
 
 const Gap = styled.div`
@@ -10,24 +10,26 @@ const Gap = styled.div`
   width: 100px;
 `;
 
+const sampleText = {
+  short: "Lorem Hipsum",
+  long: `Lorem ipsum lumbersexual hot chicken austin readymade messenger bag aesthetic meh twee you probably havent
+    heard of them 3 wolf moon listicle. Normcore ramps gastropub fanny pack pabst. Hashtag roof party pour-over food
+    truck, crucifix try-hard godard biodiesel next level snackwave disrupt flexitarian.`,
+};
+
 export const popoverProps = () => ({
   align: select("align", ["bottom", "top", "right", "left"], "bottom"),
   edge: select("edge", ["left", "right", null], null),
   maxWidth: text("maxWidth", "320"),
   minWidth: text("minWidth", "0"),
   offset: number("offset", 12),
-  shouldKeepFocus: boolean("shouldKeepFocus", false),
-  isEager: boolean("isEager", false),
 });
 
-/* eslint-disable jsx-a11y/tabindex-no-positive */
 const ExampleStory = () => (
   <CenteredStory>
-    <input tabIndex="3" />
-    <Gap />
     <Popover {...popoverProps()}>
       <Popover.Trigger>
-        <InfoCircleIcon />
+        <Button>Open Popover</Button>
       </Popover.Trigger>
       <Popover.Content>
         <Popover.Card>
@@ -42,10 +44,19 @@ const ExampleStory = () => (
       </Popover.Content>
       <Popover.Tip />
     </Popover>
+
     <Gap />
-    <input />
+
+    <Popover {...popoverProps()} isDark isEager>
+      <Popover.Trigger>
+        <Button kind="minor">Open Tooltip</Button>
+      </Popover.Trigger>
+      <Popover.Content>
+        <Popover.Card>{sampleText.short}</Popover.Card>
+      </Popover.Content>
+      <Popover.Tip />
+    </Popover>
   </CenteredStory>
 );
-/* eslint-enable jsx-a11y/tabindex-no-positive */
 
 export default () => <ExampleStory />;

--- a/packages/Popover/stories/examples/Controlled.js
+++ b/packages/Popover/stories/examples/Controlled.js
@@ -22,10 +22,20 @@ export default class ExampleStory extends React.Component {
         <Popover isOpen={this.state.isOpen} onClose={this.handleClose}>
           <Button onClick={this.handleClick}>Open Popover</Button>
           <Popover.Content>
-            <Popover.Card>This popover is a controlled component.</Popover.Card>
+            <Popover.Card>
+              <p>
+                Some copy with a{" "}
+                <a href="http://www.google.ca" target="_blank" rel="noopener noreferrer">
+                  link
+                </a>
+              </p>
+              <button type="button">Submit</button>
+            </Popover.Card>
           </Popover.Content>
           <Popover.Tip />
         </Popover>
+        &nbsp;&nbsp;&nbsp;
+        <a href="http://www.google.ca">Another link</a>
       </CenteredStory>
     );
   }

--- a/packages/Popover/stories/examples/FocusTest.js
+++ b/packages/Popover/stories/examples/FocusTest.js
@@ -1,0 +1,68 @@
+import React from "react";
+import { Story, Gap } from "storybook/assets/styles/common.styles";
+import Button from "@paprika/button";
+import Popover from "../../src";
+
+class ExampleStory extends React.Component {
+  state = {
+    isOpen: false,
+  };
+
+  handleClick = () => {
+    this.setState(state => ({ isOpen: !state.isOpen }));
+  };
+
+  handleClose = () => {
+    this.setState({ isOpen: false });
+  };
+
+  render() {
+    return (
+      <Story>
+        <Button>Vinyl</Button>
+        <Gap />
+        <p>
+          <Popover>
+            <Popover.Trigger>Open Popover</Popover.Trigger>
+            <Popover.Content>
+              <Popover.Card>
+                <Button>Aesthetic</Button>
+                <Button>Gastropub</Button>
+                <Button>Snackwave</Button>
+              </Popover.Card>
+            </Popover.Content>
+            <Popover.Tip />
+          </Popover>
+        </p>
+        <Gap />
+        <p>
+          <Popover isOpen={this.state.isOpen} onClose={this.handleClose}>
+            <Button onClick={this.handleClick}>Open Controlled Popover</Button>
+            <Popover.Content>
+              <Popover.Card>
+                <Button>Aesthetic</Button>
+                <Button>Gastropub</Button>
+                <Button>Snackwave</Button>
+              </Popover.Card>
+            </Popover.Content>
+            <Popover.Tip />
+          </Popover>
+        </p>
+        <Gap />
+        <p>
+          <Popover isDark isEager>
+            <Popover.Trigger>Open Tooltip</Popover.Trigger>
+            <Popover.Content>
+              <Popover.Card>Lorem hipsum snackwave</Popover.Card>
+            </Popover.Content>
+            <Popover.Tip />
+          </Popover>
+        </p>
+        <Gap />
+        <Button>Adaptogen</Button>
+      </Story>
+    );
+  }
+}
+
+export default () => <ExampleStory />;


### PR DESCRIPTION
Bug fix in the Popover component.

### 🛠 Purpose

Before this PR, when you open the popover, focus goes into it.  Then when you tab through its content, focus goes to the address bar (since the Popover is added to the bottom of the DOM).

After this PR, when you open the popover, focus goes into it. Then when you tab through its content, focus goes to the next item on screen and the popover closes.

This is maybe premature and it needs to be tested with `isEager` and some other props.... just want to get some feedback.

### 🖥 Screenshots

Notice the `tabIndex` before (3), how it is removed (-1), then how it is restored (3).
Notice I can tab right through the popover, in both directions.


![focus2](https://user-images.githubusercontent.com/23224777/68981564-ab726800-07b8-11ea-9cfc-3917107c5811.gif)
