### PR TITLE
UX-695 Use secret SCREENER_API_KEY 🐐

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -92,3 +92,5 @@ blocks:
             - npx lerna bootstrap
             - yarn storybook:build
             - yarn storybook:screener
+      secrets:
+        - name: screener-api-key

--- a/screener.config.js
+++ b/screener.config.js
@@ -1,11 +1,12 @@
 module.exports = {
-  apiKey: "809f59e2-e260-4303-a661-7c69d72486ef",
+  apiKey: process.env.SCREENER_API_KEY,
   baseBranch: "master",
+  branch: process.env.SEMAPHORE_GIT_BRANCH,
   initialBaselineBranch: "master",
   projectRepo: "acl-services/paprika",
   resolution: "1280x1024",
   storybookConfigDir: ".storybook",
   storybookStaticDir: "./.storybook/assets",
-  failureExitCode: 0, // Don't fail CI builds
-  includeRules: [/Screener/, /^Stylers/, /^Button: Basic/],
+  failureExitCode: 0, // Don't fail CI build when regressions found
+  includeRules: [/Screener/, /^Stylers/, /^Button\/Examples: Basic/],
 };


### PR DESCRIPTION
### Purpose 🚀
Use a Semaphore secret to protect the Screener API Key.

### Notes ✏️
- Also trying to add the `branch` config to `screener.config.js` for better Screener experience (grouping builds by branch name). This may need to be reverted if it still won't recognize the `baseBranch`.
- Also fixed the `includeRules` for the Button story.

### References 🔗
https://aclgrc.atlassian.net/browse/UX-695


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
