### PR TITLE
PD-14427 Fix Button.Link props

### DIFF
--- a/packages/Button/src/Button.js
+++ b/packages/Button/src/Button.js
@@ -13,12 +13,6 @@ const propTypes = {
   /** Descriptive a11y text for assistive technologies. By default, text from children node will be used. */
   a11yText: PropTypes.string,
 
-  /** If click the button, we need a href (url) to open a new tab  */
-  href: PropTypes.string,
-
-  /** If click the button, it will open a new tab. */
-  isOpenNewTab: PropTypes.bool,
-
   /** If click events are allowed to propagate up the DOM tree. */
   canPropagate: PropTypes.bool,
 
@@ -70,8 +64,6 @@ const defaultProps = {
   canPropagate: true,
   children: null,
   icon: null,
-  href: null,
-  isOpenNewTab: true,
   isActive: false,
   isDisabled: false,
   isDropdown: false,
@@ -111,11 +103,9 @@ const Button = React.forwardRef((props, ref) => {
     isDropdown,
     isPending,
     isSemantic,
-    isOpenNewTab,
     isSubmit,
     kind,
     onClick,
-    href,
     role,
     tabIndex,
     ...moreProps

--- a/packages/Button/src/LinkButton.js
+++ b/packages/Button/src/LinkButton.js
@@ -5,6 +5,7 @@ import Button from "./Button";
 import buttonStyles from "./Button.styles";
 
 const LinkPropTypes = {
+  a11yText: PropTypes.string,
   children: PropTypes.node.isRequired,
   href: PropTypes.string.isRequired,
   isOpenNewTab: PropTypes.bool,
@@ -13,20 +14,30 @@ const LinkPropTypes = {
 };
 
 const LinkDefaultProps = {
+  a11yText: null,
   isOpenNewTab: true,
   kind: Button.Kinds.DEFAULT,
   size: ShirtSizes.MEDIUM,
 };
 
-const LinkButton = React.forwardRef((props, ref) => {
-  const isOpenNewTabProps = {};
-  if (props.isOpenNewTab) {
-    isOpenNewTabProps.target = "_blank";
-    isOpenNewTabProps.rel = "noopener noreferrer";
-  }
+const isOpenNewTabProps = {
+  target: "_blank",
+  rel: "noopener noreferrer",
+};
+
+const LinkButton = React.forwardRef(({ a11yText, children, href, isOpenNewTab, kind, size, ...moreProps }, ref) => {
   return (
-    <a css={buttonStyles} {...props} ref={ref} href={props.href} {...isOpenNewTabProps}>
-      {props.children}
+    <a
+      css={buttonStyles}
+      ref={ref}
+      href={href}
+      aria-label={a11yText}
+      kind={kind}
+      size={size}
+      {...(isOpenNewTab ? isOpenNewTabProps : {})}
+      {...moreProps}
+    >
+      {children}
     </a>
   );
 });

--- a/packages/Button/stories/examples/Basic.js
+++ b/packages/Button/stories/examples/Basic.js
@@ -28,7 +28,7 @@ const ExampleStory = () => (
       <Button onClick={clickHandler} isDisabled>
         disabled button
       </Button>
-      <Button onClick={clickHandler} isDisabled isSemantic={false} tabIndex="0">
+      <Button onClick={clickHandler} isDisabled isSemantic={false} tabIndex={0}>
         disabled but tabbable
       </Button>
     </p>

--- a/packages/RawButton/stories/examples/Basic.js
+++ b/packages/RawButton/stories/examples/Basic.js
@@ -47,7 +47,7 @@ const ExampleStory = () => {
       </p>
       <Rule />
       <p>
-        <RawButton isDisabled tabIndex="0" onClick={clickHandler}>
+        <RawButton isDisabled tabIndex={0} onClick={clickHandler}>
           Disabled but tabbable
         </RawButton>
       </p>


### PR DESCRIPTION
### Purpose 🚀

`<Button.Link />` doesn't render any extra props on the element, and missing `a11yText`

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_
- [x] PATCH (bug fix) change to `@paprika/button` `@paprika/raw-button`

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/PD-14427-Fix-Button.Link

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
