### PR TITLE
PD-14384 add light orange and light blue for pill

### DIFF
--- a/packages/Pill/src/Pill.js
+++ b/packages/Pill/src/Pill.js
@@ -4,7 +4,7 @@ import RawButton from "@paprika/raw-button";
 import { ShirtSizes } from "@paprika/helpers/lib/customPropTypes";
 import pillStyles, { pillTextStyles } from "./Pill.styles";
 
-export const pillColors = ["black", "blue", "green", "grey", "orange"];
+export const pillColors = ["black", "blue", "green", "grey", "orange", "lightBlue", "lightOrange"];
 export const severityPillColors = ["noRisk", "lowRisk", "mediumRisk", "highRisk"];
 
 const propTypes = {

--- a/packages/Pill/src/Pill.styles.js
+++ b/packages/Pill/src/Pill.styles.js
@@ -29,6 +29,16 @@ const pillColorStyles = {
     color: ${tokens.color.black};
   `,
 
+  lightBlue: css`
+    background: ${tokens.color.blueLighten50};
+    color: ${tokens.color.blueDarken20};
+  `,
+
+  lightOrange: css`
+    background: ${tokens.color.orangeLighten40};
+    color: ${tokens.color.orangeDarken20};
+  `,
+
   lowRisk: css`
     background: #299a7a;
   `,

--- a/packages/Pill/stories/examples/SizesColors.js
+++ b/packages/Pill/stories/examples/SizesColors.js
@@ -15,8 +15,10 @@ const SizesColorsExample = () => (
     <Pill pillColor="black">Black pill</Pill>
     <Pill pillColor="grey">Grey pill</Pill>
     <Pill pillColor="blue">Blue pill</Pill>
+    <Pill pillColor="lightBlue">Light blue pill</Pill>
     <Pill pillColor="green">Green pill</Pill>
     <Pill pillColor="orange">Orange pill</Pill>
+    <Pill pillColor="lightOrange">Light orange pill</Pill>
     <Pill pillColor="noRisk">No risk</Pill>
     <Pill pillColor="lowRisk">Low risk</Pill>
     <Pill pillColor="mediumRisk">Medium risk</Pill>


### PR DESCRIPTION
### Purpose 🚀
- add light orange, light blue pill color to pill

### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [x] MINOR (backward compatible) change to _Pill_
- [ ] PATCH (bug fix) change to _these packages_

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/PD-14384-fix-pill-color