### PR TITLE
PD-14060 make divider left aligned

### DIFF
--- a/packages/ListBox/src/components/Divider/Divider.styles.js
+++ b/packages/ListBox/src/components/Divider/Divider.styles.js
@@ -11,24 +11,12 @@ const pseudoElement = css`
 `;
 
 const textDividerStyles = css`
-  &:before {
-    ${pseudoElement}
-    margin-right: ${tokens.space};
-  }
-
   &:after {
     ${pseudoElement}
     margin-left: ${tokens.space};
   }
 `;
 
-const lineDividerStyles = css`
-  &:before {
-    ${pseudoElement}
-  }
-`;
-
-// css let the IDE recognize css highlight
 export const dividerCSS = css`
   align-items: center;
   color: ${tokens.color.blackLighten20};
@@ -39,5 +27,5 @@ export const dividerCSS = css`
 
   ${stylers.fontSize(-1)};
 
-  ${({ hasChildren }) => (hasChildren ? textDividerStyles : lineDividerStyles)}
+  ${({ hasChildren }) => hasChildren && textDividerStyles}
 `;


### PR DESCRIPTION
### Purpose 🚀
- make divider left aligned instead of centered


### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_
- [x] PATCH (bug fix) change to _Listbox_

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/PD-14060-listbox-divider

### Screenshots 📸
![Screen Shot 2020-01-07 at 2 29 31 PM](https://user-images.githubusercontent.com/19940076/71934859-32f5ab00-315a-11ea-9901-588921ac4bea.png)