### PR TITLE
feature(DataTable): support for onKeyDownArrow onClickCell onCollapse…

### DIFF
--- a/packages/DataTable/package.json
+++ b/packages/DataTable/package.json
@@ -19,6 +19,7 @@
     "@paprika/helpers": "^0.2.3",
     "@paprika/icon": "^0.2.5",
     "@paprika/raw-button": "^0.2.2",
+    "@paprika/sidepanel": "^0.2.6",
     "@paprika/stylers": "^0.2.2",
     "@paprika/tokens": "^0.1.9",
     "lodash.debounce": "^4.0.8",

--- a/packages/DataTable/src/DataTable.js
+++ b/packages/DataTable/src/DataTable.js
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import ColumnDefinition from "./components/ColumnDefinition";
 import Navigation from "./components/Navigation";
 import VirtualizedTable from "./components/VirtualizedTable";
+import LoadMoreButton from "./components/LoadMoreButton";
 import { extractChildren } from "./helpers";
 import { sortDirections, columnTypes } from "./constants";
 import { TableProvider } from "./context";
@@ -15,6 +16,9 @@ const propTypes = {
   rowHeight: PropTypes.number,
   reducers: PropTypes.arrayOf(PropTypes.func),
   isLoading: PropTypes.bool,
+  onExpandedRow: PropTypes.func,
+  onKeyDownArrow: PropTypes.func,
+  onClickCell: PropTypes.func,
 };
 
 const defaultProps = {
@@ -24,14 +28,34 @@ const defaultProps = {
   rowHeight: 32,
   reducers: [],
   isLoading: false,
+  onExpandedRow: () => {},
+  onKeyDownArrow: () => {},
+  onClickCell: () => {},
 };
 
 export default function DataTable(props) {
-  const { data, children: childrenProps, height, rowHeight, width, keygen, reducers, isLoading } = props;
-  const { "DataTable.ColumnDefinition": ColumnsDefinition, "DataTable.Navigation": Navigation } = extractChildren(
-    childrenProps,
-    ["DataTable.ColumnDefinition", "DataTable.Navigation"]
-  );
+  const {
+    children: childrenProps,
+    data,
+    height,
+    isLoading,
+    keygen,
+    onKeyDownArrow,
+    onClickCell,
+    onExpandedRow,
+    reducers,
+    rowHeight,
+    width,
+  } = props;
+  const {
+    "DataTable.ColumnDefinition": ColumnsDefinition,
+    "DataTable.Navigation": Navigation,
+    "DataTable.LoadMoreButton": LoadMoreButton,
+  } = extractChildren(childrenProps, [
+    "DataTable.ColumnDefinition",
+    "DataTable.Navigation",
+    "DataTable.LoadMoreButton",
+  ]);
 
   const columns = ColumnsDefinition.map(Column => Column.props);
 
@@ -46,7 +70,16 @@ export default function DataTable(props) {
     <TableProvider data={data} keygen={keygen} reducers={navigationReducers.concat(reducers)}>
       <div>{isLoading ? "Loading..." : null}</div>
       {Navigation ? React.cloneElement(Navigation, { columns }) : null}
-      <VirtualizedTable columns={columns} height={height} rowHeight={rowHeight} width={width} />
+      <VirtualizedTable
+        onExpandedRow={onExpandedRow}
+        columns={columns}
+        height={height}
+        rowHeight={rowHeight}
+        width={width}
+        LoadMoreButton={LoadMoreButton}
+        onKeyDownArrow={onKeyDownArrow}
+        onClickCell={onClickCell}
+      />
     </TableProvider>
   );
 }
@@ -57,3 +90,4 @@ DataTable.ColumnDefinition = ColumnDefinition;
 DataTable.SortDirections = { ...sortDirections };
 DataTable.Navigation = Navigation;
 DataTable.ColumnTypes = columnTypes;
+DataTable.LoadMoreButton = LoadMoreButton;

--- a/packages/DataTable/src/DataTable.styles.js
+++ b/packages/DataTable/src/DataTable.styles.js
@@ -1,5 +1,0 @@
-import { css } from "styled-components";
-
-export const dummyTableStyles = css`
-  background: white;
-`;

--- a/packages/DataTable/src/VirtualizeRows.js
+++ b/packages/DataTable/src/VirtualizeRows.js
@@ -8,6 +8,7 @@ const propTypes = {
   gridRowHeight: PropTypes.number.isRequired,
   gridHeight: PropTypes.number.isRequired,
   gridWidth: PropTypes.number,
+  gridFooter: PropTypes.node,
   data: PropTypes.arrayOf(PropTypes.any).isRequired,
   children: PropTypes.func.isRequired,
 };
@@ -15,10 +16,21 @@ const propTypes = {
 const defaultProps = {
   index: 0,
   gridWidth: null,
+  gridFooter: null,
 };
 
 const VirtualizeRows = React.forwardRef((props, ref) => {
-  const { data, index: $index, gridLength, gridRowHeight, gridHeight, gridWidth, children, ...moreProps } = props;
+  const {
+    children,
+    data,
+    gridFooter,
+    gridHeight,
+    gridLength,
+    gridRowHeight,
+    gridWidth,
+    index: $index,
+    ...moreProps
+  } = props;
   const [state, setState] = React.useState({ index: $index, top: 0 });
   const refElementToScroll = React.useRef(null);
 
@@ -85,20 +97,23 @@ const VirtualizeRows = React.forwardRef((props, ref) => {
 
   // need more a11y love https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Row_Role
   return (
-    <styled.Virtualize
-      width={gridWidth}
-      height={gridHeight}
-      data-pka-anchor="virtualize-rows-root"
-      ref={refElementToScroll}
-      {...moreProps}
-      tabIndex="0"
-    >
-      <styled.VirtualizeContent role="grid" height={memoHeight}>
-        <styled.VirtualizeRows role="rowgroup" top={state.top}>
-          {children(subsetToRender, keys, { row: { role: "row" }, cell: { role: "cell" } })}
-        </styled.VirtualizeRows>
-      </styled.VirtualizeContent>
-    </styled.Virtualize>
+    <>
+      <styled.Virtualize
+        width={gridWidth}
+        height={gridHeight}
+        data-pka-anchor="virtualize-rows-root"
+        ref={refElementToScroll}
+        {...moreProps}
+        tabIndex="0"
+      >
+        <styled.VirtualizeContent role="grid" height={memoHeight}>
+          <styled.VirtualizeRows role="rowgroup" top={state.top}>
+            {children(subsetToRender, keys, { row: { role: "row" }, cell: { role: "cell" } })}
+            {gridLength && gridFooter ? <styled.VirtualizeFooter>{gridFooter}</styled.VirtualizeFooter> : null}
+          </styled.VirtualizeRows>
+        </styled.VirtualizeContent>
+      </styled.Virtualize>
+    </>
   );
 });
 

--- a/packages/DataTable/src/VirtualizeRows.styles.js
+++ b/packages/DataTable/src/VirtualizeRows.styles.js
@@ -29,3 +29,11 @@ export const VirtualizeRows = styled.div.attrs(({ top }) => ({
 }))`
   position: relative;
 `;
+
+export const VirtualizeFooter = styled.div`
+  align-items: center;
+  display: flex;
+  justify-items: center;
+  padding: 8px;
+  width: 100%;
+`;

--- a/packages/DataTable/src/components/Cell/Cell.js
+++ b/packages/DataTable/src/components/Cell/Cell.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import * as styled from "./Cell.styles";
+import getRow, { getCoordinatesByCellIndex } from "../../helpers/getRow";
 
 const propTypes = {
   a11yProps: PropTypes.shape({}).isRequired,
@@ -10,15 +11,28 @@ const propTypes = {
   height: PropTypes.number.isRequired,
   setActiveCell: PropTypes.func.isRequired,
   width: PropTypes.string,
+  onClickCell: PropTypes.func,
+  refActivePage: PropTypes.shape({ current: PropTypes.shape({}) }).isRequired,
 };
 
 const defaultProps = {
   width: null,
   activeCellIndex: null,
+  onClickCell: () => {},
 };
 
 export default function Cell(props) {
-  const { a11yProps, activeCellIndex, cellIndex, children, height, setActiveCell, width } = props;
+  const {
+    a11yProps,
+    activeCellIndex,
+    cellIndex,
+    refActivePage,
+    children,
+    height,
+    setActiveCell,
+    width,
+    onClickCell,
+  } = props;
 
   function handleClickCell() {
     if (activeCellIndex !== cellIndex) {
@@ -26,6 +40,11 @@ export default function Cell(props) {
         index: cellIndex,
       });
     }
+
+    const coordinate = getCoordinatesByCellIndex(cellIndex);
+    const row = getRow({ row: coordinate.row, refActivePage });
+    // coordinate includes row number and cell number
+    onClickCell(coordinate, row);
   }
 
   return (

--- a/packages/DataTable/src/components/LoadMoreButton/LoadMoreButton.js
+++ b/packages/DataTable/src/components/LoadMoreButton/LoadMoreButton.js
@@ -1,0 +1,14 @@
+import React from "react";
+import PropTypes from "prop-types";
+import Button from "@paprika/button";
+
+const propTypes = {
+  onClick: PropTypes.func.isRequired,
+};
+
+export default function LoadMoreButton(props) {
+  return <Button {...props}>[L10n] Load More...</Button>;
+}
+
+LoadMoreButton.propTypes = propTypes;
+LoadMoreButton.displayName = "DataTable.LoadMoreButton";

--- a/packages/DataTable/src/components/LoadMoreButton/index.js
+++ b/packages/DataTable/src/components/LoadMoreButton/index.js
@@ -1,0 +1,1 @@
+export { default } from "./LoadMoreButton";

--- a/packages/DataTable/src/components/VirtualizedTable/VirtualizedTable.js
+++ b/packages/DataTable/src/components/VirtualizedTable/VirtualizedTable.js
@@ -12,12 +12,36 @@ import Cell from "../Cell";
 import { Cell as CellStyled } from "../Cell/Cell.styles";
 import { useDataTableState } from "../../context";
 
+const propTypes = {
+  columns: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+    })
+  ).isRequired,
+  height: PropTypes.number.isRequired,
+  LoadMoreButton: PropTypes.node,
+  onClickCell: PropTypes.func,
+  onKeyDownArrow: PropTypes.func,
+  onExpandedRow: PropTypes.func,
+  rowHeight: PropTypes.number.isRequired,
+  width: PropTypes.number,
+};
+
+const defaultProps = {
+  LoadMoreButton: null,
+  onClickCell: () => {},
+  onKeyDownArrow: () => {},
+  onExpandedRow: () => {},
+  width: null,
+};
+
 export default function VirtualizedTable(props) {
-  const { columns, height, rowHeight, width } = props;
+  const { columns, height, rowHeight, width, onExpandedRow, onKeyDownArrow, onClickCell, LoadMoreButton } = props;
   const [activeRowOnMouseEnter, setActiveRowOnMouseEnter] = React.useState({ index: null, data: null });
   const [activeCell, setActiveCell] = React.useState({ rowIndex: null, dataRow: null, index: null, data: null });
-  const refActivePage = React.useRef({ from: null, to: null });
+  const refActivePage = React.useRef({ from: null, to: null, subset: null });
   const refVirtualizeRows = React.useRef(null);
+
   const delayedKeyDown = React.useRef(
     debounce(
       ({
@@ -25,6 +49,7 @@ export default function VirtualizedTable(props) {
         columnsLength,
         delayedKeyDown,
         event,
+        onKeyDownArrow,
         refActivePage,
         refVirtualizeRows,
         rowHeight,
@@ -36,6 +61,7 @@ export default function VirtualizedTable(props) {
           columnsLength,
           delayedKeyDown,
           event,
+          onKeyDownArrow,
           refActivePage,
           refVirtualizeRows,
           rowHeight,
@@ -67,6 +93,7 @@ export default function VirtualizedTable(props) {
   function handleKeyDown(event) {
     if (arrowKeys.includes(event.key)) {
       event.preventDefault();
+      event.persist();
       delayedKeyDown({
         activeCell,
         columnsLength,
@@ -76,10 +103,14 @@ export default function VirtualizedTable(props) {
         rowHeight: rowHeightValue,
         rowsLength,
         setActiveCell,
+        onKeyDownArrow,
       });
-      event.persist();
     }
   }
+
+  const handleRowExpand = row => () => {
+    onExpandedRow(row);
+  };
 
   /* eslint-disable jsx-a11y/no-static-element-interactions */
   /* eslint-disable jsx-a11y/no-noninteractive-tabindex  */
@@ -99,7 +130,13 @@ export default function VirtualizedTable(props) {
         {columns.map((column, columnIndex) => {
           const { header: headerProp, width } = column;
           return (
-            <CellStyled isHeaderStyledCell key={`cell_${columnIndex}`} $width={width} $height={rowHeightValue}>
+            <CellStyled
+              role="columnheader"
+              isHeaderStyledCell
+              key={`cell_${columnIndex}`}
+              $width={width}
+              $height={rowHeightValue}
+            >
               {typeof headerProp === "function" ? headerProp(column) : headerProp}
               <Options {...column} />
             </CellStyled>
@@ -112,12 +149,14 @@ export default function VirtualizedTable(props) {
         gridLength={data.length}
         gridHeight={height}
         gridWidth={width}
+        gridFooter={LoadMoreButton}
         ref={refVirtualizeRows}
       >
         {(subset, keys, a11y) => {
           // this information will help to calculated next and previous ArrowUp and ArrowDown
           refActivePage.current.from = keys[0];
           refActivePage.current.to = keys[keys.length - 1];
+          refActivePage.current.subset = subset;
 
           return (
             <>
@@ -136,7 +175,7 @@ export default function VirtualizedTable(props) {
                         <CheckBox indexRowOnMouseEnter={activeRowOnMouseEnter.index} index={keys[rowIndex]} />
                       </styled.Check>
                       <styled.Expand>
-                        <RawButton>⇗</RawButton>
+                        <RawButton onClick={handleRowExpand(row)}>⇗</RawButton>
                       </styled.Expand>
                     </styled.Counter>
                     {columns.map((column, cellIndex) => {
@@ -153,6 +192,8 @@ export default function VirtualizedTable(props) {
                           activeCellIndex={activeCell.index}
                           setActiveCell={setActiveCell}
                           cell={cell}
+                          onClickCell={onClickCell}
+                          refActivePage={refActivePage}
                         >
                           {typeof cell === "function" ? cell(row) : row[cell]}
                         </Cell>
@@ -170,17 +211,5 @@ export default function VirtualizedTable(props) {
 }
 /* eslint-enable react/no-array-index-key */
 
-VirtualizedTable.propTypes = {
-  columns: PropTypes.arrayOf(
-    PropTypes.shape({
-      id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
-    })
-  ).isRequired,
-  height: PropTypes.number.isRequired,
-  width: PropTypes.number,
-  rowHeight: PropTypes.number.isRequired,
-};
-
-VirtualizedTable.defaultProps = {
-  width: null,
-};
+VirtualizedTable.propTypes = propTypes;
+VirtualizedTable.defaultProps = defaultProps;

--- a/packages/DataTable/src/helpers/getRow.js
+++ b/packages/DataTable/src/helpers/getRow.js
@@ -1,0 +1,10 @@
+export default function getRow({ row, refActivePage }) {
+  return refActivePage.current.subset[row - refActivePage.current.from];
+}
+
+export function getCoordinatesByCellIndex(cellIndex) {
+  const coordinate = cellIndex.split("_");
+  const row = coordinate[0];
+  const cell = coordinate[1];
+  return { row, cell };
+}

--- a/packages/DataTable/src/helpers/handleArrowKeys.js
+++ b/packages/DataTable/src/helpers/handleArrowKeys.js
@@ -1,12 +1,23 @@
 import closest from "@paprika/helpers/lib/dom/closest";
+import getRow from "./getRow";
 
 export const arrowKeys = ["ArrowDown", "ArrowUp", "ArrowRight", "ArrowLeft"];
 const isOutOfBoundaries = (nextRow, boundaries) => nextRow < boundaries.top || nextRow > boundaries.bottom;
+
+function handleArrowKeyDown({ event, onKeyDownArrow, row, refActivePage }) {
+  // wait until the next repaint and let the scroll happens with the new virtualizes subset then
+  // get the value of the next loaded row.
+  window.requestAnimationFrame(() => {
+    const rowData = getRow({ row, refActivePage });
+    onKeyDownArrow(event, rowData);
+  });
+}
 
 export default function handleArrowKeys({
   activeCell,
   columnsLength,
   event,
+  onKeyDownArrow,
   refActivePage,
   refVirtualizeRows,
   rowHeight,
@@ -45,13 +56,13 @@ export default function handleArrowKeys({
           // if we are approaching to the top start scrolling
           if (nextRow <= top - 1) {
             const $scrollableElement = refVirtualizeRows.current.getScrollableElement();
-            // from + 3 indicate will show 4 new row once start navigating out of the area
             const _top = top - 1 === 0 ? 0 : top - 1;
 
             $scrollableElement.scrollTo({ top: rowHeight * _top });
           }
 
           setActiveCell(activeCell => ({ ...activeCell, index: nextIndex }));
+          handleArrowKeyDown({ event, onKeyDownArrow, row: nextRow, refActivePage });
         },
         ArrowDown: () => {
           const { top, end } = boundaries;
@@ -86,6 +97,7 @@ export default function handleArrowKeys({
           }
 
           setActiveCell(activeCell => ({ ...activeCell, index: nextIndex }));
+          handleArrowKeyDown({ event, onKeyDownArrow, row: nextRow, refActivePage });
         },
         ArrowRight: () => {
           if (cell + 1 < boundaries.right) {
@@ -97,6 +109,7 @@ export default function handleArrowKeys({
           }
 
           setActiveCell(activeCell => ({ ...activeCell, index: nextIndex }));
+          handleArrowKeyDown({ event, onKeyDownArrow, row, refActivePage });
         },
         ArrowLeft: () => {
           if (cell - 1 >= boundaries.left) {
@@ -108,6 +121,7 @@ export default function handleArrowKeys({
           }
 
           setActiveCell(activeCell => ({ ...activeCell, index: nextIndex }));
+          handleArrowKeyDown({ event, onKeyDownArrow, row, refActivePage });
         },
       };
 

--- a/packages/DataTable/stories/examples/Marvel/App.js
+++ b/packages/DataTable/stories/examples/Marvel/App.js
@@ -1,12 +1,16 @@
 import React from "react";
+import SidePanel from "@paprika/sidepanel";
 import DataTable from "../../../src";
 import { fetchMarvelAPI } from "./helpers";
 
 export default function App() {
-  const [offsetLetter] = React.useState(0);
-  const [offset] = React.useState(0);
-  const [, setLetters] = React.useState({});
+  const [offsetLetter, setOffsetLetter] = React.useState(0);
+  const [offset, setOffset] = React.useState(0);
+  const [letters, setLetters] = React.useState({});
   const [data, setData] = React.useState([]);
+  const [row, setRow] = React.useState(null);
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [isLoading, setIsLoading] = React.useState(false);
 
   React.useEffect(() => {
     async function getData() {
@@ -14,13 +18,17 @@ export default function App() {
       const letter = String.fromCharCode(97 + offsetLetter);
       const data = await fetchMarvelAPI(letter, offset);
       setLetters(letters => {
-        return { ...letters, [letter]: { total: data.total } };
+        const { count, limit, offset, total } = data.data;
+        return { ...letters, [letter]: { count, limit, offset, total } };
       });
 
       setData(state => {
         return state.concat(data.data.results);
       });
+      setIsLoading(() => false);
     }
+
+    setIsLoading(() => true);
     getData();
   }, [offset, offsetLetter]);
 
@@ -28,13 +36,62 @@ export default function App() {
     return cell.series.items.map(item => <span>{item.name}</span>);
   }
 
-  function renderThumbnail(cell) {
-    return `${cell.thumbnail.path}.${cell.thumbnail.extension}`;
+  function renderThumbnail(row) {
+    return `${row.thumbnail.path}.${row.thumbnail.extension}`;
+  }
+
+  function handleExpandedRow(row) {
+    setRow(row);
+    setIsOpen(() => true);
+  }
+
+  function handleSidePanelClose() {
+    setIsOpen(() => false);
+  }
+
+  function handleLoadMore() {
+    const currentLetter = String.fromCharCode(97 + offsetLetter);
+    const { offset: currentOffset, total, count } = letters[currentLetter];
+    if (currentOffset + count <= total) {
+      setOffset(off => off + 1);
+      return;
+    }
+    setOffset(() => 0);
+    setOffsetLetter(off => off + 1);
+  }
+
+  function handleKeyDownArrow(event, row) {
+    setRow(() => row);
+  }
+
+  function handleClickCell(cell, row) {
+    setRow(() => row);
   }
 
   return (
     <>
-      <DataTable data={data} keygen="id">
+      {row && (
+        <SidePanel onClose={handleSidePanelClose} isOpen={isOpen}>
+          <SidePanel.Header>{row.name}</SidePanel.Header>
+          <div
+            css={`
+              width: 300px;
+              overflow: hidden;
+            `}
+          >
+            <img src={`${row.thumbnail.path}.${row.thumbnail.extension}`} width="100%" alt={row.name} />
+          </div>
+          <div>{row.description}</div>
+        </SidePanel>
+      )}
+      <DataTable
+        data={data}
+        onKeyDownArrow={handleKeyDownArrow}
+        isLoading={isLoading}
+        keygen="id"
+        onExpandedRow={handleExpandedRow}
+        onClickCell={handleClickCell}
+      >
         <DataTable.ColumnDefinition id="0" header="Key" cell="id" />
         <DataTable.ColumnDefinition id="1" header="Name" cell="name" />
         <DataTable.ColumnDefinition id="2" header="Description" cell="description" />
@@ -42,6 +99,7 @@ export default function App() {
         <DataTable.ColumnDefinition id="4" header="URI" cell="resourceURI" />
         <DataTable.ColumnDefinition id="5" header="Series" cell={renderSeries} />
         <DataTable.ColumnDefinition id="6" header="thumbnail" cell={renderThumbnail} />
+        <DataTable.LoadMoreButton kind="primary" isDisabled={isLoading} onClick={handleLoadMore} />
       </DataTable>
       <a href="http://marvel.com">Data provided by Marvel. © 2019 MARVEL</a>
     </>

--- a/packages/DataTable/stories/examples/Marvel/helpers.js
+++ b/packages/DataTable/stories/examples/Marvel/helpers.js
@@ -1,4 +1,4 @@
-export async function fetchMarvelAPI(term, offset = null, limit = 100) {
+export async function fetchMarvelAPI(term, offset = null, limit = 20) {
   const url = "https://gateway.marvel.com:443/v1/public/characters?nameStartsWith=";
   const offsetParameter = offset ? `&offset=${offset * limit}` : "";
   // low risk to share api key for now, I can invalidate it later and extracted it to an env variable


### PR DESCRIPTION
…dRow

### Purpose 🚀
Add support for load more button

`<DataTable.LoadMoreButton />` works as a regular button so you can pass `kind` `isDisabled` etc and works correctly.

add new events:
- onCellClick
- onExpandedRow
- onKeyDownArrow

```js
<DataTable 
  onCellClick 
  onExpandedRow
  onKeyDownArrow
/>
```

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_ 
- [ ] PATCH (big fix) change to _these packages_

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
