### PR TITLE
tw-204 change refOf function to support func components

### DIFF
--- a/packages/helpers/CHANGELOG.md
+++ b/packages/helpers/CHANGELOG.md
@@ -1,3 +1,7 @@
 ## 0.2.2 (October 23, 2019)
 
 - Add `usePrevious` hook. [#244](https://github.com/acl-services/paprika/pull/244)
+
+## 0.2.12 (June 4th 2020)
+
+- Update `RefOf` helper to support functional components. [@tristanjasper](https://github.com/tristanjasper).

--- a/packages/helpers/src/customPropTypes.js
+++ b/packages/helpers/src/customPropTypes.js
@@ -68,5 +68,5 @@ export const FocusPropTypes = {
 
 InputValidTypes.ALL = Object.values(InputValidTypes);
 
-export const RefOf = (propType = PropTypes.instanceOf(Element)) =>
+export const RefOf = (propType = PropTypes.object) =>
   PropTypes.oneOfType([PropTypes.func, PropTypes.shape({ current: propType })]);


### PR DESCRIPTION
### Purpose 🚀
As discussed in https://github.com/acl-services/acl-exception/pull/7657/files#r434794944

This pr is updating the RefOf method helper to support functional components so that we don't get any more invalid prop types warnings when using class components

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
- [x] PATCH (bug fix) change to helpers

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/tw-204-ref-proptype-support-functional-components

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
