### PR TITLE
UX-738 DropdownMenu / Confirmation propagation cancellation 🐐

### DIFF
--- a/packages/Confirmation/src/Confirmation.js
+++ b/packages/Confirmation/src/Confirmation.js
@@ -116,23 +116,25 @@ const Confirmation = props => {
           {body && <div css={confirmBodyStyles}>{body}</div>}
           <div css={confirmFooterStyles}>
             <Button
+              canPropagate={false}
+              data-pka-anchor="confirmation.confirm-button"
               isPending={isPending}
               isSemantic={false}
-              ref={confirmButtonRef}
               kind={confirmButtonType}
-              size={buttonSize}
               onClick={handleOnConfirm}
-              data-pka-anchor="confirmation.confirm-button"
+              ref={confirmButtonRef}
+              size={buttonSize}
             >
               {confirmLabel}
             </Button>
             <Button
+              canPropagate={false}
+              data-pka-anchor="confirmation.cancel-button"
               isDisabled={isPending}
               isSemantic={false}
               kind={Button.Kinds.MINOR}
-              size={buttonSize}
               onClick={handleCloseConfirm}
-              data-pka-anchor="confirmation.cancel-button"
+              size={buttonSize}
             >
               {I18n.t("actions.cancel")}
             </Button>

--- a/packages/DropdownMenu/src/components/Item/Item.js
+++ b/packages/DropdownMenu/src/components/Item/Item.js
@@ -55,15 +55,18 @@ const Item = props => {
   };
 
   const itemProps = {
-    onClick: renderConfirmation !== null ? onShowConfirmation : handleClickItem,
-    role: "menuitem",
+    canPropagate: false,
     "data-pka-anchor": "dropdown.item",
-    onKeyDown,
+    hasInsetFocusStyle: true,
     isDestructive,
+    onClick: renderConfirmation !== null ? onShowConfirmation : handleClickItem,
+    onKeyDown,
+    role: "menuitem",
+    tabIndex: 0,
   };
 
   return (
-    <RawButton tabIndex={0} hasInsetFocusStyle css={ItemStyles} {...itemProps} {...moreProps}>
+    <RawButton css={ItemStyles} {...itemProps} {...moreProps}>
       {children}
     </RawButton>
   );

--- a/packages/DropdownMenu/src/components/LinkItem/LinkItem.js
+++ b/packages/DropdownMenu/src/components/LinkItem/LinkItem.js
@@ -26,24 +26,21 @@ const LinkItem = props => {
   const I18n = useI18n();
 
   const linkItemProps = {
-    role: "menuitem",
     "data-pka-anchor": "dropdown.item",
     href: link,
     onKeyDown,
+    role: "menuitem",
     ...moreProps,
   };
 
   if (isExternal) {
+    linkItemProps["aria-label"] = I18n.t("dropdownMenu.isExternal", { link: children });
     linkItemProps.target = "_blank";
     linkItemProps.rel = "noopener noreferrer";
   }
 
   return (
-    <a
-      aria-label={isExternal ? I18n.t("dropdownMenu.isExternal", { link: children }) : ""}
-      css={linkItemStyles}
-      {...linkItemProps}
-    >
+    <a css={linkItemStyles} {...linkItemProps}>
       {children}
     </a>
   );


### PR DESCRIPTION
### Purpose 🚀
Don't let click events that occur on the buttons inside the `<DropdownMenu.Item>` + `<Confirmation>` propagate – this has undesired consequences when those events dismiss the `<Popover>` and the event bubbles up the element that was underneath.

### Notes ✏️
- Added `canPropagate={false}` props to `<Buttons>` and `<RawButton>` in `<Confirmation>` + `<DropdownMenu>`.

### Updates 📦
- [x] MINOR (backward compatible) change to `@paprika/dropdown-menu`, `@paprika/confirmation`.

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/UX-738--dropdown-confirmation-propagation-cancelation

### References 🔗
https://aclgrc.atlassian.net/browse/UX-738


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
