### PR TITLE
PD-13299 Fix Axe error on SortableItem

### DIFF
--- a/packages/Sortable/package.json
+++ b/packages/Sortable/package.json
@@ -20,7 +20,7 @@
     "@paprika/stylers": "^0.2.2",
     "@paprika/tokens": "^0.1.9",
     "prop-types": "^15.7.2",
-    "react-beautiful-dnd": "^11.0.4",
+    "react-beautiful-dnd": "^12.1.1",
     "uuid": "^3.3.2"
   },
   "peerDependencies": {

--- a/packages/Sortable/src/Sortable.js
+++ b/packages/Sortable/src/Sortable.js
@@ -75,6 +75,7 @@ const Sortable = ({ children, onChange, hasNumbers, hasZebraStripes, onRemove, .
             data-is-dragging-over={snapshot.isDraggingOver ? true : undefined}
             isDraggingOver={snapshot.isDraggingOver}
             ref={provided.innerRef}
+            role="tree"
           >
             {validChildren.length > 0 &&
               validChildren.map((child, index) => (

--- a/packages/Sortable/src/Sortable.js
+++ b/packages/Sortable/src/Sortable.js
@@ -80,7 +80,6 @@ const Sortable = ({ children, onChange, hasNumbers, hasZebraStripes, onRemove, .
             data-is-dragging-over={snapshot.isDraggingOver ? true : undefined}
             isDraggingOver={snapshot.isDraggingOver}
             ref={provided.innerRef}
-            role="tree"
           >
             {validChildren.length > 0 &&
               validChildren.map((child, index) => (

--- a/packages/Sortable/src/Sortable.js
+++ b/packages/Sortable/src/Sortable.js
@@ -63,7 +63,12 @@ const Sortable = ({ children, onChange, hasNumbers, hasZebraStripes, onRemove, .
   };
 
   return (
-    <DragDropContext onDragEnd={handleDragEnd} onDragStart={handleDragStart} onDragUpdate={handleDragUpdate}>
+    <DragDropContext
+      onDragEnd={handleDragEnd}
+      onDragStart={handleDragStart}
+      onDragUpdate={handleDragUpdate}
+      liftInstruction={I18n.t("sortable.aria_description")}
+    >
       <Droppable droppableId={dropId.current}>
         {(provided, snapshot) => (
           <ul

--- a/packages/Sortable/src/components/SortableItem/SortableItem.js
+++ b/packages/Sortable/src/components/SortableItem/SortableItem.js
@@ -39,7 +39,7 @@ const SortableItem = ({ children, index, hasNumbers, onRemove, ...moreProps }) =
           isDragging={snapshot.isDragging}
           ref={provided.innerRef}
           aria-roledescription={I18n.t("sortable.aria_description")}
-          role="button" /* eslint-disable-line */
+          role="treeitem"
           {...moreProps}
         >
           <div css={itemHandleStyles} data-pka-anchor="sortable.item.handle">

--- a/packages/Sortable/src/components/SortableItem/SortableItem.js
+++ b/packages/Sortable/src/components/SortableItem/SortableItem.js
@@ -38,7 +38,6 @@ const SortableItem = ({ children, index, hasNumbers, onRemove, ...moreProps }) =
           data-is-dragging={snapshot.isDragging ? true : undefined}
           isDragging={snapshot.isDragging}
           ref={provided.innerRef}
-          role="treeitem"
           {...moreProps}
         >
           <div css={itemHandleStyles} data-pka-anchor="sortable.item.handle">

--- a/packages/Sortable/src/components/SortableItem/SortableItem.js
+++ b/packages/Sortable/src/components/SortableItem/SortableItem.js
@@ -38,7 +38,6 @@ const SortableItem = ({ children, index, hasNumbers, onRemove, ...moreProps }) =
           data-is-dragging={snapshot.isDragging ? true : undefined}
           isDragging={snapshot.isDragging}
           ref={provided.innerRef}
-          aria-roledescription={I18n.t("sortable.aria_description")}
           role="treeitem"
           {...moreProps}
         >

--- a/packages/Sortable/src/components/SortableItem/SortableItem.js
+++ b/packages/Sortable/src/components/SortableItem/SortableItem.js
@@ -39,6 +39,7 @@ const SortableItem = ({ children, index, hasNumbers, onRemove, ...moreProps }) =
           isDragging={snapshot.isDragging}
           ref={provided.innerRef}
           aria-roledescription={I18n.t("sortable.aria_description")}
+          role="button" /* eslint-disable-line */
           {...moreProps}
         >
           <div css={itemHandleStyles} data-pka-anchor="sortable.item.handle">

--- a/packages/Sortable/tests/Sortable.cypress.js
+++ b/packages/Sortable/tests/Sortable.cypress.js
@@ -25,7 +25,7 @@ describe("<Sortable />", () => {
       .trigger("mousemove", { button: 0, ...dragOffset })
       .wait(animationDelay);
     cy.get(selector.root)
-      .trigger("mousemove", { button: 0, ...dragOffset })
+      .trigger("mousemove", { button: 0, ...dragOffset, clientY: 100 })
       .trigger("mouseup")
       .wait(animationDelay * 2);
     cy.get(selector.item)

--- a/yarn.lock
+++ b/yarn.lock
@@ -945,10 +945,18 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-transform-typescript" "^7.6.0"
 
-"@babel/runtime-corejs2@^7.3.1", "@babel/runtime-corejs2@^7.4.4", "@babel/runtime-corejs2@^7.4.5":
+"@babel/runtime-corejs2@^7.3.1", "@babel/runtime-corejs2@^7.4.4":
   version "7.6.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs2/-/runtime-corejs2-7.6.3.tgz#de3f446b3fb688b98cbd220474d1a7cad909bcb8"
   integrity sha512-nuA2o+rgX2+PrNTZ063ehncVcg7sn+tU71BB81SaWRVUbGwCOlb0+yQA1e0QqmzOfRSYOxfvf8cosYqFbJEiwQ==
+  dependencies:
+    core-js "^2.6.5"
+    regenerator-runtime "^0.13.2"
+
+"@babel/runtime-corejs2@^7.6.3":
+  version "7.7.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs2/-/runtime-corejs2-7.7.2.tgz#5a8c4e2f8688ce58adc9eb1d8320b6e7341f96ce"
+  integrity sha512-GfVnHchOBvIMsweQ13l4jd9lT4brkevnavnVOej5g2y7PpTRY+R4pcQlCjWMZoUla5rMLFzaS/Ll2s59cB1TqQ==
   dependencies:
     core-js "^2.6.5"
     regenerator-runtime "^0.13.2"
@@ -5586,7 +5594,7 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
-css-box-model@^1.1.2:
+css-box-model@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-box-model/-/css-box-model-1.2.0.tgz#3a26377b4162b3200d2ede4b064ec5b6a75186d0"
   integrity sha512-lri0br+jSNV0kkkiGEp9y9y3Njq2PmpqbeGWRFQJuZteZzY9iC9GZhQ8Y4WpPwM/2YocjHePxy14igJY7YKzkA==
@@ -10247,7 +10255,7 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
-memoize-one@^5.0.0, memoize-one@^5.0.4:
+memoize-one@^5.0.0, memoize-one@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
   integrity sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==
@@ -12216,7 +12224,7 @@ quick-lru@^1.0.0:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
   integrity sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=
 
-raf-schd@^4.0.0:
+raf-schd@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.2.tgz#bd44c708188f2e84c810bf55fcea9231bcaed8a0"
   integrity sha512-VhlMZmGy6A6hrkJWHLNTGl5gtgMUm+xfGza6wbwnE914yeQ5Ybm18vgM734RZhMgfw4tacUrWseGZlpUrrakEQ==
@@ -12306,19 +12314,18 @@ react-base16-styling@^0.5.1:
     lodash.flow "^3.3.0"
     pure-color "^1.2.0"
 
-react-beautiful-dnd@^11.0.4:
-  version "11.0.5"
-  resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-11.0.5.tgz#16b1dbd4d6493de0cb3f842cad57c7e9e1ff5fe7"
-  integrity sha512-7llby9U+jIfkINcyxPHVWU0HFYzqxMemUYgGHsFsbx4fZo1n/pW6sYKYzhxGxR3Ap5HxqswcQkKUZX4uEUWhlw==
+react-beautiful-dnd@^12.1.1:
+  version "12.1.1"
+  resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-12.1.1.tgz#810f9b9d94f667b15b253793e853d016a0f3f07c"
+  integrity sha512-w/mpIXMEXowc53PCEnMoFyAEYFgxMfygMK5msLo5ifJ2/CiSACLov9A79EomnPF7zno3N207QGXsraBxAJnyrw==
   dependencies:
-    "@babel/runtime-corejs2" "^7.4.5"
-    css-box-model "^1.1.2"
-    memoize-one "^5.0.4"
-    raf-schd "^4.0.0"
-    react-redux "^7.0.3"
-    redux "^4.0.1"
-    tiny-invariant "^1.0.4"
-    use-memo-one "^1.1.0"
+    "@babel/runtime-corejs2" "^7.6.3"
+    css-box-model "^1.2.0"
+    memoize-one "^5.1.1"
+    raf-schd "^4.0.2"
+    react-redux "^7.1.1"
+    redux "^4.0.4"
+    use-memo-one "^1.1.1"
 
 react-clientside-effect@^1.2.0:
   version "1.2.2"
@@ -12546,10 +12553,22 @@ react-portal@^4.1.5:
   dependencies:
     prop-types "^15.5.8"
 
-react-redux@^7.0.2, react-redux@^7.0.3:
+react-redux@^7.0.2:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.1.1.tgz#ce6eee1b734a7a76e0788b3309bf78ff6b34fa0a"
   integrity sha512-QsW0vcmVVdNQzEkrgzh2W3Ksvr8cqpAv5FhEk7tNEft+5pp7rXxAudTz3VOPawRkLIepItpkEIyLcN/VVXzjTg==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    hoist-non-react-statics "^3.3.0"
+    invariant "^2.2.4"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^16.9.0"
+
+react-redux@^7.1.1:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.1.3.tgz#717a3d7bbe3a1b2d535c94885ce04cdc5a33fc79"
+  integrity sha512-uI1wca+ECG9RoVkWQFF4jDMqmaw0/qnvaSvOoL/GA4dNxf6LoV8sUAcNDvE5NWKs4hFpn0t6wswNQnY3f7HT3w==
   dependencies:
     "@babel/runtime" "^7.5.5"
     hoist-non-react-statics "^3.3.0"
@@ -12891,7 +12910,7 @@ redent@^2.0.0:
     indent-string "^3.0.0"
     strip-indent "^2.0.0"
 
-redux@^4.0.1:
+redux@^4.0.1, redux@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.4.tgz#4ee1aeb164b63d6a1bcc57ae4aa0b6e6fa7a3796"
   integrity sha512-vKv4WdiJxOWKxK0yRoaK3Y4pxxB0ilzVx6dszU2W8wLxlb2yikRph4iV/ymtdJ6ZxpBLFbyrxklnT5yBbQSl3Q==
@@ -14586,7 +14605,7 @@ tiny-emitter@^2.0.0:
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
   integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
 
-tiny-invariant@^1.0.4, tiny-invariant@^1.0.6:
+tiny-invariant@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.0.6.tgz#b3f9b38835e36a41c843a3b0907a5a7b3755de73"
   integrity sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA==
@@ -15097,7 +15116,7 @@ url@0.11.0, url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-use-memo-one@^1.1.0:
+use-memo-one@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.1.tgz#39e6f08fe27e422a7d7b234b5f9056af313bd22c"
   integrity sha512-oFfsyun+bP7RX8X2AskHNTxu+R3QdE/RC5IefMbqptmACAA/gfol1KDD5KRzPsGMa62sWxGZw+Ui43u6x4ddoQ==


### PR DESCRIPTION
MINOR (backward compatible) change to SortableItem

### 🛠 Purpose
Using the paprika/sortable i was getting this axe error:
`Ensure ARIA attributes are allowed for an element's role.`

Digging into it, it seems to be because the `<li>` elements have an `aria-roledescription` (added both by us, and by the react-beautiful-dnd library) and I need to remove those.

I updated to the latest version of the react-beautiful-dnd library, as they no longer add that attribute. I also removed where we add the attribute. Now the axe error is gone, yay.

But when using screen reader in Chrome, it no longer says “Draggable Item. Press space to lift”.
No announcement is made in Chrome (though one is made in Safari) even though the sortable item has `aria-labelledby="rbd-lift-instruction-0"` and the page includes:
```<div id="rbd-lift-instruction-0" style="display: none;">Draggable item. Ensure your screen reader is not in browse mode and then press space bar to lift.</div>```

I read this page: https://developer.paciellogroup.com/blog/2017/07/short-note-on-aria-label-aria-labelledby-and-aria-describedby/ which basically said aria-labelledby won't work consistently on `li` items.  So i added the `role="treeitem"` and now it does announce it in Chrome.