### PR TITLE
PD-14210 add isPortal prop to popover

### DIFF
--- a/packages/Popover/CHANGELOG.md
+++ b/packages/Popover/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [0.3.11] - 2020-01-21
+### Added
+- `isPortal` prop that controls if a popover is rendered inline with the DOM or as a React portal element
+- Note: The prop added is only used with caution as it can cause indesirable behaviour with paprika side panels / modals.
+- This was added to help with using the Popover component in legacy code where rendering it as portal element will cause the
+- popover not to be rendered.

--- a/packages/Popover/src/Popover.js
+++ b/packages/Popover/src/Popover.js
@@ -41,7 +41,7 @@ const propTypes = {
   /** How "controlled" popovers are shown / hidden. */
   isOpen: PropTypes.bool,
 
-  /** This renders the popover inline in the DOM and not in a react portal. WARNING: may have side effects, use with caution. */
+  /** This renders the popover inline in the DOM and not in a react portal. WARNING: will have side effects with paprika side panels and modals, use with caution. */
   isPortal: PropTypes.bool,
 
   /** How "uncontrolled" popovers can be rendered open by default. */

--- a/packages/Popover/src/Popover.js
+++ b/packages/Popover/src/Popover.js
@@ -41,6 +41,9 @@ const propTypes = {
   /** How "controlled" popovers are shown / hidden. */
   isOpen: PropTypes.bool,
 
+  /** This renders the popover inline in the DOM and not in a react portal. WARNING: may have side effects, use with caution. */
+  isPortal: PropTypes.bool,
+
   /** How "uncontrolled" popovers can be rendered open by default. */
   defaultIsOpen: PropTypes.bool,
 
@@ -77,6 +80,7 @@ const defaultProps = {
   isDark: false,
   isEager: false,
   isOpen: null,
+  isPortal: true,
   defaultIsOpen: null,
   edge: null,
   maxWidth: 320,
@@ -98,8 +102,10 @@ class Popover extends React.Component {
     this.$trigger = null;
     this.$tip = null; // this ref comes from a callback of the <Tip /> component
 
-    const portalNode = document.createElement("div");
-    this.$portal = document.body.appendChild(portalNode);
+    if (props.isPortal) {
+      const portalNode = document.createElement("div");
+      this.$portal = document.body.appendChild(portalNode);
+    }
 
     this.focusableElements = [];
     this.triggerFocusIndex = null;
@@ -138,6 +144,7 @@ class Popover extends React.Component {
       width,
       isEager,
       isOpen,
+      isPortal,
       portalElement,
       refContent,
       refTip,
@@ -161,6 +168,7 @@ class Popover extends React.Component {
       onDelayedClose: this.handleDelayedClose,
       onDelayedOpen: this.handleDelayedOpen,
       onOpen: this.handleOpen,
+      isPortal,
       portalElement,
       refContent,
       refTip,
@@ -208,7 +216,9 @@ class Popover extends React.Component {
     clearTimeout(this.closeTimer);
     this.closeTimer = null;
 
-    document.body.removeChild(this.$portal);
+    if (this.props.isPortal) {
+      document.body.removeChild(this.$portal);
+    }
   }
 
   getContentWidth() {
@@ -472,6 +482,7 @@ class Popover extends React.Component {
       isDark,
       isEager,
       isOpen,
+      isPortal,
       defaultIsOpen,
       maxWidth,
       minWidth,
@@ -490,6 +501,7 @@ class Popover extends React.Component {
       this.state.width,
       isEager,
       this.isOpen(),
+      isPortal,
       this.$portal,
       this.refContent,
       this.refTip,

--- a/packages/Popover/src/components/Content/Content.js
+++ b/packages/Popover/src/components/Content/Content.js
@@ -88,31 +88,8 @@ const Content = React.forwardRef((props, ref) => {
     contentStyles.width = content.width;
   }
 
-  if (isPortal) {
-    /* eslint-disable jsx-a11y/mouse-events-have-key-events */
-    return ReactDOM.createPortal(
-      <ContentStyled
-        aria-hidden={!isOpen}
-        data-component-name="PopoverContent"
-        data-pka-anchor="popover.content"
-        ref={handleRef}
-        id={isEager ? content.ariaId : null}
-        isOpen={isOpen}
-        onBlur={handleBlur}
-        onMouseOut={handleMouseEvent}
-        onMouseOver={handleMouseEvent}
-        style={contentStyles}
-        tabIndex="-1"
-        zIndex={content.zIndex}
-        {...moreProps}
-      >
-        {props.children}
-      </ContentStyled>,
-      portalElement
-    );
-  }
-
-  return (
+  /* eslint-disable jsx-a11y/mouse-events-have-key-events */
+  const ContentStyledComponent = (
     <ContentStyled
       aria-hidden={!isOpen}
       data-component-name="PopoverContent"
@@ -131,6 +108,12 @@ const Content = React.forwardRef((props, ref) => {
       {props.children}
     </ContentStyled>
   );
+
+  if (isPortal) {
+    return ReactDOM.createPortal(ContentStyledComponent, portalElement);
+  }
+
+  return ContentStyledComponent;
 });
 /* eslint-enable jsx-a11y/mouse-events-have-key-events */
 

--- a/packages/Popover/src/components/Content/Content.js
+++ b/packages/Popover/src/components/Content/Content.js
@@ -23,6 +23,7 @@ const Content = React.forwardRef((props, ref) => {
     content,
     isEager,
     isOpen,
+    isPortal,
     onClose,
     onDelayedClose,
     onDelayedOpen,
@@ -87,8 +88,31 @@ const Content = React.forwardRef((props, ref) => {
     contentStyles.width = content.width;
   }
 
-  /* eslint-disable jsx-a11y/mouse-events-have-key-events */
-  return ReactDOM.createPortal(
+  if (isPortal) {
+    /* eslint-disable jsx-a11y/mouse-events-have-key-events */
+    return ReactDOM.createPortal(
+      <ContentStyled
+        aria-hidden={!isOpen}
+        data-component-name="PopoverContent"
+        data-pka-anchor="popover.content"
+        ref={handleRef}
+        id={isEager ? content.ariaId : null}
+        isOpen={isOpen}
+        onBlur={handleBlur}
+        onMouseOut={handleMouseEvent}
+        onMouseOver={handleMouseEvent}
+        style={contentStyles}
+        tabIndex="-1"
+        zIndex={content.zIndex}
+        {...moreProps}
+      >
+        {props.children}
+      </ContentStyled>,
+      portalElement
+    );
+  }
+
+  return (
     <ContentStyled
       aria-hidden={!isOpen}
       data-component-name="PopoverContent"
@@ -105,8 +129,7 @@ const Content = React.forwardRef((props, ref) => {
       {...moreProps}
     >
       {props.children}
-    </ContentStyled>,
-    portalElement
+    </ContentStyled>
   );
 });
 /* eslint-enable jsx-a11y/mouse-events-have-key-events */

--- a/packages/Popover/src/components/Tip/Tip.js
+++ b/packages/Popover/src/components/Tip/Tip.js
@@ -17,11 +17,31 @@ function Tip(props) {
   const { zIndex, ...moreProps } = props;
 
   const isDark = React.useContext(ThemeContext);
-  const { content, tip, refTip, isOpen, portalElement } = React.useContext(PopoverContext);
+  const { content, tip, refTip, isOpen, isPortal, portalElement } = React.useContext(PopoverContext);
   const borderColor = isDark ? tokens.color.black : tokens.border.color;
   const backgroundColor = isDark ? tokens.color.black : tokens.color.white;
 
-  return ReactDOM.createPortal(
+  if (isPortal) {
+    return ReactDOM.createPortal(
+      <TipStyled
+        isOpen={isOpen}
+        data-pka-anchor="popover.tip"
+        ref={refTip}
+        rotate={tip.rotate}
+        style={{ left: tip.x, top: tip.y }}
+        zIndex={zIndex || content.zIndex}
+        {...moreProps}
+      >
+        <svg height="100%" width="100%" viewBox="0 0 12 12" version="1.1" xmlns="http://www.w3.org/2000/svg">
+          <polygon points="0 12 12 12 6 6" fill={borderColor} />
+          <polygon points="1 12 11 12 6 7" fill={backgroundColor} />
+        </svg>
+      </TipStyled>,
+      portalElement
+    );
+  }
+
+  return (
     <TipStyled
       isOpen={isOpen}
       data-pka-anchor="popover.tip"
@@ -35,8 +55,7 @@ function Tip(props) {
         <polygon points="0 12 12 12 6 6" fill={borderColor} />
         <polygon points="1 12 11 12 6 7" fill={backgroundColor} />
       </svg>
-    </TipStyled>,
-    portalElement
+    </TipStyled>
   );
 }
 

--- a/packages/Popover/src/components/Tip/Tip.js
+++ b/packages/Popover/src/components/Tip/Tip.js
@@ -21,27 +21,7 @@ function Tip(props) {
   const borderColor = isDark ? tokens.color.black : tokens.border.color;
   const backgroundColor = isDark ? tokens.color.black : tokens.color.white;
 
-  if (isPortal) {
-    return ReactDOM.createPortal(
-      <TipStyled
-        isOpen={isOpen}
-        data-pka-anchor="popover.tip"
-        ref={refTip}
-        rotate={tip.rotate}
-        style={{ left: tip.x, top: tip.y }}
-        zIndex={zIndex || content.zIndex}
-        {...moreProps}
-      >
-        <svg height="100%" width="100%" viewBox="0 0 12 12" version="1.1" xmlns="http://www.w3.org/2000/svg">
-          <polygon points="0 12 12 12 6 6" fill={borderColor} />
-          <polygon points="1 12 11 12 6 7" fill={backgroundColor} />
-        </svg>
-      </TipStyled>,
-      portalElement
-    );
-  }
-
-  return (
+  const TipStyledComponent = (
     <TipStyled
       isOpen={isOpen}
       data-pka-anchor="popover.tip"
@@ -57,6 +37,12 @@ function Tip(props) {
       </svg>
     </TipStyled>
   );
+
+  if (isPortal) {
+    return ReactDOM.createPortal(TipStyledComponent, portalElement);
+  }
+
+  return TipStyledComponent;
 }
 
 Tip.displayName = "Popover.Tip";

--- a/packages/Popover/stories/examples/Basic.js
+++ b/packages/Popover/stories/examples/Basic.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { text, number, select } from "@storybook/addon-knobs";
+import { boolean, text, number, select } from "@storybook/addon-knobs";
 import styled from "styled-components";
 import { CenteredStory } from "storybook/assets/styles/common.styles";
 import Button from "@paprika/button";
@@ -22,6 +22,7 @@ export const popoverProps = () => ({
   edge: select("edge", { left: "left", right: "right", none: null }, null),
   maxWidth: text("maxWidth", "320"),
   minWidth: text("minWidth", "0"),
+  isPortal: boolean("isPortal", true),
   offset: number("offset", 12),
 });
 


### PR DESCRIPTION
### Purpose 🚀
- add `isPortal` prop that allows consumer to render popover inline with the DOM or as a portal

### Notes ✏️


### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [x] MINOR (backward compatible) change to _these packages_
- [ ] PATCH (bug fix) change to _these packages_

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/PD-14210-add-isportal-prop

<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
