### PR TITLE
STAR-185 chore(DataGrid): adding autofocus prop to control the focus …

### DIFF
--- a/packages/DataGrid/src/DataGrid.js
+++ b/packages/DataGrid/src/DataGrid.js
@@ -12,28 +12,30 @@ import Basement, { End } from "./components/Basement";
 import InfiniteScroll from "./components/InfiniteScroll";
 
 const propTypes = {
+  autofocus: PropTypes.bool,
   children: PropTypes.node.isRequired,
   data: PropTypes.arrayOf(PropTypes.shape({})),
   height: PropTypes.number,
   onClick: PropTypes.func,
-  onPressEnter: PropTypes.func,
   onKeyDown: PropTypes.func,
-  onRowChecked: PropTypes.func,
+  onPressEnter: PropTypes.func,
   onPressShiftSpaceBar: PropTypes.func,
   onPressSpaceBar: PropTypes.func,
+  onRowChecked: PropTypes.func,
   rowHeight: PropTypes.number,
   width: PropTypes.number,
 };
 
 const defaultProps = {
+  autofocus: true,
   data: [],
   height: 600,
   onClick: null,
-  onPressEnter: null,
   onKeyDown: () => {},
-  onRowChecked: () => {},
+  onPressEnter: null,
   onPressShiftSpaceBar: null,
   onPressSpaceBar: null,
+  onRowChecked: () => {},
   rowHeight: 36,
   width: null,
 };
@@ -50,15 +52,16 @@ const innerElementTypeMainGrid = React.forwardRef((props, ref) => (
 
 const DataGrid = React.forwardRef((props, ref) => {
   const {
+    autofocus,
     children,
     data,
     height,
     onClick,
-    onPressEnter,
     onKeyDown,
-    onRowChecked,
+    onPressEnter,
     onPressShiftSpaceBar,
     onPressSpaceBar,
+    onRowChecked,
     rowHeight,
     width,
     ...moreProps
@@ -313,7 +316,7 @@ const DataGrid = React.forwardRef((props, ref) => {
     refPrevLastScrollHeight.current = refScrollGrid.current && refScrollGrid.current.scrollHeight;
   }, []);
 
-  React.useEffect(() => {
+  function focusDataGrid() {
     // this is required to readjust the active highlight
     // after any rerender
     if (
@@ -323,8 +326,11 @@ const DataGrid = React.forwardRef((props, ref) => {
     ) {
       if (refScrollGrid.current) refScrollGrid.current.scrollTo(0, refScrollGrid.current.scrollTop + 1);
     }
-    restoreHighlightFocus();
-  });
+
+    if (autofocus) {
+      restoreHighlightFocus();
+    }
+  }
 
   React.useImperativeHandle(
     ref,
@@ -425,6 +431,8 @@ const DataGrid = React.forwardRef((props, ref) => {
   }, [deemphasizeRow]);
 
   if (data.length === 0) return null;
+
+  focusDataGrid();
 
   return (
     <>

--- a/packages/DataGrid/src/hooks/useGridEventHandler.js
+++ b/packages/DataGrid/src/hooks/useGridEventHandler.js
@@ -445,12 +445,14 @@ export default function useGridEventHandler({
 
   const restoreHighlightFocus = React.useCallback(() => {
     if (cell.current && (cell.current.columnIndex !== null && cell.current.rowIndex !== null)) {
-      const $cell = $getCell();
+      window.requestAnimationFrame(() => {
+        const $cell = $getCell();
 
-      if (!$cell) return;
-      setRefPrevCell();
-      setHighlight();
-      focus($cell);
+        if (!$cell) return;
+        setRefPrevCell();
+        setHighlight();
+        focus($cell);
+      });
     }
   }, [$getCell, setHighlight, setRefPrevCell]);
 

--- a/packages/DataGrid/stories/DataGrid.autofocus.stories.js
+++ b/packages/DataGrid/stories/DataGrid.autofocus.stories.js
@@ -1,0 +1,101 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import Button from "@paprika/button";
+import * as Sbook from "storybook/assets/styles/common.styles";
+import DataGrid from "../src";
+
+const _DATA_ = [
+  {
+    country: "Austria",
+    name: "Josef Bican ‡",
+    goals: 805,
+    status: "inactive",
+    joined: "12/12/2019",
+    description: `Puppy kitty ipsum dolor sit good dog foot stick canary. Teeth Mittens furry treats fish.`,
+    link: "https://wegalvanize.com",
+  },
+  {
+    country: "Brazil",
+    name: "Romário",
+    goals: 772,
+    status: "inactive",
+    joined: "08/11/2019",
+    description: `Puppy kitty ipsum dolor sit good dog foot stick canary. Teeth Mittens furry treats fish.`,
+    link: "https://wegalvanize.com",
+  },
+  {
+    country: "Brazil",
+    name: "Pelé",
+    goals: 767,
+    status: "inactive",
+    joined: "04/01/2014",
+    description: `Puppy kitty ipsum dolor sit good dog foot stick canary. Teeth Mittens furry treats fish.`,
+    link: "https://wegalvanize.com",
+  },
+];
+
+export function App() {
+  const [data, setData] = React.useState(_DATA_);
+  const [autofocus, setAutofocus] = React.useState(true);
+  const counter = React.useRef(0);
+
+  return (
+    <Sbook.Story>
+      <p>
+        Autofocus will grab the focus after a render happened on the table, there a cases where you wont to have this
+        prop enable and you will prefer to control the focus manually
+      </p>
+      <p>To see how this works:</p>
+      <ol>
+        <li>Click on any select</li>
+        <li>Select if you want to have autofocus enable or not</li>
+        <li>Click add row</li>
+      </ol>
+      <p>
+        If you have autofocus enable the DataGrid will reclaim the focus and will focus the latest cell where the focus
+        was.
+        <br />
+        in case you didnt checked the autofocus the table shouldnt claim the focus and the focus should remain on the
+        checkbox
+      </p>
+      autofocus:
+      <input
+        type="checkbox"
+        checked={autofocus}
+        onChange={() => {
+          setAutofocus(prev => !prev);
+        }}
+      />
+      <br />
+      add a row:{" "}
+      <Button
+        size="small"
+        onClick={() => {
+          counter.current += 1;
+          setData(prevData => {
+            return [
+              ...prevData,
+              {
+                country: `Mock ${counter.current}`,
+                name: `Mock ${counter.current}`,
+                goals: 767,
+                status: "inactive",
+                joined: "04/01/2014",
+                description: `Puppy kitty ipsum dolor sit good dog foot stick canary. Teeth Mittens furry treats fish.`,
+                link: "https://wegalvanize.com",
+              },
+            ];
+          });
+        }}
+      >
+        +
+      </Button>
+      <hr />
+      <DataGrid data={data} autofocus={autofocus}>
+        <DataGrid.ColumnDefinition header="Name" cell="name" />
+      </DataGrid>
+    </Sbook.Story>
+  );
+}
+
+storiesOf("DataGrid / regular", module).add("autofocus", () => <App />);


### PR DESCRIPTION
…on the DataGrid

 / 🦄.

### Purpose 🚀
This allow the DataGrid to have control over the autofocus prop. So far autofocus is always on and can't be controlled. 

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [x] MINOR (backward compatible) change to DataGrid. 
- [] PATCH (bug fix) change to _these packages_

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/STAR-185-DataGrid-autofocus/?path=/story/datagrid-regular--autofocus

### Screenshots 📸

<img width="702" alt="Screen Shot 2020-03-26 at 5 10 08 PM" src="https://user-images.githubusercontent.com/19418590/77708222-b7e7a800-6f84-11ea-98fe-bb6dfe0ae5f9.png">


### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
