### PR TITLE
STAR-128 Integrate Screener with GitHub 🐐

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -93,6 +93,6 @@ blocks:
           commands:
             - npx lerna bootstrap
             - yarn storybook:build
-            - SEMAPHORE_BUILD_NUMBER=$SEMAPHORE_WORKFLOW_ID yarn storybook:screener:ci
+            - BRANCH_NAME=$SEMAPHORE_GIT_BRANCH REVISION=$SEMAPHORE_GIT_PR_SHA SEMAPHORE_BUILD_NUMBER=$SEMAPHORE_WORKFLOW_ID yarn storybook:screener:ci
       secrets:
         - name: screener-api-key

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -19,68 +19,70 @@ blocks:
           - npx lerna bootstrap
           - cache store client-node-modules-$SEMAPHORE_GIT_BRANCH-$(checksum yarn.lock) node_modules
           - cache store cypress-$SEMAPHORE_GIT_BRANCH ~/.cache/Cypress
-  # - name: "🔗 Storybook link"
-  #   task:
-  #     secrets:
-  #       - name: paprika-env
-  #     prologue:
-  #       commands:
-  #         - checkout
-  #         - cache restore node-modules-$SEMAPHORE_GIT_BRANCH
-  #     jobs:
-  #       - name: Insert Storybook link into PR Body Message
-  #         commands:
-  #           - node scripts/storybookLink.js
-  # - name: "💅 Format"
-  #   task:
-  #     prologue:
-  #       commands:
-  #         - checkout
-  #         - cache restore client-node-modules-$SEMAPHORE_GIT_BRANCH-$(checksum yarn.lock),client-node-modules-$SEMAPHORE_GIT_BRANCH,client-node-modules-master
-  #     jobs:
-  #       - name: Lint && prettier
-  #         commands:
-  #           - yarn add eslint-plugin-react-hooks -D -W
-  #           - yarn lint && yarn prettier -- --list-different
+  
+  - name: "🔗 Storybook link"
+    task:
+      secrets:
+        - name: paprika-env
+      prologue:
+        commands:
+          - checkout
+          - cache restore node-modules-$SEMAPHORE_GIT_BRANCH
+      jobs:
+        - name: Insert Storybook link into PR Body Message
+          commands:
+            - node scripts/storybookLink.js
+  
+  - name: "💅 Format"
+    task:
+      prologue:
+        commands:
+          - checkout
+          - cache restore client-node-modules-$SEMAPHORE_GIT_BRANCH-$(checksum yarn.lock),client-node-modules-$SEMAPHORE_GIT_BRANCH,client-node-modules-master
+      jobs:
+        - name: Lint && prettier
+          commands:
+            - yarn add eslint-plugin-react-hooks -D -W
+            - yarn lint && yarn prettier -- --list-different
 
-  # - name: "♿️ Accessibility"
-  #   task:
-  #     prologue:
-  #       commands:
-  #         - checkout
-  #         - cache restore client-node-modules-$SEMAPHORE_GIT_BRANCH-$(checksum yarn.lock),client-node-modules-$SEMAPHORE_GIT_BRANCH,client-node-modules-master
-  #     jobs:
-  #       - name: Axe test
-  #         commands:
-  #           - yarn test:a11y
+  - name: "♿️ Accessibility"
+    task:
+      prologue:
+        commands:
+          - checkout
+          - cache restore client-node-modules-$SEMAPHORE_GIT_BRANCH-$(checksum yarn.lock),client-node-modules-$SEMAPHORE_GIT_BRANCH,client-node-modules-master
+      jobs:
+        - name: Axe test
+          commands:
+            - yarn test:a11y
 
-  # - name: "⚡️ Integration/Unit"
-  #   task:
-  #     prologue:
-  #       commands:
-  #         - checkout
-  #         - cache restore client-node-modules-$SEMAPHORE_GIT_BRANCH-$(checksum yarn.lock),client-node-modules-$SEMAPHORE_GIT_BRANCH,client-node-modules-master
-  #         - yarn
-  #     jobs:
-  #       - name: JEST
-  #         commands:
-  #           - yarn test
+  - name: "⚡️ Integration/Unit"
+    task:
+      prologue:
+        commands:
+          - checkout
+          - cache restore client-node-modules-$SEMAPHORE_GIT_BRANCH-$(checksum yarn.lock),client-node-modules-$SEMAPHORE_GIT_BRANCH,client-node-modules-master
+          - yarn
+      jobs:
+        - name: JEST
+          commands:
+            - yarn test
 
-  # - name: "⛰ E2E"
-  #   task:
-  #     prologue:
-  #       commands:
-  #         - checkout
-  #         - sudo apt-get -y install xvfb libgtk2.0-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2
-  #         - cache restore client-node-modules-$SEMAPHORE_GIT_BRANCH-$(checksum yarn.lock),client-node-modules-$SEMAPHORE_GIT_BRANCH,client-node-modules-master
-  #         - cache restore cypress-$SEMAPHORE_GIT_BRANCH
-  #         - sudo sysctl fs.inotify.max_user_watches=1048576
-  #     jobs:
-  #       - name: Cypress
-  #         commands:
-  #           - npx lerna bootstrap
-  #           - yarn
-  #           - yarn cypress:ci
+  - name: "⛰ E2E"
+    task:
+      prologue:
+        commands:
+          - checkout
+          - sudo apt-get -y install xvfb libgtk2.0-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2
+          - cache restore client-node-modules-$SEMAPHORE_GIT_BRANCH-$(checksum yarn.lock),client-node-modules-$SEMAPHORE_GIT_BRANCH,client-node-modules-master
+          - cache restore cypress-$SEMAPHORE_GIT_BRANCH
+          - sudo sysctl fs.inotify.max_user_watches=1048576
+      jobs:
+        - name: Cypress
+          commands:
+            - npx lerna bootstrap
+            - yarn
+            - yarn cypress:ci
 
   - name: "🔎 Visual Regression"
     task:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -90,9 +90,12 @@ blocks:
           - cache restore client-node-modules-$SEMAPHORE_GIT_BRANCH-$(checksum yarn.lock),client-node-modules-$SEMAPHORE_GIT_BRANCH,client-node-modules-master
       jobs:
         - name: Screener
+          env_vars:
+            - name: SEMAPHORE_BUILD_NUMBER
+              value: $SEMAPHORE_WORKFLOW_ID
           commands:
             - npx lerna bootstrap
             - yarn storybook:build
-            - yarn storybook:screener
+            - yarn storybook:screener:ci
       secrets:
         - name: screener-api-key

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -19,68 +19,68 @@ blocks:
           - npx lerna bootstrap
           - cache store client-node-modules-$SEMAPHORE_GIT_BRANCH-$(checksum yarn.lock) node_modules
           - cache store cypress-$SEMAPHORE_GIT_BRANCH ~/.cache/Cypress
-  - name: "🔗 Storybook link"
-    task:
-      secrets:
-        - name: paprika-env
-      prologue:
-        commands:
-          - checkout
-          - cache restore node-modules-$SEMAPHORE_GIT_BRANCH
-      jobs:
-        - name: Insert Storybook link into PR Body Message
-          commands:
-            - node scripts/storybookLink.js
-  - name: "💅 Format"
-    task:
-      prologue:
-        commands:
-          - checkout
-          - cache restore client-node-modules-$SEMAPHORE_GIT_BRANCH-$(checksum yarn.lock),client-node-modules-$SEMAPHORE_GIT_BRANCH,client-node-modules-master
-      jobs:
-        - name: Lint && prettier
-          commands:
-            - yarn add eslint-plugin-react-hooks -D -W
-            - yarn lint && yarn prettier -- --list-different
+  # - name: "🔗 Storybook link"
+  #   task:
+  #     secrets:
+  #       - name: paprika-env
+  #     prologue:
+  #       commands:
+  #         - checkout
+  #         - cache restore node-modules-$SEMAPHORE_GIT_BRANCH
+  #     jobs:
+  #       - name: Insert Storybook link into PR Body Message
+  #         commands:
+  #           - node scripts/storybookLink.js
+  # - name: "💅 Format"
+  #   task:
+  #     prologue:
+  #       commands:
+  #         - checkout
+  #         - cache restore client-node-modules-$SEMAPHORE_GIT_BRANCH-$(checksum yarn.lock),client-node-modules-$SEMAPHORE_GIT_BRANCH,client-node-modules-master
+  #     jobs:
+  #       - name: Lint && prettier
+  #         commands:
+  #           - yarn add eslint-plugin-react-hooks -D -W
+  #           - yarn lint && yarn prettier -- --list-different
 
-  - name: "♿️ Accessibility"
-    task:
-      prologue:
-        commands:
-          - checkout
-          - cache restore client-node-modules-$SEMAPHORE_GIT_BRANCH-$(checksum yarn.lock),client-node-modules-$SEMAPHORE_GIT_BRANCH,client-node-modules-master
-      jobs:
-        - name: Axe test
-          commands:
-            - yarn test:a11y
+  # - name: "♿️ Accessibility"
+  #   task:
+  #     prologue:
+  #       commands:
+  #         - checkout
+  #         - cache restore client-node-modules-$SEMAPHORE_GIT_BRANCH-$(checksum yarn.lock),client-node-modules-$SEMAPHORE_GIT_BRANCH,client-node-modules-master
+  #     jobs:
+  #       - name: Axe test
+  #         commands:
+  #           - yarn test:a11y
 
-  - name: "⚡️ Integration/Unit"
-    task:
-      prologue:
-        commands:
-          - checkout
-          - cache restore client-node-modules-$SEMAPHORE_GIT_BRANCH-$(checksum yarn.lock),client-node-modules-$SEMAPHORE_GIT_BRANCH,client-node-modules-master
-          - yarn
-      jobs:
-        - name: JEST
-          commands:
-            - yarn test
+  # - name: "⚡️ Integration/Unit"
+  #   task:
+  #     prologue:
+  #       commands:
+  #         - checkout
+  #         - cache restore client-node-modules-$SEMAPHORE_GIT_BRANCH-$(checksum yarn.lock),client-node-modules-$SEMAPHORE_GIT_BRANCH,client-node-modules-master
+  #         - yarn
+  #     jobs:
+  #       - name: JEST
+  #         commands:
+  #           - yarn test
 
-  - name: "⛰ E2E"
-    task:
-      prologue:
-        commands:
-          - checkout
-          - sudo apt-get -y install xvfb libgtk2.0-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2
-          - cache restore client-node-modules-$SEMAPHORE_GIT_BRANCH-$(checksum yarn.lock),client-node-modules-$SEMAPHORE_GIT_BRANCH,client-node-modules-master
-          - cache restore cypress-$SEMAPHORE_GIT_BRANCH
-          - sudo sysctl fs.inotify.max_user_watches=1048576
-      jobs:
-        - name: Cypress
-          commands:
-            - npx lerna bootstrap
-            - yarn
-            - yarn cypress:ci
+  # - name: "⛰ E2E"
+  #   task:
+  #     prologue:
+  #       commands:
+  #         - checkout
+  #         - sudo apt-get -y install xvfb libgtk2.0-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2
+  #         - cache restore client-node-modules-$SEMAPHORE_GIT_BRANCH-$(checksum yarn.lock),client-node-modules-$SEMAPHORE_GIT_BRANCH,client-node-modules-master
+  #         - cache restore cypress-$SEMAPHORE_GIT_BRANCH
+  #         - sudo sysctl fs.inotify.max_user_watches=1048576
+  #     jobs:
+  #       - name: Cypress
+  #         commands:
+  #           - npx lerna bootstrap
+  #           - yarn
+  #           - yarn cypress:ci
 
   - name: "🔎 Visual Regression"
     task:
@@ -92,7 +92,7 @@ blocks:
         - name: Screener
           env_vars:
             - name: SEMAPHORE_BUILD_NUMBER
-              value: $SEMAPHORE_WORKFLOW_ID
+              value: '${SEMAPHORE_WORKFLOW_ID}'
           commands:
             - npx lerna bootstrap
             - yarn storybook:build

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -95,6 +95,6 @@ blocks:
           commands:
             - npx lerna bootstrap
             - yarn storybook:build
-            - BRANCH_NAME=$SEMAPHORE_GIT_BRANCH REVISION=$SEMAPHORE_GIT_SHA SEMAPHORE_BUILD_NUMBER=$SEMAPHORE_WORKFLOW_ID yarn storybook:screener:ci
+            - BRANCH_NAME=$SEMAPHORE_GIT_BRANCH REVISION=$SEMAPHORE_GIT_SHA SEMAPHORE_BUILD_NUMBER=$SEMAPHORE_WORKFLOW_ID yarn storybook:screener
       secrets:
         - name: screener-api-key

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -90,12 +90,9 @@ blocks:
           - cache restore client-node-modules-$SEMAPHORE_GIT_BRANCH-$(checksum yarn.lock),client-node-modules-$SEMAPHORE_GIT_BRANCH,client-node-modules-master
       jobs:
         - name: Screener
-          env_vars:
-            - name: SEMAPHORE_BUILD_NUMBER
-              value: '${SEMAPHORE_WORKFLOW_ID}'
           commands:
             - npx lerna bootstrap
             - yarn storybook:build
-            - yarn storybook:screener:ci
+            - SEMAPHORE_BUILD_NUMBER=$SEMAPHORE_WORKFLOW_ID yarn storybook:screener:ci
       secrets:
         - name: screener-api-key

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -93,6 +93,6 @@ blocks:
           commands:
             - npx lerna bootstrap
             - yarn storybook:build
-            - BRANCH_NAME=$SEMAPHORE_GIT_BRANCH REVISION=$SEMAPHORE_GIT_PR_SHA SEMAPHORE_BUILD_NUMBER=$SEMAPHORE_WORKFLOW_ID yarn storybook:screener:ci
+            - BRANCH_NAME=$SEMAPHORE_GIT_BRANCH REVISION=$SEMAPHORE_GIT_SHA SEMAPHORE_BUILD_NUMBER=$SEMAPHORE_WORKFLOW_ID yarn storybook:screener:ci
       secrets:
         - name: screener-api-key

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "registrymock": "run-p -l registrymock:start registrymock:publish",
     "storybook:build": "build-storybook -s ./.storybook/public -c .storybook -o storybook-dist",
     "storybook:screener": "screener-storybook --conf screener.config.js",
+    "storybook:screener:ci": "CI=true SEMAPHORE=true screener-storybook --conf screener.config.js",
     "storybook:start": "start-storybook -p 9009 -c .storybook",
     "storybook:uploadserver": "node scripts/uploaderServer",
     "storybook": "run-p storybook:start storybook:uploadserver",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "registrymock": "run-p -l registrymock:start registrymock:publish",
     "storybook:build": "build-storybook -s ./.storybook/public -c .storybook -o storybook-dist",
     "storybook:screener": "screener-storybook --conf screener.config.js",
-    "storybook:screener:ci": "CI=true SEMAPHORE=true screener-storybook --conf screener.config.js",
     "storybook:start": "start-storybook -p 9009 -c .storybook",
     "storybook:uploadserver": "node scripts/uploaderServer",
     "storybook": "run-p storybook:start storybook:uploadserver",


### PR DESCRIPTION
### Purpose 🚀
Enable GitHub integration with Screener for Semaphore 2.0 builds.

### Notes ✏️
- Inspired by workaround by @danwu: https://github.com/acl-services/visualizer/pull/2823
- Native Semaphore 2.0 support in `screener-storybook` is waiting on: https://github.com/screener-io/screener-runner/pull/80
  Specifically, these lines: https://github.com/screener-io/screener-runner/blob/ca976779a22c940f0af0707f0e6959546d04b0ee/src/ci.js#L79-L81

### References 🔗
https://aclgrc.atlassian.net/browse/STAR-128
https://screener.io/v2/dashboard/H1OkdIZtV.acl-services-paprika/STAR-128--reintegrate-screener


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
