### PR TITLE
UX-633 Adding isOpen to popover trigger render function params

### DIFF
--- a/packages/Popover/src/components/Trigger/Trigger.js
+++ b/packages/Popover/src/components/Trigger/Trigger.js
@@ -50,7 +50,6 @@ function Trigger(props) {
   const { children, a11yText, ...moreProps } = props;
 
   if (typeof children === "function") {
-    console.log("isoPEN", isOpen);
     return (
       <React.Fragment>
         {React.cloneElement(children(handleTriggerEvent, { "aria-describedby": content.ariaId }, isOpen), {

--- a/packages/Popover/src/components/Trigger/Trigger.js
+++ b/packages/Popover/src/components/Trigger/Trigger.js
@@ -20,6 +20,7 @@ function Trigger(props) {
   const {
     content,
     isEager,
+    isOpen,
     onClick,
     onClose,
     onDelayedClose,
@@ -49,9 +50,12 @@ function Trigger(props) {
   const { children, a11yText, ...moreProps } = props;
 
   if (typeof children === "function") {
+    console.log("isoPEN", isOpen);
     return (
       <React.Fragment>
-        {React.cloneElement(children(handleTriggerEvent, { "aria-describedby": content.ariaId }), { ...moreProps })}
+        {React.cloneElement(children(handleTriggerEvent, { "aria-describedby": content.ariaId }, isOpen), {
+          ...moreProps,
+        })}
       </React.Fragment>
     );
   }

--- a/packages/Popover/stories/examples/WithTriggers.js
+++ b/packages/Popover/stories/examples/WithTriggers.js
@@ -172,6 +172,19 @@ const ExampleStory = () => (
         <Popover.Tip />
       </Popover>
       <Gap />
+      <h5>Render prop: &lt;a&gt; Button with different state</h5>
+      <Popover>
+        <Popover.Trigger data-test-attr="propagated">
+          {(handler, attributes, isOpen) => (
+            <Button onClick={handler}>{isOpen ? "Click to close" : "Click to open"}</Button>
+          )}
+        </Popover.Trigger>
+        <Popover.Content>
+          <Popover.Card>Lorem ipsum single-origin kombucha.</Popover.Card>
+        </Popover.Content>
+        <Popover.Tip />
+      </Popover>
+      <Gap />
     </div>
   </CenteredStory>
 );


### PR DESCRIPTION
### Purpose 🚀

Adding `isOpen` to `<Popover.Trigger />` render child function params to show different trigger status. This will be used in table navigation

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [x] MINOR (backward compatible) change to `@paprika/popover`
- [ ] PATCH (bug fix) change to _these packages_

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/UX-633-passing-isOpen-into-popover-trigger

### Screenshots 📸
![Jietu20200130-165146-HD](https://user-images.githubusercontent.com/38733362/73503392-f8f67e00-4380-11ea-96c9-4f6b72d38f8b.gif)


### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
