### PR TITLE
STAR-192 bug(ListBox) fixing a bugh on a combination of divider + fil…

### DIFF
--- a/packages/ListBox/src/components/Divider/Divider.js
+++ b/packages/ListBox/src/components/Divider/Divider.js
@@ -18,7 +18,7 @@ const defaultProps = {
 
 export default function Divider(props) {
   return (
-    <li aria-hidden="true" data-pka-anchor="listbox.divider" css={dividerCSS} hasChildren={!!props.children}>
+    <li aria-hidden="true" data-pka-anchor="listbox.divider" css={dividerCSS}>
       {props.children}
     </li>
   );

--- a/packages/ListBox/src/components/Divider/Divider.styles.js
+++ b/packages/ListBox/src/components/Divider/Divider.styles.js
@@ -27,5 +27,5 @@ export const dividerCSS = css`
 
   ${stylers.fontSize(-1)};
 
-  ${({ hasChildren }) => hasChildren && textDividerStyles}
+  ${textDividerStyles}
 `;

--- a/packages/ListBox/src/components/Filter/helpers.js
+++ b/packages/ListBox/src/components/Filter/helpers.js
@@ -18,12 +18,7 @@ export const filter = ({ state, textSearchValue }) => {
         return label.match(filterRegExp);
       }
 
-      throw new Error(
-        `Textsearch: ${textSearchValue} during ${options[key]}.
-        ListBox.Filter  filter: <ListBox.Option /> need to have
-        a string as a children or please provide a label prop
-        <ListBox.Option label='yourOptionDescription' />.`
-      );
+      return false;
     });
 
     if (!filteredOptions.length) {

--- a/packages/ListBox/src/components/Options/helpers/options.js
+++ b/packages/ListBox/src/components/Options/helpers/options.js
@@ -19,6 +19,7 @@ export function toggleMultipleOption({ activeOptionIndex, dispatch, onChangeCont
 
 export function selectMultipleOption({ activeOptionIndex, dispatch, isSelected, onChange = null, onChangeContext }) {
   const onChangeFn = onChange || invokeOnChange(onChangeContext, "listbox:option-selected");
+
   dispatch({
     type: useListBox.types.selectMultipleOption,
     payload: { activeOptionIndex, onChangeFn, isSelected },

--- a/packages/ListBox/src/store/reducer.js
+++ b/packages/ListBox/src/store/reducer.js
@@ -46,7 +46,7 @@ export default function reducer(state, { type, payload }) {
     }
 
     case useListBox.types.selectMultipleOption: {
-      const { activeOptionIndex, isSelected, isOpen } = payload;
+      const { activeOptionIndex, isSelected } = payload;
       let selectedOptions = [];
 
       if (isSelected) {
@@ -63,7 +63,6 @@ export default function reducer(state, { type, payload }) {
       return {
         ...state,
         activeOption: activeOptionIndex,
-        isOpen,
         onChangeFn: payload.onChangeFn,
         selectedOptions,
       };
@@ -79,8 +78,7 @@ export default function reducer(state, { type, payload }) {
 
     case useListBox.types.toggleMultipleOption: {
       const selectedOptionsArray = state.selectedOptions.slice();
-      const { activeOptionIndex } = payload;
-
+      const { activeOptionIndex, onChangeFn } = payload;
       if (selectedOptionsArray.includes(activeOptionIndex)) {
         const index = selectedOptionsArray.indexOf(activeOptionIndex);
         selectedOptionsArray.splice(index, 1);
@@ -91,8 +89,7 @@ export default function reducer(state, { type, payload }) {
       return {
         ...state,
         activeOption: activeOptionIndex,
-        isOpen: true,
-        onChangeFn: payload.onChangeFn,
+        onChangeFn,
         selectedOptions: selectedOptionsArray,
       };
     }

--- a/packages/ListBox/stories/examples/multi.js
+++ b/packages/ListBox/stories/examples/multi.js
@@ -222,3 +222,56 @@ export const TriggerIsHidden = () => {
     </ListBox>
   );
 };
+
+const AppFullOptionControlled = () => {
+  const [options, setOptions] = React.useState([
+    { label: "Black Panther", isSelected: false },
+    { label: "Wonder Woman", isSelected: false },
+    { label: "Spiderman", isSelected: false },
+    { label: "The Incredibles", isSelected: false },
+    { label: "Thor", isSelected: false },
+    { label: "Batman", isSelected: false },
+    { label: "Iron Man", isSelected: false },
+    { label: "Doctor Strange", isSelected: false },
+  ]);
+  const [isFixedOptionSelected, setIsFixedOptionSelected] = React.useState(false);
+
+  const handleChange = (indexes, listBoxOptions) => {
+    if (indexes.includes(0)) {
+      // this only work because we know there is none other option or divider above this option
+      setIsFixedOptionSelected(true);
+    }
+
+    const cloneArray = options.slice(0);
+    indexes.forEach(index => {
+      const i = options.findIndex(item => item.label === listBoxOptions[index].value);
+      if (i >= 0) {
+        cloneArray[i].isSelected = true;
+      }
+    });
+
+    setOptions(cloneArray);
+  };
+
+  console.log("options", options);
+
+  return (
+    <div className="App">
+      <ListBox onChange={handleChange} isMulti>
+        <ListBox.Filter />
+        <ListBox.Option value="Fixed option" isSelected={isFixedOptionSelected}>
+          Fixed option
+        </ListBox.Option>
+        <ListBox.Divider />
+        {options.map(o => (
+          <ListBox.Option label={o.label} value={o.label} key={o.label} isSelected={o.isSelected}>
+            {o.label}
+          </ListBox.Option>
+        ))}
+      </ListBox>
+    </div>
+  );
+};
+export const FullyOptionControlledWithFilter = () => {
+  return <AppFullOptionControlled />;
+};

--- a/packages/ListBox/stories/multi.stories.js
+++ b/packages/ListBox/stories/multi.stories.js
@@ -16,6 +16,9 @@ storiesOf("ListBox / multi", module).add("With Groups and have preselected optio
 ));
 storiesOf("ListBox / multi", module).add("Controlled listbox", () => <Multi.ControlledIsSelected />);
 storiesOf("ListBox / multi", module).add("UnControlled defaultIsSelected listbox", () => <Multi.DefaultIsSelected />);
+storiesOf("ListBox / multi", module).add("Fully Controlled with Filter", () => (
+  <Multi.FullyOptionControlledWithFilter />
+));
 storiesOf("ListBox / multi", module).add("Trigger is hidden when isInline", () => (
   <Story>
     <Multi.TriggerIsHidden />


### PR DESCRIPTION
…ter + controlled

 / 🦄.

### Purpose 🚀
Fixed #476 
This issue has three parts:

1. From the codesandbox example https://codesandbox.io/s/beautiful-platform-jlpzo 
 on the `handleChange`, the iteration part assumes that the Listbox children count matches the children that were sent on the ListBox.Options, but this it is not true. the `onChange` 
method of the ListBox Provides and indexes as first argument and options arrays as the second argument. 
The options provided by the ListBox !== in length than the one in the consumer side, the ListBox also count the `ListBox.Divider` as an Item, therefore you should always do the calculation over the indexes and options arrays provided by the array.

2.- The Divider is not appearing, this has been fixed again and screen test has been added.  

3.- Closing the listbox-multi whenever an option its clicked, this was a bug introduced when we fixed the scroll behaviour on all ListBox, has been resolved removing the `isOpen` prop that was set to `undefined` due to the previous changes. 

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_
- [x] PATCH (bug fix) change to _these packages_

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/STAR-192-listbox-controlled-filter

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
