### PR TITLE
PD-13960 fix checkbox states

### DIFF
--- a/packages/Checkbox/CHANGELOG.md
+++ b/packages/Checkbox/CHANGELOG.md
@@ -5,4 +5,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [0.2.0] - 2020-01-14
 ### Added
-- Fixed broken checkboxStates import to use Checkbox.States instead [@oscarkwan](https://github.com/oscarkwan).
+- Fixed broken checkboxStates import to use Checkbox.states instead [@oscarkwan](https://github.com/oscarkwan).

--- a/packages/Checkbox/CHANGELOG.md
+++ b/packages/Checkbox/CHANGELOG.md
@@ -4,5 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [0.2.0] - 2020-01-14
+### Removed
+- checkboxStates import which was broken [@oscarkwan](https://github.com/oscarkwan).
+
 ### Added
-- Fixed broken checkboxStates import to use Checkbox.states instead [@oscarkwan](https://github.com/oscarkwan).
+- Checkbox.states instead of checkboxStates [@oscarkwan](https://github.com/oscarkwan).

--- a/packages/Checkbox/CHANGELOG.md
+++ b/packages/Checkbox/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [0.2.0] - 2020-01-14
+### Added
+- Fixed broken checkboxStates import to use Checkbox.States instead [@oscarkwan](https://github.com/oscarkwan).

--- a/packages/Checkbox/src/Checkbox.js
+++ b/packages/Checkbox/src/Checkbox.js
@@ -74,7 +74,7 @@ const Checkbox = props => {
   );
 };
 
-Checkbox.States = checkboxStates;
+Checkbox.states = checkboxStates;
 
 Checkbox.displayName = "Checkbox";
 Checkbox.propTypes = propTypes;

--- a/packages/Checkbox/src/Checkbox.js
+++ b/packages/Checkbox/src/Checkbox.js
@@ -6,7 +6,7 @@ import CheckIcon from "@paprika/icon/lib/Check";
 import DashIcon from "@paprika/icon/lib/Dash";
 import checkboxStyles from "./Checkbox.styles";
 
-export const checkboxStates = {
+const checkboxStates = {
   CHECKED: "checked",
   UNCHECKED: "unchecked",
   INDETERMINATE: "indeterminate",
@@ -74,8 +74,9 @@ const Checkbox = props => {
   );
 };
 
+Checkbox.States = checkboxStates;
+
 Checkbox.displayName = "Checkbox";
 Checkbox.propTypes = propTypes;
 Checkbox.defaultProps = defaultProps;
-
 export default Checkbox;

--- a/packages/Checkbox/stories/examples/CheckboxAlign.js
+++ b/packages/Checkbox/stories/examples/CheckboxAlign.js
@@ -3,7 +3,7 @@ import { Rule } from "storybook/assets/styles/common.styles";
 import Heading from "@paprika/heading";
 import Checkbox from "../../src/Checkbox";
 
-const { CHECKED, UNCHECKED } = Checkbox.States;
+const { CHECKED, UNCHECKED } = Checkbox.states;
 
 const CheckboxExample = props => {
   const [checkedState, setCheckedState] = React.useState(props.value || UNCHECKED);

--- a/packages/Checkbox/stories/examples/CheckboxAlign.js
+++ b/packages/Checkbox/stories/examples/CheckboxAlign.js
@@ -1,9 +1,9 @@
 import React from "react";
 import { Rule } from "storybook/assets/styles/common.styles";
 import Heading from "@paprika/heading";
-import Checkbox, { checkboxStates } from "../../src/Checkbox";
+import Checkbox from "../../src/Checkbox";
 
-const { CHECKED, UNCHECKED } = checkboxStates;
+const { CHECKED, UNCHECKED } = Checkbox.States;
 
 const CheckboxExample = props => {
   const [checkedState, setCheckedState] = React.useState(props.value || UNCHECKED);

--- a/packages/Checkbox/stories/examples/CheckboxGrouping.js
+++ b/packages/Checkbox/stories/examples/CheckboxGrouping.js
@@ -3,7 +3,7 @@ import { Rule } from "storybook/assets/styles/common.styles";
 import Heading from "@paprika/heading";
 import Checkbox from "../../src/Checkbox";
 
-const { CHECKED, UNCHECKED } = Checkbox.States;
+const { CHECKED, UNCHECKED } = Checkbox.states;
 
 const CheckboxExample = props => {
   const [checkedState, setCheckedState] = React.useState(props.value || UNCHECKED);

--- a/packages/Checkbox/stories/examples/CheckboxGrouping.js
+++ b/packages/Checkbox/stories/examples/CheckboxGrouping.js
@@ -1,9 +1,9 @@
 import React from "react";
 import { Rule } from "storybook/assets/styles/common.styles";
 import Heading from "@paprika/heading";
-import Checkbox, { checkboxStates } from "../../src/Checkbox";
+import Checkbox from "../../src/Checkbox";
 
-const { CHECKED, UNCHECKED } = checkboxStates;
+const { CHECKED, UNCHECKED } = Checkbox.States;
 
 const CheckboxExample = props => {
   const [checkedState, setCheckedState] = React.useState(props.value || UNCHECKED);

--- a/packages/Checkbox/stories/examples/Showcase.js
+++ b/packages/Checkbox/stories/examples/Showcase.js
@@ -6,12 +6,12 @@ import Heading from "@paprika/heading";
 import { CheckboxStory } from "../Checkbox.stories.styles";
 import Checkbox from "../../src/Checkbox";
 
-const { CHECKED, UNCHECKED } = Checkbox.States;
+const { CHECKED, UNCHECKED } = Checkbox.states;
 
 const checkboxProps = () => ({
   size: select("size", ShirtSizes.DEFAULT, "medium"),
   isDisabled: boolean("isDisabled", false),
-  checkedState: select("checkedState", Object.values(Checkbox.States), UNCHECKED),
+  checkedState: select("checkedState", Object.values(Checkbox.states), UNCHECKED),
   a11yText: text("a11yText", ""),
 });
 

--- a/packages/Checkbox/stories/examples/Showcase.js
+++ b/packages/Checkbox/stories/examples/Showcase.js
@@ -4,14 +4,14 @@ import { Rule, Tagline } from "storybook/assets/styles/common.styles";
 import { ShirtSizes } from "@paprika/helpers/lib/customPropTypes";
 import Heading from "@paprika/heading";
 import { CheckboxStory } from "../Checkbox.stories.styles";
-import Checkbox, { checkboxStates } from "../../src/Checkbox";
+import Checkbox from "../../src/Checkbox";
 
-const { CHECKED, UNCHECKED } = checkboxStates;
+const { CHECKED, UNCHECKED } = Checkbox.States;
 
 const checkboxProps = () => ({
   size: select("size", ShirtSizes.DEFAULT, "medium"),
   isDisabled: boolean("isDisabled", false),
-  checkedState: select("checkedState", Object.values(checkboxStates), UNCHECKED),
+  checkedState: select("checkedState", Object.values(Checkbox.States), UNCHECKED),
   a11yText: text("a11yText", ""),
 });
 

--- a/packages/Checkbox/tests/Checkbox.spec.js
+++ b/packages/Checkbox/tests/Checkbox.spec.js
@@ -5,7 +5,7 @@ import Checkbox from "../src/Checkbox";
 function renderComponent(props = {}) {
   const defaultProps = {
     a11yText: null,
-    checkedState: Checkbox.States.CHECKED,
+    checkedState: Checkbox.states.CHECKED,
     children: null,
     isDisabled: false,
     onChange: () => {},
@@ -21,12 +21,12 @@ describe("Checkbox", () => {
   });
 
   it("Renders checkedState is unchecked", () => {
-    const { getByRole } = renderComponent({ checkedState: Checkbox.States.UNCHECKED });
+    const { getByRole } = renderComponent({ checkedState: Checkbox.states.UNCHECKED });
     expect(getByRole("checkbox")).not.toHaveAttribute("checked");
   });
 
   it("Renders checkedState is indeterminate", () => {
-    const { getByRole } = renderComponent({ checkedState: Checkbox.States.INDETERMINATE });
+    const { getByRole } = renderComponent({ checkedState: Checkbox.states.INDETERMINATE });
     expect(getByRole("checkbox").indeterminate).toBe(true);
   });
 

--- a/packages/Checkbox/tests/Checkbox.spec.js
+++ b/packages/Checkbox/tests/Checkbox.spec.js
@@ -1,11 +1,11 @@
 import { render } from "@testing-library/react";
 import React from "react";
-import Checkbox, { checkboxStates } from "../src/Checkbox";
+import Checkbox from "../src/Checkbox";
 
 function renderComponent(props = {}) {
   const defaultProps = {
     a11yText: null,
-    checkedState: checkboxStates.CHECKED,
+    checkedState: Checkbox.States.CHECKED,
     children: null,
     isDisabled: false,
     onChange: () => {},
@@ -21,12 +21,12 @@ describe("Checkbox", () => {
   });
 
   it("Renders checkedState is unchecked", () => {
-    const { getByRole } = renderComponent({ checkedState: checkboxStates.UNCHECKED });
+    const { getByRole } = renderComponent({ checkedState: Checkbox.States.UNCHECKED });
     expect(getByRole("checkbox")).not.toHaveAttribute("checked");
   });
 
   it("Renders checkedState is indeterminate", () => {
-    const { getByRole } = renderComponent({ checkedState: checkboxStates.INDETERMINATE });
+    const { getByRole } = renderComponent({ checkedState: Checkbox.States.INDETERMINATE });
     expect(getByRole("checkbox").indeterminate).toBe(true);
   });
 


### PR DESCRIPTION
### Purpose 🚀
- fix checkboxStates import, before `import Checkbox, { checkedStates } from '@paprika/checkbox' was not working

### Notes ✏️
- Changed it so it is similar to `Button.Kinds`. So now we use `Checkbox.States` instead of exporting `checkboxStates`

### Updates 📦
- [x] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_
- [ ] PATCH (bug fix) change to _these packages_

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/PD-13960-fix-checkboxstates