### PR TITLE
Star-43 Support default widgets status

### DIFF
--- a/packages/DataTable/src/DataTable.js
+++ b/packages/DataTable/src/DataTable.js
@@ -64,8 +64,8 @@ export default function DataTable(props) {
   ]);
 
   const columns = ColumnsDefinition.map(({ props }) => {
-    const { id, momentParsingFormat, canFilter, canSort, type, canHide, isHidden, width } = props;
-    return { id, momentParsingFormat, canFilter, canSort, type, canHide, isHidden, width };
+    const { id, momentParsingFormat, canFilter, canSort, type, canHide, isHidden, width, defaultIsHidden } = props;
+    return { id, momentParsingFormat, canFilter, canSort, type, canHide, isHidden, width, defaultIsHidden };
   });
   const availablePlugins = Object.keys(plugins).map(key => plugins[key]);
 

--- a/packages/DataTable/src/components/ColumnDefinition/ColumnDefinition.js
+++ b/packages/DataTable/src/components/ColumnDefinition/ColumnDefinition.js
@@ -13,15 +13,17 @@ ColumnDefinition.propTypes = {
   type: PropTypes.oneOf([columnTypes.TEXT, columnTypes.NUMBER, columnTypes.DATE]),
   canHide: PropTypes.bool,
   isHidden: PropTypes.bool,
+  defaultIsHidden: PropTypes.bool,
 };
 
 ColumnDefinition.defaultProps = {
   momentParsingFormat: null,
   canFilter: true,
   canSort: true,
-  type: null,
+  type: columnTypes.TEXT,
   canHide: true,
   isHidden: false,
+  defaultIsHidden: false,
 };
 
 ColumnDefinition.displayName = "DataTable.ColumnDefinition";

--- a/packages/DataTable/src/components/Navigation/components/ColumnManaging/ColumnManaging.js
+++ b/packages/DataTable/src/components/Navigation/components/ColumnManaging/ColumnManaging.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import Popover from "@paprika/popover";
 import Sortable from "@paprika/sortable";
 import { useDataTableState, useDispatch } from "../../../..";
@@ -6,10 +7,27 @@ import ColumnManagingItem from "./ColumnManagingItem";
 import { useLocalStorage } from "../../../../context";
 import { plugins } from "../../../../constants";
 
-export default function ColumnManaging() {
+const propTypes = {
+  defaultColumnsOrder: PropTypes.arrayOf(PropTypes.string),
+};
+
+const defaultProps = {
+  defaultColumnsOrder: null,
+};
+
+export default function ColumnManaging(props) {
+  const { defaultColumnsOrder } = props;
   const { columnsOrder } = useDataTableState();
   const dispatch = useDispatch();
   const updateLocalStorage = useLocalStorage();
+
+  React.useEffect(() => {
+    if (defaultColumnsOrder) {
+      dispatch({ type: "REORDER__COLUMNS", payload: defaultColumnsOrder });
+    }
+    // Only runs for first time
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleChangeOrder = result => {
     const { source, destination } = result;
@@ -68,4 +86,6 @@ ColumnManaging.reducer = (state, action) => {
   return action.changes;
 };
 
+ColumnManaging.propTypes = propTypes;
+ColumnManaging.defaultProps = defaultProps;
 ColumnManaging.displayName = plugins.COLUMN_MANAGING;

--- a/packages/DataTable/src/components/Navigation/components/Filters/FilterItem.js
+++ b/packages/DataTable/src/components/Navigation/components/Filters/FilterItem.js
@@ -6,13 +6,12 @@ import { useDataTableState, useDispatch } from "../../../..";
 import rules, { rulesByType } from "./rules";
 import { columnTypes } from "../../../../constants";
 import { FilterItemStyled } from "./Filters.styles";
-import getColumnType from "../../../../helpers/getColumnType";
 
 export default function FilterItem(prop) {
   const { columnId: selectedColumnId, rule: selectedRule, id, value } = prop;
-  const { columns, columnsOrder, data } = useDataTableState();
+  const { columns, columnsOrder } = useDataTableState();
   const dispatch = useDispatch();
-  const selectedColumnType = getColumnType(data, columns, selectedColumnId);
+  const selectedColumnType = columns[selectedColumnId].type;
 
   function handleRemoveFilter() {
     dispatch({ type: "REMOVE_FILTER", payload: id });
@@ -26,7 +25,7 @@ export default function FilterItem(prop) {
         id,
         changes: {
           columnId: newColumnId,
-          rule: rulesByType[getColumnType(data, columns, newColumnId)][0],
+          rule: rulesByType[columns(newColumnId)][0],
           value: "",
         },
       },

--- a/packages/DataTable/src/components/Navigation/components/Sort/Sort.js
+++ b/packages/DataTable/src/components/Navigation/components/Sort/Sort.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import DropdownMenu from "@paprika/dropdown-menu";
-import { useDataTableState } from "../../../..";
+import { useDataTableState, useDispatch } from "../../../..";
 import SortTrigger from "./SortTrigger";
 import { sortDirections, plugins } from "../../../../constants";
 import { useLocalStorage } from "../../../../context";
@@ -9,21 +9,37 @@ import useIsUpdated from "../../../../hooks/useIsUpdated";
 
 const propTypes = {
   onSort: PropTypes.func,
+  defaultSortColumn: PropTypes.string,
+  defaultSortDirection: PropTypes.oneOf([sortDirections.ASCEND, sortDirections.DESCEND]),
 };
 
 const defaultProps = {
   onSort: null,
+  defaultSortColumn: null,
+  defaultSortDirection: null,
 };
 
 const noop = () => {};
 
 export default function Sort(props) {
-  const { onSort } = props;
+  const { onSort, defaultSortColumn, defaultSortDirection } = props;
   const { sortColumn, sortDirection, columns, columnsOrder } = useDataTableState();
+  const dispatch = useDispatch();
   const hasColumnCanBeSorted = !!columnsOrder.find(columnId => columns[columnId].canSort);
   const updateLocalStorage = useLocalStorage();
   const isSortColumnUpdated = useIsUpdated(sortColumn);
   const isSortDirectionUpdated = useIsUpdated(sortDirection);
+
+  React.useEffect(() => {
+    if (defaultSortColumn && defaultSortDirection) {
+      dispatch({
+        type: "SORT",
+        payload: { columnId: defaultSortColumn, direction: defaultSortDirection },
+      });
+    }
+    // Only runs for first time
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   React.useEffect(() => {
     if (!isSortColumnUpdated && !isSortDirectionUpdated) return;

--- a/packages/DataTable/src/components/Navigation/components/Sort/SortTrigger.js
+++ b/packages/DataTable/src/components/Navigation/components/Sort/SortTrigger.js
@@ -4,7 +4,6 @@ import Button from "@paprika/button";
 import { sortDirections } from "../../../../constants";
 
 import { useDataTableState, useDispatch } from "../../../..";
-import getColumnType from "../../../../helpers/getColumnType";
 
 const propTypes = {
   columnId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
@@ -19,12 +18,12 @@ const defaultProps = {
 export default function SortTrigger(props) {
   const { columnId, direction, momentParsingFormat } = props;
   const dispatch = useDispatch();
-  const { data, columns } = useDataTableState();
+  const { columns } = useDataTableState();
 
   function handleSort() {
     dispatch({
       type: "SORT",
-      payload: { columnId, direction, columnType: getColumnType(data, columns, columnId), momentParsingFormat },
+      payload: { columnId, direction, columnType: columns[columnId].type, momentParsingFormat },
     });
   }
 

--- a/packages/DataTable/src/components/Options/SortOption.js
+++ b/packages/DataTable/src/components/Options/SortOption.js
@@ -2,17 +2,16 @@ import React from "react";
 import PropTypes from "prop-types";
 import DropdownMenu from "@paprika/dropdown-menu";
 import { useDataTableState, useDispatch } from "../../context";
-import getColumnType from "../../helpers/getColumnType";
 
 export default function SortOption(props) {
   const { direction, columnId, momentParsingFormat } = props;
   const dispatch = useDispatch();
-  const { data, columns } = useDataTableState();
+  const { columns } = useDataTableState();
 
   function handleSortBy() {
     dispatch({
       type: "SORT",
-      payload: { columnId, direction, columnType: getColumnType(data, columns, columnId), momentParsingFormat },
+      payload: { columnId, direction, columnType: columns[columnId].type, momentParsingFormat },
     });
   }
 

--- a/packages/DataTable/src/context.js
+++ b/packages/DataTable/src/context.js
@@ -28,7 +28,16 @@ function TableProvider(props) {
       sortColumn: null,
       sortDirection: null,
       columnsOrder: columns.map(column => column.id),
-      columns: columns.reduce((columnsObject, column) => ({ ...columnsObject, [column.id]: column }), {}),
+      columns: columns.reduce(
+        (columnsObject, column) => ({
+          ...columnsObject,
+          [column.id]: {
+            ...column,
+            isHidden: column.defaultIsHidden,
+          },
+        }),
+        {}
+      ),
       filters: [],
       logicalFilterOperator: logicalFilterOperators.AND,
     };

--- a/packages/DataTable/src/helpers/getColumnType.js
+++ b/packages/DataTable/src/helpers/getColumnType.js
@@ -1,5 +1,0 @@
-import { columnTypes } from "../constants";
-
-export default function getColumnType(data, columns, columnId) {
-  return columns[columnId].type || (typeof data[0][columnId] === "number" ? columnTypes.NUMBER : columnTypes.TEXT);
-}

--- a/packages/DataTable/stories/UsingDefaultNavigationStatus.stories.js
+++ b/packages/DataTable/stories/UsingDefaultNavigationStatus.stories.js
@@ -1,0 +1,48 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import DataTable, { Filters, Sort, ColumnManaging } from "../src";
+import fixtures from "./fixtures";
+import { viewPortHeight } from "./helpers";
+
+const mockData = fixtures(1);
+
+const defaultFilters = [{ id: "a", columnId: "goals", rule: "LESS_THAN", value: "600" }];
+
+function App() {
+  const [isLoading, setIsLoading] = React.useState(true);
+  const [data, setData] = React.useState(null);
+
+  React.useEffect(() => {
+    setTimeout(() => {
+      setIsLoading(false);
+      setData(mockData);
+    }, 1000);
+  }, []);
+
+  function handleFilter(filters, operator, columns) {
+    console.log(filters, operator, columns);
+    setIsLoading(true);
+    setTimeout(() => {
+      setIsLoading(false);
+      setData([{ country: "Brazil", name: "Roberto Dinamite", goals: 512, status: "inactive", joined: "10/01/2019" }]);
+    }, 1000);
+  }
+
+  return (
+    <React.Fragment>
+      <DataTable keygen="id" data={data} height={viewPortHeight()} isLoading={isLoading}>
+        <DataTable.Navigation>
+          <Filters onFilter={handleFilter} defaultFilters={defaultFilters} defaultLogicalFilterOperator="OR" />
+          <Sort defaultSortColumn="goals" defaultSortDirection="DESCEND" />
+          <ColumnManaging defaultColumnsOrder={["goals", "name", "status", "country"]} />
+        </DataTable.Navigation>
+        <DataTable.ColumnDefinition id="country" width="190" header="Country" cell="country" defaultIsHidden />
+        <DataTable.ColumnDefinition id="name" header="Name" cell="name" />
+        <DataTable.ColumnDefinition id="goals" header="Goals" cell="goals" />
+        <DataTable.ColumnDefinition id="status" header="Status" cell="status" />
+      </DataTable>
+    </React.Fragment>
+  );
+}
+
+storiesOf("DataTable", module).add("Using default navigation status", () => <App />);


### PR DESCRIPTION
### Purpose 🚀

- Being able to use `defaultColumnsOrder` on `<ColumnManaging />` 
- Being able to use `defaultIsHidden` on `<ColumnDefinition />`, maybe remove `isHidden` ?
- Being able to use `defaultFilters` and `defaultLogicalFilterOperator` on `<Filters />`
- Being able to use `defaultSortColumn` and `defaultSortDirection` on `<Sort />`

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_
- [ ] PATCH (bug fix) change to _these packages_

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/STAR-43-support-default-widgets-status

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
