### PR TITLE
XD-7713 - set modal header isSemantic false

### DIFF
--- a/packages/Modal/CHANGELOG.md
+++ b/packages/Modal/CHANGELOG.md
@@ -1,1 +1,11 @@
 # CHANGELOG
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [0.2.20] - 2020-05-12
+
+### Added
+
+- Set modal header close button to isSemantic false [@tristanjasper](https://github.com/tristanjasper).

--- a/packages/Modal/src/components/Header/Header.js
+++ b/packages/Modal/src/components/Header/Header.js
@@ -25,7 +25,9 @@ const Header = React.forwardRef((props, ref) => {
       <Heading tabIndex="-1" level={level} displayLevel={3} isLight>
         {children}
       </Heading>
-      {hasCloseButton && <Button.Close data-pka-anchor="modal.header.close-button" onClick={onClose} size="medium" />}
+      {hasCloseButton && (
+        <Button.Close data-pka-anchor="modal.header.close-button" isSemantic={false} onClick={onClose} size="medium" />
+      )}
     </styled.Wrapper>
   );
 });


### PR DESCRIPTION
### Purpose 🚀
Set the modal header close button to semantic false

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
- [x] PATCH (bug fix) change to modal

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/xd-7713-modal-header-close-button-semantic-false

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
