### PR TITLE
SNP-131 Listbox small fix

### DIFF
--- a/packages/ListBox/src/ListBox.js
+++ b/packages/ListBox/src/ListBox.js
@@ -88,7 +88,7 @@ export function ListBox(props) {
   return (
     <React.Fragment>
       {trigger}
-      <Content onCancel={footer ? footer.props.onClickCancel : null}>
+      <Content onCancelFooter={footer ? footer.props.onClickCancel : null}>
         <Box {...box.props}>
           {filter}
           <List height={height}>

--- a/packages/ListBox/src/ListBox.js
+++ b/packages/ListBox/src/ListBox.js
@@ -88,7 +88,7 @@ export function ListBox(props) {
   return (
     <React.Fragment>
       {trigger}
-      <Content>
+      <Content onCancel={footer ? footer.props.onClickCancel : null}>
         <Box {...box.props}>
           {filter}
           <List height={height}>

--- a/packages/ListBox/src/components/Content/Content.js
+++ b/packages/ListBox/src/components/Content/Content.js
@@ -9,13 +9,13 @@ import { ContentStyled } from "./Content.styles";
 
 const propTypes = {
   children: PropTypes.node.isRequired,
-  onCancel: PropTypes.func,
+  onCancelFooter: PropTypes.func,
 };
 const defaultProps = {
-  onCancel: null,
+  onCancelFooter: null,
 };
 
-const handleBlur = (state, dispatch, onCancel) => () => {
+const handleBlur = (state, dispatch, onCancelFooter) => () => {
   const { refListBoxContainer } = state;
 
   if (state.isDisabled) {
@@ -42,7 +42,7 @@ const handleBlur = (state, dispatch, onCancel) => () => {
 
       if (state.hasFooter) {
         dispatch({ type: useListBox.types.cancel });
-        if (onCancel) onCancel();
+        if (onCancelFooter) onCancelFooter();
       }
     }
   });
@@ -78,7 +78,7 @@ export default function Content(props) {
 
   return (
     <Popover.Content
-      onBlur={handleBlur(state, dispatch, props.onCancel)}
+      onBlur={handleBlur(state, dispatch, props.onCancelFooter)}
       ref={refListBoxContainer}
       {...getDOMAttributesForListBoxContainer()}
       onKeyDown={handleKeyboardKeys({ state, dispatch, onChangeContext })}

--- a/packages/ListBox/src/components/Content/Content.js
+++ b/packages/ListBox/src/components/Content/Content.js
@@ -9,10 +9,13 @@ import { ContentStyled } from "./Content.styles";
 
 const propTypes = {
   children: PropTypes.node.isRequired,
+  onCancel: PropTypes.func,
 };
-const defaultProps = {};
+const defaultProps = {
+  onCancel: null,
+};
 
-const handleBlur = (state, dispatch) => () => {
+const handleBlur = (state, dispatch, onCancel) => () => {
   const { refListBoxContainer } = state;
 
   if (state.isDisabled) {
@@ -39,6 +42,7 @@ const handleBlur = (state, dispatch) => () => {
 
       if (state.hasFooter) {
         dispatch({ type: useListBox.types.cancel });
+        if (onCancel) onCancel();
       }
     }
   });
@@ -74,7 +78,7 @@ export default function Content(props) {
 
   return (
     <Popover.Content
-      onBlur={handleBlur(state, dispatch)}
+      onBlur={handleBlur(state, dispatch, props.onCancel)}
       ref={refListBoxContainer}
       {...getDOMAttributesForListBoxContainer()}
       onKeyDown={handleKeyboardKeys({ state, dispatch, onChangeContext })}

--- a/packages/ListBox/src/hooks/hooks.js
+++ b/packages/ListBox/src/hooks/hooks.js
@@ -96,7 +96,9 @@ export function useOnScrolled() {
     if (!state.refListBox.current || state.activeOption === null) return;
 
     const $box = state.refListBox.current;
-    const $option = document.getElementById(state.options[state.activeOption].id);
+    const $option = state.options[state.activeOption]
+      ? document.getElementById(state.options[state.activeOption].id)
+      : null;
 
     if ($box && $option) {
       const rectBox = $box.getBoundingClientRect();

--- a/packages/ListBox/stories/examples/multi.js
+++ b/packages/ListBox/stories/examples/multi.js
@@ -223,17 +223,15 @@ export const TriggerIsHidden = () => {
   );
 };
 
+const initialOptions = [
+  { id: 1, label: "Black Panther", isSelected: false },
+  { id: 2, label: "Wonder Woman", isSelected: false },
+  { id: 3, label: "Spiderman", isSelected: false },
+  { id: 4, label: "The Incredibles", isSelected: false },
+];
+
 const AppFullOptionControlled = () => {
-  const [options, setOptions] = React.useState([
-    { label: "Black Panther", isSelected: false },
-    { label: "Wonder Woman", isSelected: false },
-    { label: "Spiderman", isSelected: false },
-    { label: "The Incredibles", isSelected: false },
-    { label: "Thor", isSelected: false },
-    { label: "Batman", isSelected: false },
-    { label: "Iron Man", isSelected: false },
-    { label: "Doctor Strange", isSelected: false },
-  ]);
+  const [options, setOptions] = React.useState(initialOptions);
   const [isFixedOptionSelected, setIsFixedOptionSelected] = React.useState(false);
 
   const handleChange = (indexes, listBoxOptions) => {
@@ -253,12 +251,22 @@ const AppFullOptionControlled = () => {
     setOptions(cloneArray);
   };
 
-  console.log("options", options);
+  const handleFilter = filter => {
+    if (filter.search) {
+      setOptions([
+        { id: 2, label: "Wonder Woman", isSelected: false },
+        { id: 5, label: "Filtered item 1", isSelected: false },
+        { id: 6, label: "Filtered item 2", isSelected: false },
+      ]);
+    } else {
+      setOptions(initialOptions);
+    }
+  };
 
   return (
     <div className="App">
       <ListBox onChange={handleChange} isMulti>
-        <ListBox.Filter />
+        <ListBox.Filter filter={handleFilter} />
         <ListBox.Option value="Fixed option" isSelected={isFixedOptionSelected}>
           Fixed option
         </ListBox.Option>


### PR DESCRIPTION
### Purpose 🚀

- Fixed an error in `useOnScrolled`, when the options list got refreshed (for example, when using backend search, we need to replace all the previous options), `state.options[state.activeOption]` might be undefined
- Call `onClickCancel` in `Listbox.Content` when it's on blur. When the listbox has a footer, users can either click the cancel button on the footer or click outside to cancel the action

### Notes ✏️


### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_
- [x] PATCH (bug fix) change to `@paprika/listbox`

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
