### PR TITLE
SNP-200 Passing more props on listbox trigger

### DIFF
--- a/packages/ListBox/src/components/Trigger/Trigger.js
+++ b/packages/ListBox/src/components/Trigger/Trigger.js
@@ -52,7 +52,7 @@ const defaultProps = {
 export default function Trigger(props) {
   const [state, dispatch] = useListBox();
   const onChangeContext = React.useContext(OnChangeContext);
-  const { placeholder, hasClearButton, onClickFooterAccept, children, isHidden } = props;
+  const { placeholder, hasClearButton, onClickFooterAccept, children, isHidden, ...moreProps } = props;
   const {
     isDisabled,
     formElementLabelDescribedBy,
@@ -203,6 +203,7 @@ export default function Trigger(props) {
       ref={refTriggerContainer}
       size={size}
       {...getDOMAttributesForListBoxButton(state.idListBox)()}
+      {...moreProps}
     >
       {hasRenderTrigger ? renderChildrenProps : renderLabel()}
       {state.selectedOptions.length && hasClearButton && !shouldHideClearButton ? (


### PR DESCRIPTION
### Purpose 🚀

In projects, we need to assign unique `data-qa-anchor` on different listbox trigger

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_
- [x] PATCH (bug fix) change to `@paprika/listbox`

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
