### PR TITLE
Add a testing story for the Popover in the Takeover

### DIFF
--- a/packages/Popover/stories/Popover.stories.js
+++ b/packages/Popover/stories/Popover.stories.js
@@ -8,6 +8,7 @@ import PositioningElement from "./examples/PositioningElement";
 import ScrollContainer from "./examples/ScrollContainer";
 import Transformed from "./examples/Transformed";
 import FocusTest from "./examples/FocusTest";
+import FocusTakeoverTest from "./examples/FocusTakeoverTest";
 import A11y from "./examples/A11y";
 import Cypress, { propHandles } from "./examples/Cypress";
 import Screener from "./examples/Screener";
@@ -24,7 +25,8 @@ storiesOf("Popover", module)
 
 storiesOf("Popover/Dev", module)
   .add("Has container with a CSS transform", () => <Transformed />)
-  .add("Testing Focus Management", () => <FocusTest />);
+  .add("Testing Focus Management", () => <FocusTest />)
+  .add("Testing Focus Management in Takeover", () => <FocusTakeoverTest />);
 
 storiesOf("Popover/Automation Tests", module)
   .add("Accessibility", () => <A11y />)

--- a/packages/Popover/stories/examples/FocusTakeoverTest.js
+++ b/packages/Popover/stories/examples/FocusTakeoverTest.js
@@ -5,101 +5,70 @@ import InfoIcon from "@paprika/icon/lib/InfoCircle";
 import Popover from "../../src";
 
 export default function ExampleStory() {
-  const [isOpen, setIsOpen] = React.useState(true);
+  const viewInIframeLink = (
+    <a href="/iframe.html?id=popover-dev--testing-focus-management-in-takeover&viewMode=story" target="_blank">
+      View in iframe
+    </a>
+  );
 
-  function handleOpen() {
-    setIsOpen(true);
-  }
-
-  function handleClose() {
-    setIsOpen(false);
-  }
+  const popoverContent = (
+    <p>
+      Try <a href="http://www.google.ca">clicking this</a> with the mouse or keyboard... you cannot -- the Takeover
+      prevents both. That is not good.
+    </p>
+  );
 
   return (
     <Story>
-      <a href="/iframe.html?id=popover-dev--testing-focus-management-in-takeover&viewMode=story" target="_blank">
-        View in iframe
-      </a>
-      <p>
-        Praesent at ante in eros rutrum aliquet. Maecenas sagittis iaculis erat, vitae vulputate sem tempus tincidunt.
-        In ullamcorper rhoncus nulla, non finibus augue fermentum id. Nam sit amet urna sapien. Donec ullamcorper,
-        libero vel viverra porttitor, dui ipsum viverra urna, eu maximus dui neque quis risus. Class aptent taciti
-        sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Nullam at sagittis urna, at fringilla
-        orci.
-      </p>
-      <button type="button" onClick={handleOpen}>
-        Open takeover
-      </button>
-      <p>
-        Suspendisse blandit diam eu porta porttitor. Nulla ullamcorper lectus quam, et pulvinar nibh porta sit amet.
-        Duis quis tortor dui. Fusce faucibus ultrices odio, vitae pulvinar magna tempus sit amet. Mauris lacinia gravida
-        ante eget ornare. Nulla ut nibh diam. Aenean vulputate nunc tincidunt dictum consequat. Morbi imperdiet, ipsum
-        at fermentum placerat, nunc diam interdum massa, et euismod nisl sem sit amet dolor. Nulla finibus lorem vel
-        vestibulum rhoncus.
-      </p>
-
-      <Takeover isOpen={isOpen} onClose={handleClose}>
-        <Takeover.Header hasCloseButton>Takeover heading</Takeover.Header>
+      <Takeover isOpen>
+        <Takeover.Header>Takeover heading</Takeover.Header>
         <Takeover.Content>
+          {viewInIframeLink}
           <p>
-            Below is the popover trigger; click on it to open the popover. The other focusable elements on the page are
-            to test where focus goes when using the keyboard.
+            This example demonstrates how the Popover handles focus when created inside of a Takeover. Click the icons
+            below to see how the popovers behave.
           </p>
+          <p>The Popover gets added at the end of the DOM when created, and the Takeover traps focus.</p>
           <p>
-            Popover with no focusable elements:&nbsp;
-            <Popover>
-              <Popover.Trigger>
-                <InfoIcon />
-              </Popover.Trigger>
-              <Popover.Content>
-                <Popover.Card>Peek-a-boo!</Popover.Card>
-              </Popover.Content>
-              <Popover.Tip />
-            </Popover>
+            A work-around is to add either `isEager` or `shouldKeepFocus` to the Popover. This will keep it open (but as
+            a side effect, screenreaders will not read its content, and you cannot tab into its content to click on any
+            links).
           </p>
+          <hr />
+          <h3>Popover with `shouldKeepFocus` or `isEager`:</h3>
+          <Popover shouldKeepFocus>
+            <Popover.Trigger>
+              <InfoIcon />
+            </Popover.Trigger>
+            <Popover.Content>
+              <Popover.Card>{popoverContent}</Popover.Card>
+            </Popover.Content>
+            <Popover.Tip />
+          </Popover>
           <p>
-            Donec et ante tristique elit sodales euismod nec id <a href="http://www.google.ca">sollicitudin</a>. Morbi
-            vehicula ex nec vestibulum consectetur. Suspendisse malesuada, purus nec finibus imperdiet, turpis nisi
-            varius urna, in venenatis justo lorem quis neque. Morbi magna magna, porttitor non orci quis, ornare
-            vestibulum lacus. Vivamus mollis risus nulla, vitae facilisis erat varius vel.
+            The Popover opens, but the Takeover prevents you from interacting with its contents with the mouse or
+            keyboard.
           </p>
+          <hr />
+          <h3>Popover with no props:&nbsp;</h3>
+          <Popover>
+            <Popover.Trigger>
+              <InfoIcon />
+            </Popover.Trigger>
+            <Popover.Content>
+              <Popover.Card>{popoverContent}</Popover.Card>
+            </Popover.Content>
+            <Popover.Tip />
+          </Popover>
           <p>
-            Popover with focusable elements:&nbsp;
-            <Popover>
-              <Popover.Trigger>
-                <InfoIcon />
-              </Popover.Trigger>
-              <Popover.Content>
-                <Popover.Card>
-                  <p>
-                    Pellentesque ullamcorper sem eget tincidunt consequat. <a href="http://www.google.ca">Phasellus</a>{" "}
-                    nec tincidunt lacus. Mauris gravida <a href="http://www.google.ca">porttitor urna</a>, ornare
-                    laoreet nulla vehicula vitae. Aenean nunc eros, vulputate at nulla ut, imperdiet rhoncus enim.
-                  </p>
-                </Popover.Card>
-              </Popover.Content>
-              <Popover.Tip />
-            </Popover>
+            When you open the Popover, focus goes to its content -- but the Takeover notices that it lost focus, and
+            takes it right back again by moving the focus back to the last element that had it. Now since the Popover
+            lost focus, it closes. So the net effect: when you open a Popover in a Takeover, it closes right away.
           </p>
-
-          <button type="button">Hello</button>
-          <p>
-            In hendrerit purus sapien, at pharetra ipsum convallis quis. Morbi venenatis mauris sapien, id faucibus
-            ipsum gravida sit amet. Vivamus faucibus est odio. Nulla volutpat quis neque a venenatis. Maecenas gravida
-            mauris at arcu <a href="http://www.google.ca">vehicula</a>, eget placerat dui finibus. Sed sed elementum
-            libero, nec rutrum felis. Integer ut vulputate tortor. Praesent maximus erat quis tellus efficitur pretium.
-          </p>
+          <hr />
+          {viewInIframeLink}
         </Takeover.Content>
       </Takeover>
     </Story>
   );
 }
-
-/*
-
-
-
-        <p>
-
-        </p>
-*/

--- a/packages/Popover/stories/examples/FocusTakeoverTest.js
+++ b/packages/Popover/stories/examples/FocusTakeoverTest.js
@@ -30,9 +30,9 @@ export default function ExampleStory() {
           </p>
           <p>The Popover gets added at the end of the DOM when created, and the Takeover traps focus.</p>
           <p>
-            A work-around is to add either `isEager` or `shouldKeepFocus` to the Popover. This will keep it open (but as
-            a side effect, screenreaders will not read its content, and you cannot tab into its content to click on any
-            links).
+            A work-around is to add either `isEager` or `shouldKeepFocus` to the Popover. This will keep it open, but:
+            screenreaders will not read its content, and you cannot interact with its content with the mouse or
+            keyboard.
           </p>
           <hr />
           <h3>Popover with `shouldKeepFocus` or `isEager`:</h3>

--- a/packages/Popover/stories/examples/FocusTakeoverTest.js
+++ b/packages/Popover/stories/examples/FocusTakeoverTest.js
@@ -1,0 +1,105 @@
+import React from "react";
+import { Story } from "storybook/assets/styles/common.styles";
+import Takeover from "@paprika/takeover";
+import InfoIcon from "@paprika/icon/lib/InfoCircle";
+import Popover from "../../src";
+
+export default function ExampleStory() {
+  const [isOpen, setIsOpen] = React.useState(true);
+
+  function handleOpen() {
+    setIsOpen(true);
+  }
+
+  function handleClose() {
+    setIsOpen(false);
+  }
+
+  return (
+    <Story>
+      <a href="/iframe.html?id=popover-dev--testing-focus-management-in-takeover&viewMode=story" target="_blank">
+        View in iframe
+      </a>
+      <p>
+        Praesent at ante in eros rutrum aliquet. Maecenas sagittis iaculis erat, vitae vulputate sem tempus tincidunt.
+        In ullamcorper rhoncus nulla, non finibus augue fermentum id. Nam sit amet urna sapien. Donec ullamcorper,
+        libero vel viverra porttitor, dui ipsum viverra urna, eu maximus dui neque quis risus. Class aptent taciti
+        sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Nullam at sagittis urna, at fringilla
+        orci.
+      </p>
+      <button type="button" onClick={handleOpen}>
+        Open takeover
+      </button>
+      <p>
+        Suspendisse blandit diam eu porta porttitor. Nulla ullamcorper lectus quam, et pulvinar nibh porta sit amet.
+        Duis quis tortor dui. Fusce faucibus ultrices odio, vitae pulvinar magna tempus sit amet. Mauris lacinia gravida
+        ante eget ornare. Nulla ut nibh diam. Aenean vulputate nunc tincidunt dictum consequat. Morbi imperdiet, ipsum
+        at fermentum placerat, nunc diam interdum massa, et euismod nisl sem sit amet dolor. Nulla finibus lorem vel
+        vestibulum rhoncus.
+      </p>
+
+      <Takeover isOpen={isOpen} onClose={handleClose}>
+        <Takeover.Header hasCloseButton>Takeover heading</Takeover.Header>
+        <Takeover.Content>
+          <p>
+            Below is the popover trigger; click on it to open the popover. The other focusable elements on the page are
+            to test where focus goes when using the keyboard.
+          </p>
+          <p>
+            Popover with no focusable elements:&nbsp;
+            <Popover>
+              <Popover.Trigger>
+                <InfoIcon />
+              </Popover.Trigger>
+              <Popover.Content>
+                <Popover.Card>Peek-a-boo!</Popover.Card>
+              </Popover.Content>
+              <Popover.Tip />
+            </Popover>
+          </p>
+          <p>
+            Donec et ante tristique elit sodales euismod nec id <a href="http://www.google.ca">sollicitudin</a>. Morbi
+            vehicula ex nec vestibulum consectetur. Suspendisse malesuada, purus nec finibus imperdiet, turpis nisi
+            varius urna, in venenatis justo lorem quis neque. Morbi magna magna, porttitor non orci quis, ornare
+            vestibulum lacus. Vivamus mollis risus nulla, vitae facilisis erat varius vel.
+          </p>
+          <p>
+            Popover with focusable elements:&nbsp;
+            <Popover>
+              <Popover.Trigger>
+                <InfoIcon />
+              </Popover.Trigger>
+              <Popover.Content>
+                <Popover.Card>
+                  <p>
+                    Pellentesque ullamcorper sem eget tincidunt consequat. <a href="http://www.google.ca">Phasellus</a>{" "}
+                    nec tincidunt lacus. Mauris gravida <a href="http://www.google.ca">porttitor urna</a>, ornare
+                    laoreet nulla vehicula vitae. Aenean nunc eros, vulputate at nulla ut, imperdiet rhoncus enim.
+                  </p>
+                </Popover.Card>
+              </Popover.Content>
+              <Popover.Tip />
+            </Popover>
+          </p>
+
+          <button type="button">Hello</button>
+          <p>
+            In hendrerit purus sapien, at pharetra ipsum convallis quis. Morbi venenatis mauris sapien, id faucibus
+            ipsum gravida sit amet. Vivamus faucibus est odio. Nulla volutpat quis neque a venenatis. Maecenas gravida
+            mauris at arcu <a href="http://www.google.ca">vehicula</a>, eget placerat dui finibus. Sed sed elementum
+            libero, nec rutrum felis. Integer ut vulputate tortor. Praesent maximus erat quis tellus efficitur pretium.
+          </p>
+        </Takeover.Content>
+      </Takeover>
+    </Story>
+  );
+}
+
+/*
+
+
+
+        <p>
+
+        </p>
+*/


### PR DESCRIPTION
### Purpose 🚀
This PR isn't a solution, it demonstrates a problem and I am looking for suggestions how to remedy this.

Since the Popover gets added at the end of the DOM, and the Takeover hijacks behaviour outside of its scope, a Popover within a Takeover doesn't work very well.

### Notes ✏️

1. The Takeover uses `focus-trap-react`, which uses `focus-trap`.
2. The Popover gets added at the end of the DOM -- outside of the Takeover's HTML element.

When you open a popover, focus goes to its content: https://github.com/acl-services/paprika/blob/master/packages/Popover/src/Popover.js#L357

Except that the Takeover says `I dont think so!` and takes back the focus:  https://github.com/davidtheclark/focus-trap/blob/master/index.js#L253
This causes the takeover to open quickly, then close, and focus moves to a weird spot.

### Interacting with a Popover with the `isEager` or `shouldKeepFocus` prop:

The Popover opens, but the Takeover prevents you from interacting with its contents with the mouse or keyboard.
![Nov-27-2019 15-30-45](https://user-images.githubusercontent.com/23224777/69766015-1e6dce00-112b-11ea-8498-d649562c65f0.gif)

### Interacting with a Popover with no props:

The Popover opens then closes right away.
![Nov-27-2019 15-31-28](https://user-images.githubusercontent.com/23224777/69766014-1ca40a80-112b-11ea-9439-240ef9c0fd89.gif)
