### PR TITLE
UX-346 lint rule for sc import

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -48,6 +48,10 @@
       {
         "selector": "ImportDeclaration[source.value=\"react\"] :matches(ImportSpecifier, ImportNamespaceSpecifier)",
         "message": "Prefer accessing properties of `React` import, e.g. `React.Component`"
+      },
+      {
+        "selector": "ImportDeclaration[source.value=/\\.styles/] ImportNamespaceSpecifier[local.name!=/^(sc|Sbook)$/]",
+        "message": "Prefer naming styled components import `sc` (`Sbook` for Storybook components)"
       }
     ],
     "no-underscore-dangle": "off",

--- a/packages/Modal/src/Modal.js
+++ b/packages/Modal/src/Modal.js
@@ -5,7 +5,7 @@ import { zValue } from "@paprika/stylers/lib/helpers";
 import { ShirtSizes } from "@paprika/helpers/lib/customPropTypes";
 import extractChildren from "@paprika/helpers/lib/extractChildren";
 import FocusLock from "./components/FocusLock";
-import * as styled from "./Modal.styles";
+import * as sc from "./Modal.styles";
 
 const propTypes = {
   /* Description of the Modal dialog for assistive technology */
@@ -64,7 +64,7 @@ const Modal = props => {
   const overlayProps = overlayExtracted ? overlayExtracted.props : {};
 
   const focusLockOptions = {
-    as: styled.FocusLock,
+    as: sc.FocusLock,
     lockProps: { size },
     ...(focusLockProps || {}),
   };
@@ -83,16 +83,16 @@ const Modal = props => {
       focusLockOptions={focusLockOptions}
     >
       {state => (
-        <styled.Wrapper size={size} data-pka-anchor="modal.wrapper" {...moreProps}>
-          <styled.Dialog state={state} role="dialog" aria-modal="true" aria-label={ariaLabel} data-pka-anchor="modal">
-            {headerExtracted && <styled.Header {...headerExtracted.props} onClose={onClose} />}
-            <styled.ContentWrapper role="region" tabIndex="0">
-              {contentExtracted && <styled.Content {...contentExtracted.props} />}
+        <sc.Wrapper size={size} data-pka-anchor="modal.wrapper" {...moreProps}>
+          <sc.Dialog state={state} role="dialog" aria-modal="true" aria-label={ariaLabel} data-pka-anchor="modal">
+            {headerExtracted && <sc.Header {...headerExtracted.props} onClose={onClose} />}
+            <sc.ContentWrapper role="region" tabIndex="0">
+              {contentExtracted && <sc.Content {...contentExtracted.props} />}
               {children}
-            </styled.ContentWrapper>
-            {footerExtracted && <styled.Footer {...footerExtracted.props} />}
-          </styled.Dialog>
-        </styled.Wrapper>
+            </sc.ContentWrapper>
+            {footerExtracted && <sc.Footer {...footerExtracted.props} />}
+          </sc.Dialog>
+        </sc.Wrapper>
       )}
     </Overlay>
   );

--- a/packages/Modal/src/components/Header/Header.js
+++ b/packages/Modal/src/components/Header/Header.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import Button from "@paprika/button";
 import Heading from "@paprika/heading";
-import * as styled from "./Header.styles";
+import * as sc from "./Header.styles";
 
 const propTypes = {
   children: PropTypes.node.isRequired,
@@ -21,14 +21,14 @@ const Header = React.forwardRef((props, ref) => {
   const { children, level, hasCloseButton, onClose, ...moreProps } = props;
 
   return (
-    <styled.Wrapper ref={ref} {...moreProps}>
+    <sc.Wrapper ref={ref} {...moreProps}>
       <Heading tabIndex="-1" level={level} displayLevel={3} isLight>
         {children}
       </Heading>
       {hasCloseButton && (
         <Button.Close data-pka-anchor="modal.header.close-button" isSemantic={false} onClick={onClose} size="medium" />
       )}
-    </styled.Wrapper>
+    </sc.Wrapper>
   );
 });
 

--- a/packages/Popover/src/Popover.js
+++ b/packages/Popover/src/Popover.js
@@ -14,7 +14,7 @@ import Content from "./components/Content/Content";
 import Card from "./components/Card/Card";
 import Trigger from "./components/Trigger/Trigger";
 import Tip from "./components/Tip/Tip";
-import * as styled from "./Popover.styles";
+import * as sc from "./Popover.styles";
 
 const openDelay = 350;
 const closeDelay = 150;
@@ -514,9 +514,9 @@ class Popover extends React.Component {
     return (
       <ThemeContext.Provider value={isDark}>
         <PopoverContext.Provider value={contextValue}>
-          <styled.Popover data-pka-anchor="popover" {...moreProps} ref={this.$popover}>
+          <sc.Popover data-pka-anchor="popover" {...moreProps} ref={this.$popover}>
             <PopoverChildren onChildChange={this.handleChildChange}>{this.props.children}</PopoverChildren>
-          </styled.Popover>
+          </sc.Popover>
         </PopoverContext.Provider>
       </ThemeContext.Provider>
     );

--- a/packages/Popover/src/components/Trigger/Trigger.js
+++ b/packages/Popover/src/components/Trigger/Trigger.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import RawButton from "@paprika/raw-button";
 import { isActiveElementPopover } from "../../helpers/isActiveElementPopover";
 import PopoverContext from "../../PopoverContext";
-import * as styled from "../../Popover.styles";
+import * as sc from "../../Popover.styles";
 
 const propTypes = {
   /** Descriptive a11y text for assistive technologies for the trigger. */
@@ -61,7 +61,7 @@ function Trigger(props) {
 
   if (isEager) {
     return (
-      <styled.Trigger
+      <sc.Trigger
         a11yText={a11yText}
         data-pka-anchor="popover.trigger"
         onMouseOver={handleTriggerEvent}
@@ -72,7 +72,7 @@ function Trigger(props) {
         {...moreProps}
       >
         {children}
-      </styled.Trigger>
+      </sc.Trigger>
     );
   }
 


### PR DESCRIPTION
### Purpose 🚀
Lint for `sc` to be used as the name of styled components imports. 

### Notes ✏️
I left `Sbook` imports from `"storybook/assets/styles/common.styles"`, LMK if that can be `sc` as well.

### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_
- [x] PATCH (bug fix) change to `Modal`, `Popover`

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/UX-346-sc-lint

### Screenshots 📸
![image](https://user-images.githubusercontent.com/93752/82401999-2f2f3a80-9a10-11ea-908a-18b3eed618bf.png)

<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
