### PR TITLE
Ux 316 popover content on after open callbacks - wip

### DIFF
--- a/packages/Popover/package.json
+++ b/packages/Popover/package.json
@@ -22,6 +22,7 @@
     "lodash.throttle": "^4.1.1",
     "memoize-one": "^5.0.0",
     "prop-types": "^15.7.2",
+    "react-transition-group": "^4.3.0",
     "uuid": "^3.3.2"
   },
   "peerDependencies": {

--- a/packages/Popover/src/components/Content/Content.js
+++ b/packages/Popover/src/components/Content/Content.js
@@ -1,7 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
-import { Transition } from "react-transition-group";
+// import { Transition } from "react-transition-group";
 import isElementContainsFocus from "../../helpers/isElementContainsFocus";
 import PopoverContext from "../../PopoverContext";
 import { consts as PopoverConstants } from "../../Popover.styles";
@@ -105,7 +105,7 @@ const Content = React.forwardRef((props, ref) => {
       zIndex={content.zIndex}
       {...moreProps}
     >
-      <Transition
+      {/* <Transition
         mountOnEnter
         unmountOnExit
         in={isOpen}
@@ -116,9 +116,9 @@ const Content = React.forwardRef((props, ref) => {
         onExited={() => {
           console.log("on after clsoe");
         }}
-      >
-        {props.children}
-      </Transition>
+      > */}
+      {props.children}
+      {/* </Transition> */}
     </ContentStyled>,
     portalElement
   );

--- a/packages/Popover/src/components/Content/Content.js
+++ b/packages/Popover/src/components/Content/Content.js
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
+import { Transition } from "react-transition-group";
 import isElementContainsFocus from "../../helpers/isElementContainsFocus";
 import PopoverContext from "../../PopoverContext";
 import { consts as PopoverConstants } from "../../Popover.styles";
@@ -104,7 +105,20 @@ const Content = React.forwardRef((props, ref) => {
       zIndex={content.zIndex}
       {...moreProps}
     >
-      {props.children}
+      <Transition
+        mountOnEnter
+        unmountOnExit
+        in={isOpen}
+        timeout={0}
+        onEntered={() => {
+          console.log("on after open");
+        }}
+        onExited={() => {
+          console.log("on after clsoe");
+        }}
+      >
+        {props.children}
+      </Transition>
     </ContentStyled>,
     portalElement
   );


### PR DESCRIPTION
### Purpose 🚀
WIP

Adding of onAfterClose and onAfterOpen callbacks in order to detect when popover content has been mounted. This can be used to focus internal child elements.

Currently the popover child position is not showing correctly when using the transition library.

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_
- [ ] PATCH (bug fix) change to _these packages_

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
