### PR TITLE
Ux 681 datepicker has error in formelement fix

### DIFF
--- a/packages/DatePicker/README.md
+++ b/packages/DatePicker/README.md
@@ -10,6 +10,21 @@ or
 
 Please use `<L10n />` component to wrap `<DatePicker />` or you application.
 
+#### DatePicker
+
+Props:
+
+- `children`
+- `dataFormat`
+- `date`
+- `humanFormat`
+- `id`
+- `isDisabled`
+- `isReadOnly`
+- `onChange`
+- `onError`
+- `hasError`
+
 For a basic date picker
 
 ```js

--- a/packages/DatePicker/README.md
+++ b/packages/DatePicker/README.md
@@ -48,6 +48,7 @@ import DatePicker from "@paprika/date-picker";
 - `a11yText`
 - `placeholder`
 - `size` `["small", "medium", "large"]`
+- `hasError`
 
 #### DatePicker.Popover
 

--- a/packages/DatePicker/src/DatePicker.js
+++ b/packages/DatePicker/src/DatePicker.js
@@ -44,14 +44,18 @@ const propTypes = {
   /** Callback when date is selected or input. */
   onChange: PropTypes.func.isRequired,
 
-  /** Errors callback */
+  /** Internal errors callback */
   onError: PropTypes.func,
+
+  /** If there is an external error or not. Not required when wrapped with <FormElement>. */
+  hasError: PropTypes.bool,
 };
 
 const defaultProps = {
   children: null,
   dataFormat: "MM/DD/YYYY",
   date: null,
+  hasError: false,
   humanFormat: undefined,
   id: null,
   isDisabled: false,
@@ -73,6 +77,7 @@ function DatePicker(props) {
     isReadOnly,
     onChange,
     onError,
+    hasError,
   } = props;
 
   const formatDateProp = React.useCallback(
@@ -200,8 +205,6 @@ function DatePicker(props) {
     hideCalendar();
     handleChange(selectedDate);
   }
-
-  const hasError = extendedInputProps && extendedInputProps.hasError;
 
   const hasErrorValue = hasError || hasParsingError;
 

--- a/packages/DatePicker/src/DatePicker.js
+++ b/packages/DatePicker/src/DatePicker.js
@@ -206,7 +206,9 @@ function DatePicker(props) {
     handleChange(selectedDate);
   }
 
-  const hasErrorValue = hasError || hasParsingError;
+  const hasInputError = extendedInputProps && extendedInputProps.hasError;
+
+  const hasErrorValue = hasError || hasParsingError || hasInputError;
 
   const inputText =
     (inputRef && isElementContainsFocus(inputRef.current)) || hasErrorValue

--- a/packages/DatePicker/src/components/DateInput/DateInput.js
+++ b/packages/DatePicker/src/components/DateInput/DateInput.js
@@ -11,12 +11,16 @@ const propTypes = {
 
   /** Size of input. */
   size: PropTypes.oneOf(ShirtSizes.DEFAULT),
+
+  /** If the value of <input> is valid or not. */
+  hasError: PropTypes.bool,
 };
 
 const defaultProps = {
   a11yText: null,
   placeholder: "",
   size: ShirtSizes.MEDIUM,
+  hasError: false,
 };
 
 // shell component for enhancing development experience

--- a/packages/DatePicker/src/components/DateInput/DateInput.js
+++ b/packages/DatePicker/src/components/DateInput/DateInput.js
@@ -11,16 +11,12 @@ const propTypes = {
 
   /** Size of input. */
   size: PropTypes.oneOf(ShirtSizes.DEFAULT),
-
-  /** If the value of <input> is valid or not. Not required when wrapped with <FormElement>. */
-  hasError: PropTypes.bool,
 };
 
 const defaultProps = {
   a11yText: null,
   placeholder: "",
   size: ShirtSizes.MEDIUM,
-  hasError: false,
 };
 
 // shell component for enhancing development experience

--- a/packages/DatePicker/stories/DatePicker.stories.js
+++ b/packages/DatePicker/stories/DatePicker.stories.js
@@ -13,12 +13,12 @@ storiesOf("DatePicker", module)
       humanFormat: select("humanFormat", ["MMMM DD, YYYY", "YYYY-MM-DD"], "MMMM DD, YYYY"),
       isDisabled: boolean("isDisabled", false),
       isReadOnly: boolean("isReadOnly", false),
+      hasError: boolean("hasError", false),
     });
 
     const inputProps = () => ({
       size: select("size", ["small", "medium", "large"], "medium"),
       placeholder: text("placeholder", ""),
-      hasError: boolean("hasError", false),
     });
     return (
       <Example locale="en" {...datePickerProps()}>

--- a/packages/DatePicker/test/DatePicker.spec.js
+++ b/packages/DatePicker/test/DatePicker.spec.js
@@ -54,7 +54,7 @@ describe("DatePicker", () => {
   });
 
   it("should render input as error state hasError", () => {
-    render({ date: moment("2019-01-02") }, { hasError: true });
+    render({ date: moment("2019-01-02"), hasError: true });
 
     expect(document.getElementsByClassName("form-input--has-error").length).toEqual(1);
   });


### PR DESCRIPTION
![](https://aclgrc.atlassian.net/secure/attachment/91298/91298_fixFormInputError.gif)
### Purpose 🚀
Date Picker doesn't currently includes the `hasError` prop on the DatePicker input component. When the Date Picker component is used as as child of the Form Element component the `DatePicker.Input` is not an immediate child and so the `hasError` prop is not added to the input therefore not highlighting the input as red when `FormElement` has an error.

### Notes ✏️

Side changes
- Expanded DatePicker readme to include props
- Retained `hasError` prop on the `DatePicker.Input` to avoid breaking change

### Updates 📦

- [x] MINOR (backward compatible) change to DatePicker

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/ux-681-datepicker-has-error-in-formelement-fix

### Screenshots 📸
Before
![image](https://user-images.githubusercontent.com/4040102/71288710-1404b580-2320-11ea-9a5e-aa5fbae7be67.png)

After
![fixFormInputError](https://user-images.githubusercontent.com/4040102/71288696-0a7b4d80-2320-11ea-900b-b27c763a63f2.gif)


### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
