### PR TITLE
STAR-136 Allow tabIndex override for Buttons 🐐

### DIFF
--- a/packages/Button/src/Button.js
+++ b/packages/Button/src/Button.js
@@ -4,8 +4,7 @@ import RawButton from "@paprika/raw-button";
 import RefreshIcon from "@paprika/icon/lib/Refresh";
 import DownIcon from "@paprika/icon/lib/CaretDown";
 import { ShirtSizes } from "@paprika/helpers/lib/customPropTypes";
-// support for IE11
-import "@paprika/helpers/lib/dom/closest";
+import "@paprika/helpers/lib/dom/closest"; // support for IE11
 import buttonStyles, { iconStyles } from "./Button.styles";
 
 import Kinds from "./ButtonKinds";
@@ -84,7 +83,7 @@ const defaultProps = {
   onClick: () => {},
   role: "button",
   size: ShirtSizes.MEDIUM,
-  tabIndex: 0,
+  tabIndex: null,
 };
 
 const buttonPropTypes = {
@@ -151,6 +150,8 @@ const Button = React.forwardRef((props, ref) => {
     if (!isButtonDisabled) onClick(event);
   };
 
+  const bestTabIndex = isButtonDisabled && tabIndex === null ? -1 : tabIndex || 0;
+
   const buttonProps = {
     isDisabled: isButtonDisabled,
     kind,
@@ -165,7 +166,7 @@ const Button = React.forwardRef((props, ref) => {
     buttonProps.type = isSubmit ? "submit" : "button";
     if (role !== "button") buttonProps.role = role;
   } else {
-    buttonProps.tabIndex = isButtonDisabled ? -1 : tabIndex;
+    buttonProps.tabIndex = bestTabIndex;
     buttonProps.role = role;
   }
 

--- a/packages/Button/stories/examples/Basic.js
+++ b/packages/Button/stories/examples/Basic.js
@@ -28,6 +28,9 @@ const ExampleStory = () => (
       <Button onClick={clickHandler} isDisabled>
         disabled button
       </Button>
+      <Button onClick={clickHandler} isDisabled isSemantic={false} tabIndex="0">
+        disabled but tabbable
+      </Button>
     </p>
     <Rule />
     <p>

--- a/packages/Button/test/Button.spec.js
+++ b/packages/Button/test/Button.spec.js
@@ -24,13 +24,13 @@ describe("Button", () => {
     expect(getByText(/happy button/i)).toBeInTheDocument();
     expect(container.querySelector("button")).toBeInTheDocument();
     expect(container.querySelector('[type="button"]')).toBeInTheDocument();
-    expect(container.querySelector('[tabindex="0"]')).toBeInTheDocument();
   });
 
   it("Renders a span when isSemantic=false", () => {
     const { container } = renderComponent({ isSemantic: false });
 
     expect(container.querySelector("span[role=button]")).toBeInTheDocument();
+    expect(container.querySelector('[tabindex="0"]')).toBeInTheDocument();
   });
 
   it("Renders with custom props", () => {

--- a/packages/Checkbox/src/Checkbox.js
+++ b/packages/Checkbox/src/Checkbox.js
@@ -73,22 +73,21 @@ const Checkbox = props => {
     size,
   };
 
-  const inputProps = {};
+  const inputProps = {
+    "aria-describedby": ariaDescribedBy,
+    checked: checkedState === CHECKED,
+    disabled: isDisabled,
+    id: checkboxId,
+    onChange,
+    ref: inputRef,
+    tabIndex,
+    type: "checkbox",
+  };
   if (a11yText) inputProps["aria-label"] = a11yText;
 
   return (
     <div data-pka-anchor="checkbox" css={checkboxStyles} {...styleProps} {...moreProps}>
-      <input
-        aria-describedby={ariaDescribedBy}
-        checked={checkedState === CHECKED}
-        disabled={isDisabled}
-        id={checkboxId}
-        ref={inputRef}
-        type="checkbox"
-        onChange={onChange}
-        tabIndex={tabIndex}
-        {...inputProps}
-      />
+      <input {...inputProps} />
       <label htmlFor={checkboxId}>
         {children}
         <CheckIcon className="checkbox-icon" aria-hidden data-pka-anchor="checkbox.icon.check" />

--- a/packages/Checkbox/stories/examples/CheckboxGrouping.js
+++ b/packages/Checkbox/stories/examples/CheckboxGrouping.js
@@ -32,11 +32,13 @@ const CheckboxExample = props => {
         <Checkbox {...props} onChange={handleChange} checkedState={checkedState}>
           Locavore
         </Checkbox>
-        <Checkbox {...props} onChange={handleChange} checkedState={checkedState} />
-        <Checkbox {...props} onChange={handleChange} checkedState={checkedState}>
-          &nbsp;
+        <Checkbox {...props} tabIndex="-1" onChange={handleChange} checkedState={checkedState}>
+          Untabbable
         </Checkbox>
         <Checkbox {...props} onChange={handleChange} checkedState={checkedState} />
+        <Checkbox {...props} isDisabled onChange={handleChange} checkedState={checkedState}>
+          Disabled
+        </Checkbox>
       </div>
     </div>
   );

--- a/packages/Radio/src/Radio.js
+++ b/packages/Radio/src/Radio.js
@@ -96,12 +96,14 @@ function Radio(props) {
     onKeyDown: handleKeyDown,
     onKeyUp: handleKeyUp,
     ref: inputRef,
+    tabIndex,
     type: "radio",
   };
   if (a11yText) inputProps["aria-label"] = a11yText;
+
   return (
     <div data-pka-anchor="radio" css={radioStyles} {...styleProps} {...moreProps}>
-      <input {...inputProps} tabIndex={tabIndex} />
+      <input {...inputProps} />
       <label onKeyUp={handleKeyUp} className={canDeselect ? "deselectable" : ""} htmlFor={radioId}>
         {children}
 

--- a/packages/RawButton/src/RawButton.js
+++ b/packages/RawButton/src/RawButton.js
@@ -37,7 +37,7 @@ const defaultProps = {
   hasInsetFocusStyle: false,
   onClick: () => {},
   role: "button",
-  tabIndex: 0,
+  tabIndex: null,
 };
 
 const RawButton = React.forwardRef((props, ref) => {
@@ -77,15 +77,7 @@ const RawButton = React.forwardRef((props, ref) => {
     }
   };
 
-  const getTabIndex = () => {
-    if (tabIndex >= 0) {
-      return tabIndex;
-    }
-    if (isDisabled) {
-      return -1;
-    }
-    return tabIndex;
-  };
+  const bestTabIndex = isDisabled && tabIndex === null ? -1 : tabIndex || 0;
 
   return (
     <span
@@ -97,7 +89,7 @@ const RawButton = React.forwardRef((props, ref) => {
       onKeyDown={handleKeyDown}
       onKeyUp={handleKeyUp}
       ref={rawButtonRef}
-      tabIndex={getTabIndex()}
+      tabIndex={bestTabIndex}
       {...moreProps}
     >
       {children}

--- a/packages/RawButton/stories/examples/Basic.js
+++ b/packages/RawButton/stories/examples/Basic.js
@@ -45,6 +45,12 @@ const ExampleStory = () => {
           Disabled RawButton
         </RawButton>
       </p>
+      <Rule />
+      <p>
+        <RawButton isDisabled tabIndex="0" onClick={clickHandler}>
+          Disabled but tabbable
+        </RawButton>
+      </p>
       {breaklines(34)}
       ...fin.
     </Story>


### PR DESCRIPTION
### Purpose 🚀
Allow disabled `<Buttons>` (with `isSemantic={false}`) to be tabbable if `tabIndex` prop is supplied.

### Notes ✏️
- Turns out a native `<button>` with a `disabled` attribute cannot be focussed, even with `tabindex=0`.  So this approach will only work with `isSemantic={false}` `<Buttons>`.
- Also applied same code to `<RawButton>`.
- Also applied a symmetrical coding approach to `<Checkbox>` and `<Radio>`.
- Added a demonstration of `tabindex` propagation to Checkbox Group story in Storybook.

### Updates 📦
- [x] PATCH (bug fix) change to `Button`, `RawButton`, `Checkbox`, `Radio`

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/STAR-136--button-tabindex-override


### References 🔗
https://aclgrc.atlassian.net/browse/STAR-136
https://aclgrc.atlassian.net/browse/BOT-2067

<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
