### PR TITLE
STAR-220 Update Filter icon 🐐

### DIFF
--- a/packages/Icon/CHANGELOG.md
+++ b/packages/Icon/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [0.3.0] - 2020-04-29
+
+### Removed
+
+- FilterAlt icon [@mikrotron](https://github.com/mikrotron).
+
+### Added
+
+- Filter icon [@mikrotron](https://github.com/mikrotron).

--- a/packages/Icon/src/svg/Filter-Alt.svg
+++ b/packages/Icon/src/svg/Filter-Alt.svg
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path 
-    d="M2.75 8.25V5.75H21.25V8.25H2.75ZM14.25 18.25H9.75V15.75H14.25V18.25ZM5.75 13.25V10.75H18.25V13.25H5.75Z" 
-    clip-rule="evenodd" 
-    fill-rule="evenodd" 
-    fill="#3F3D3C"
-  />
-</svg>

--- a/packages/Icon/src/svg/Filter.svg
+++ b/packages/Icon/src/svg/Filter.svg
@@ -1,0 +1,3 @@
+<svg height="24" width="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <path d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z" fill="#717171"/>
+</svg>


### PR DESCRIPTION
### Purpose 🚀
Rename `FilterAlt` icon to `Filter` and update source `svg` with a new version that is not "🔥💩"

### Notes ✏️
- Reference: https://github.com/acl-services/wasabicons/pull/13#issuecomment-621417776

### Updates 📦
- [x] MAJOR (breaking) change to `@paprika/icon`

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/STAR-220--filter-icon-update/?path=/story/icon--all-icons

### Screenshots 📸
New / renamed version of `Filter` icon
<img width="156" alt="Screen Shot 2020-04-29 at 4 41 57 PM" src="https://user-images.githubusercontent.com/14944896/80657674-1a770c80-8a39-11ea-85b0-5c4e6051db19.png">

### References 🔗
https://aclgrc.atlassian.net/browse/STAR-220


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
