### PR TITLE
Ux 614 fix input evaluating value false

### DIFF
--- a/packages/Input/CHANGELOG.md
+++ b/packages/Input/CHANGELOG.md
@@ -14,4 +14,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Fix bug where empty string as value is causing a warning [@tristanjasper](https://github.com/tristanjasper).
+- Fix bug where empty string as value is causing a warning, set onChange callback to not required [@tristanjasper](https://github.com/tristanjasper).

--- a/packages/Input/CHANGELOG.md
+++ b/packages/Input/CHANGELOG.md
@@ -9,3 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Simplified uncontrolled api removing state for value [@tristanjasper](https://github.com/tristanjasper).
+
+## [0.2.27] - 2020-05-13
+
+### Added
+
+- Fix bug where empty string as value is causing a warning [@tristanjasper](https://github.com/tristanjasper).

--- a/packages/Input/src/Input.js
+++ b/packages/Input/src/Input.js
@@ -33,7 +33,7 @@ const propTypes = {
   /** If true it makes the input read only. */
   isReadOnly: PropTypes.bool,
 
-  /** Callback to be executed when the input value is changed */
+  /** Callback to be executed when the input value is changed. Should not be used with defaultValue prop */
   onChange: PropTypes.func,
 
   /** Callback to be executed when the input value is cleared */

--- a/packages/Input/src/Input.js
+++ b/packages/Input/src/Input.js
@@ -34,7 +34,7 @@ const propTypes = {
   isReadOnly: PropTypes.bool,
 
   /** Callback to be executed when the input value is changed */
-  onChange: PropTypes.func.isRequired,
+  onChange: PropTypes.func,
 
   /** Callback to be executed when the input value is cleared */
   onClear: PropTypes.func,
@@ -59,6 +59,7 @@ const defaultProps = {
   inputRef: () => {},
   isDisabled: false,
   isReadOnly: false,
+  onChange: () => {},
   onClear: () => {},
   size: ShirtSizes.MEDIUM,
   type: "text",
@@ -108,7 +109,7 @@ const Input = props => {
     ...moreProps
   } = props;
 
-  if (moreProps.value) {
+  if (moreProps.value || moreProps.value === "") {
     delete moreProps.defaultValue;
   } else {
     delete moreProps.value;

--- a/packages/Input/tests/input.spec.js
+++ b/packages/Input/tests/input.spec.js
@@ -5,6 +5,7 @@ import Input from "../src";
 
 const renderComponent = props => render(<Input {...props} />);
 
+const emptyStringValue = "";
 const initialValue = "initial value";
 const updatedValue = "changed value";
 
@@ -24,6 +25,18 @@ describe("Input", () => {
     fireEvent.change(getByTestId("input"), { target: { value: updatedValue } });
     expect(changeValue).toBe(updatedValue);
     expect(getByTestId("input").value).toBe(initialValue);
+  });
+
+  it("should change value controlled when value is empty string", async () => {
+    let changeValue = null;
+    const onChangeFunc = e => {
+      changeValue = e.target.value;
+    };
+    const { getByTestId } = renderComponent({ value: emptyStringValue, onChange: onChangeFunc });
+    expect(getByTestId("input").value).toBe(emptyStringValue);
+    fireEvent.change(getByTestId("input"), { target: { value: updatedValue } });
+    expect(changeValue).toBe(updatedValue);
+    expect(getByTestId("input").value).toBe(emptyStringValue);
   });
 
   it("should set value uncontrolled using defaultValue and call the inputRef function with node when input changes", async () => {


### PR DESCRIPTION
### Purpose 🚀


### Notes ✏️
Fix bug where empty string as value is causing a warning, set onChange callback to not required

### Updates 📦
- [x] PATCH (bug fix) change to input

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/ux-614-fix-input-evaluating-value-false

### Screenshots 📸
_optional but highly recommended_

### References 🔗
https://aclgrc.atlassian.net/browse/UX-746


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
