### PR TITLE
RAPRM-353 Button + Toast styling tweaks 🐐

### DIFF
--- a/packages/Button/CHANGELOG.md
+++ b/packages/Button/CHANGELOG.md
@@ -8,4 +8,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Changed default value of `<Button.Link>` `isOpenNewTab` prop to `false` [@mikrotron](https://github.com/mikrotron)
+- Changed name / default value of `<Button.Link>` `isOpenNewTab` prop to `shouldOpenNewTab` / `false` [@mikrotron](https://github.com/mikrotron)

--- a/packages/Button/CHANGELOG.md
+++ b/packages/Button/CHANGELOG.md
@@ -1,1 +1,11 @@
 # CHANGELOG
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [0.3.0] - 2020-06-16
+
+### Changed
+
+- Changed default value of `<Button.Link>` `isOpenNewTab` prop to `false` [@mikrotron](https://github.com/mikrotron)

--- a/packages/Button/src/Button.js
+++ b/packages/Button/src/Button.js
@@ -89,7 +89,7 @@ const buttonDefaultProps = {
 
 const ButtonIcon = props =>
   props.children ? (
-    <span css={iconStyles} {...props} className="button__icon">
+    <span css={iconStyles} {...props}>
       {props.children}
     </span>
   ) : null;

--- a/packages/Button/src/Button.styles.js
+++ b/packages/Button/src/Button.styles.js
@@ -27,6 +27,13 @@ const disabledStyles = css`
     color: ${tokens.color.blackLighten40};
     text-decoration: none;
   }
+
+  &,
+  &:hover,
+  &:active {
+    box-shadow: none;
+    transform: none;
+  }
 `;
 
 const disabledTextStyles = css`

--- a/packages/Button/src/CloseButton.styles.js
+++ b/packages/Button/src/CloseButton.styles.js
@@ -9,7 +9,7 @@ const darkStyles = css`
   &:hover {
     background-color: ${stylers.alpha(tokens.color.white, 0.2)};
 
-    .button__icon {
+    [data-pka-anchor="button.icon"] {
       color: ${tokens.color.white};
     }
   }
@@ -18,20 +18,20 @@ const darkStyles = css`
     background-color: ${stylers.alpha(tokens.color.white, 0.3)};
     transition: none;
 
-    .button__icon {
+    [data-pka-anchor="button.icon"] {
       color: ${tokens.color.white};
       transition: none;
     }
   }
 
-  .button__icon {
+  [data-pka-anchor="button.icon"] {
     color: ${tokens.color.blackLighten50};
     transition: color 0.2s ease-out;
   }
 `;
 
 const closeButtonStyles = css`
-  .button__icon {
+  [data-pka-anchor="button.icon"] {
     color: ${tokens.textColor.icon};
   }
 

--- a/packages/Button/src/IconButton.styles.js
+++ b/packages/Button/src/IconButton.styles.js
@@ -38,7 +38,7 @@ const minorStyles = css`
           &:hover,
           &:active {
             [data-pka-anchor="icon"] {
-              color: ${tokens.color.blackLighten50};
+              color: ${tokens.color.blackDisabled};
             }
           }
         `
@@ -57,12 +57,11 @@ const iconButtonStyles = css`
   ${({ size }) => iconButtonSizes[size]}
   ${({ kind }) => (kind === Button.Kinds.MINOR ? minorStyles : "")}
 
+  
   [data-pka-anchor="button.icon"] {
     color: inherit;
     margin: 0;
   }
 `;
-
-// export const icon
 
 export default iconButtonStyles;

--- a/packages/Button/src/IconButton.styles.js
+++ b/packages/Button/src/IconButton.styles.js
@@ -31,23 +31,38 @@ const iconButtonSizes = {
 const minorStyles = css`
   transition: background-color 0.2s ease-out;
 
-  &:hover {
-    background-color: ${stylers.alpha(tokens.color.black, 0.1)};
-  }
+  ${({ isDisabled }) =>
+    isDisabled
+      ? css`
+          &,
+          &:hover,
+          &:active {
+            [data-pka-anchor="icon"] {
+              color: ${tokens.color.blackLighten50};
+            }
+          }
+        `
+      : css`
+          &:hover {
+            background-color: ${stylers.alpha(tokens.color.black, 0.1)};
+          }
 
-  &:active {
-    background-color: ${stylers.alpha(tokens.color.black, 0.2)};
-  }
+          &:active {
+            background-color: ${stylers.alpha(tokens.color.black, 0.2)};
+          }
+        `}
 `;
 
 const iconButtonStyles = css`
   ${({ size }) => iconButtonSizes[size]}
   ${({ kind }) => (kind === Button.Kinds.MINOR ? minorStyles : "")}
 
-  .button__icon {
+  [data-pka-anchor="button.icon"] {
     color: inherit;
     margin: 0;
   }
 `;
+
+// export const icon
 
 export default iconButtonStyles;

--- a/packages/Button/src/LinkButton.js
+++ b/packages/Button/src/LinkButton.js
@@ -10,28 +10,28 @@ const LinkPropTypes = {
   children: PropTypes.node.isRequired,
   href: PropTypes.string.isRequired,
   isDisabled: PropTypes.bool,
-  isOpenNewTab: PropTypes.bool,
   kind: PropTypes.oneOf(Button.Kinds.ALL),
   size: PropTypes.oneOf(ShirtSizes.DEFAULT),
+  shouldOpenNewTab: PropTypes.bool,
   suffixIcon: PropTypes.node,
 };
 
 const LinkDefaultProps = {
   a11yText: null,
   isDisabled: false,
-  isOpenNewTab: false,
   kind: Button.Kinds.LINK,
+  shouldOpenNewTab: false,
   size: ShirtSizes.MEDIUM,
   suffixIcon: <NewTabIcon />,
 };
 
-const isOpenNewTabProps = {
+const shouldOpenNewTabProps = {
   target: "_blank",
   rel: "noopener noreferrer",
 };
 
 const LinkButton = React.forwardRef(
-  ({ a11yText, children, href, isDisabled, isOpenNewTab, kind, size, suffixIcon, ...moreProps }, ref) => {
+  ({ a11yText, children, href, isDisabled, shouldOpenNewTab, kind, size, suffixIcon, ...moreProps }, ref) => {
     return (
       <a
         aria-label={a11yText}
@@ -40,13 +40,13 @@ const LinkButton = React.forwardRef(
         isDisabled={isDisabled}
         kind={kind}
         size={size}
-        {...(isOpenNewTab ? isOpenNewTabProps : {})}
+        {...(shouldOpenNewTab ? shouldOpenNewTabProps : {})}
         {...moreProps}
         as={isDisabled ? "span" : "a"}
         ref={ref}
       >
         {children}
-        {kind === Button.Kinds.LINK && isOpenNewTab ? suffixIcon : null}
+        {kind === Button.Kinds.LINK && shouldOpenNewTab ? suffixIcon : null}
       </a>
     );
   }

--- a/packages/Button/src/LinkButton.js
+++ b/packages/Button/src/LinkButton.js
@@ -9,6 +9,7 @@ const LinkPropTypes = {
   a11yText: PropTypes.string,
   children: PropTypes.node.isRequired,
   href: PropTypes.string.isRequired,
+  isDisabled: PropTypes.bool,
   isOpenNewTab: PropTypes.bool,
   kind: PropTypes.oneOf(Button.Kinds.ALL),
   size: PropTypes.oneOf(ShirtSizes.DEFAULT),
@@ -17,7 +18,8 @@ const LinkPropTypes = {
 
 const LinkDefaultProps = {
   a11yText: null,
-  isOpenNewTab: true,
+  isDisabled: false,
+  isOpenNewTab: false,
   kind: Button.Kinds.LINK,
   size: ShirtSizes.MEDIUM,
   suffixIcon: <NewTabIcon />,
@@ -29,17 +31,19 @@ const isOpenNewTabProps = {
 };
 
 const LinkButton = React.forwardRef(
-  ({ a11yText, children, href, isOpenNewTab, kind, size, suffixIcon, ...moreProps }, ref) => {
+  ({ a11yText, children, href, isDisabled, isOpenNewTab, kind, size, suffixIcon, ...moreProps }, ref) => {
     return (
       <a
-        css={buttonStyles}
-        ref={ref}
-        href={href}
         aria-label={a11yText}
+        css={buttonStyles}
+        href={!isDisabled && href}
+        isDisabled={isDisabled}
         kind={kind}
         size={size}
         {...(isOpenNewTab ? isOpenNewTabProps : {})}
         {...moreProps}
+        as={isDisabled ? "span" : "a"}
+        ref={ref}
       >
         {children}
         {kind === Button.Kinds.LINK && isOpenNewTab ? suffixIcon : null}

--- a/packages/Button/stories/Button.stories.js
+++ b/packages/Button/stories/Button.stories.js
@@ -3,7 +3,7 @@ import { storiesOf } from "@storybook/react";
 import { withKnobs } from "@storybook/addon-knobs";
 import { getStoryName } from "storybook/storyTree";
 import Showcase from "./examples/Showcase";
-import Basic from "./examples/Basic";
+import Variations from "./examples/Variations";
 import NewRef from "./examples/NewRef";
 import OldRef from "./examples/OldRef";
 import CloseButtonRef from "./examples/CloseButtonRef";
@@ -19,8 +19,9 @@ storiesOf(storyName, module)
   .addDecorator(withKnobs)
   .add("Showcase", Showcase);
 
+storiesOf(storyName, module).add("Variations", () => <Variations />);
+
 storiesOf(`${storyName}/Examples`, module)
-  .add("Basic", () => <Basic />)
   .add("Ref", () => <NewRef />)
   .add("Old Ref", () => <OldRef />)
   .add("Button.Close Ref", () => <CloseButtonRef />)

--- a/packages/Button/stories/examples/Variations.js
+++ b/packages/Button/stories/examples/Variations.js
@@ -91,7 +91,7 @@ const ExampleStory = () => (
       <Button.Link onClick={clickHandler} kind="primary" href="https://youtu.be/IdkCEioCp24?t=92">
         Link
       </Button.Link>
-      <Button.Link onClick={clickHandler} kind="secondary" href="https://youtu.be/IdkCEioCp24?t=92" isOpenNewTab>
+      <Button.Link onClick={clickHandler} kind="secondary" href="https://youtu.be/IdkCEioCp24?t=92" shouldOpenNewTab>
         Link in new tab
       </Button.Link>
       <Button.Link href="https://youtu.be/IdkCEioCp24?t=92" size="small">
@@ -101,7 +101,7 @@ const ExampleStory = () => (
       <Button.Link href="https://youtu.be/IdkCEioCp24?t=92" size="large">
         Link large
       </Button.Link>
-      <Button.Link href="https://youtu.be/IdkCEioCp24?t=92" isOpenNewTab>
+      <Button.Link href="https://youtu.be/IdkCEioCp24?t=92" shouldOpenNewTab>
         Link in new tab
       </Button.Link>
     </p>

--- a/packages/Button/stories/examples/Variations.js
+++ b/packages/Button/stories/examples/Variations.js
@@ -1,8 +1,9 @@
 import React from "react";
 import { action } from "@storybook/addon-actions";
 import styled from "styled-components";
-import { Rule, breaklines } from "storybook/assets/styles/common.styles";
+import { Rule, Tagline, breaklines } from "storybook/assets/styles/common.styles";
 import tokens from "@paprika/tokens";
+import Heading from "@paprika/heading";
 import PlusIcon from "@paprika/icon/lib/Add";
 import InfoIcon from "@paprika/icon/lib/InfoCircle";
 import { ButtonStory } from "../Button.stories.styles";
@@ -21,6 +22,11 @@ function clickHandler() {
 
 const ExampleStory = () => (
   <ButtonStory>
+    <Heading level={1} displayLevel={2} isLight>
+      Variations
+    </Heading>
+    <Tagline>So many different kinds of Buttons!</Tagline>
+    <Rule />
     <p>
       <Button a11yText="ceci n'est pas un bouton" data-pka-anchor="test-button" onClick={clickHandler}>
         default button
@@ -54,7 +60,6 @@ const ExampleStory = () => (
         small
       </Button>
       <Button onClick={clickHandler}>medium</Button>
-
       <Button size="large" onClick={clickHandler}>
         large
       </Button>
@@ -83,20 +88,21 @@ const ExampleStory = () => (
     </p>
     <Rule />
     <p>
-      <Button.Link onClick={clickHandler} isOpenNewTab={false} kind="primary" href="https://www.google.ca">
+      <Button.Link onClick={clickHandler} kind="primary" href="https://youtu.be/IdkCEioCp24?t=92">
         Link
       </Button.Link>
-      <Button.Link onClick={clickHandler} kind="secondary" href="https://www.google.ca">
-        Link that opens in new tab
+      <Button.Link onClick={clickHandler} kind="secondary" href="https://youtu.be/IdkCEioCp24?t=92" isOpenNewTab>
+        Link in new tab
       </Button.Link>
       <Button.Link href="https://youtu.be/IdkCEioCp24?t=92" size="small">
         Link small
       </Button.Link>
-      <Button.Link href="https://youtu.be/IdkCEioCp24?t=92" size="medium">
-        Link medium
-      </Button.Link>
+      <Button.Link href="https://youtu.be/IdkCEioCp24?t=92">Link medium</Button.Link>
       <Button.Link href="https://youtu.be/IdkCEioCp24?t=92" size="large">
         Link large
+      </Button.Link>
+      <Button.Link href="https://youtu.be/IdkCEioCp24?t=92" isOpenNewTab>
+        Link in new tab
       </Button.Link>
     </p>
     <Rule />
@@ -145,9 +151,6 @@ const ExampleStory = () => (
       <Button onClick={clickHandler} icon={<PlusIcon />} size="large">
         with icon
       </Button>
-    </p>
-    <Rule />
-    <p>
       <Button onClick={clickHandler} icon={<PlusIcon />} kind="minor">
         with icon
       </Button>
@@ -163,6 +166,30 @@ const ExampleStory = () => (
       <Button onClick={clickHandler} icon={<PlusIcon />} kind="primary" isDisabled>
         with icon
       </Button>
+    </p>
+    <Rule />
+    <p>
+      <Button onClick={clickHandler} isDisabled>
+        disabled
+      </Button>
+      <Button onClick={clickHandler} isDisabled kind="primary">
+        disabled primary
+      </Button>
+      <Button onClick={clickHandler} isDisabled kind="minor">
+        disabled minor
+      </Button>
+      <Button onClick={clickHandler} isDisabled kind="link">
+        disabled kind=link
+      </Button>
+      <Button.Icon onClick={clickHandler} isDisabled>
+        <InfoIcon />
+      </Button.Icon>
+      <Button.Icon onClick={clickHandler} isDisabled kind="minor">
+        <InfoIcon />
+      </Button.Icon>
+      <Button.Link href="https://youtu.be/IdkCEioCp24?t=92" isDisabled>
+        disabled Button.Link
+      </Button.Link>
     </p>
     <Rule />
     <p>

--- a/packages/Toast/src/Toast.styles.js
+++ b/packages/Toast/src/Toast.styles.js
@@ -59,8 +59,7 @@ export const IconStyled = styled.div`
   color: ${({ kind }) => iconColors[kind]};
   flex-grow: 0;
   flex-shrink: 0;
-  padding-right: ${tokens.space};
-  padding-top: 1px;
+  margin: 1px ${tokens.space} 0 0;
 
   ${stylers.fontSize(2)}
 `;

--- a/screener.config.js
+++ b/screener.config.js
@@ -8,5 +8,5 @@ module.exports = {
   storybookConfigDir: ".storybook",
   storybookStaticDir: "./.storybook/assets",
   failureExitCode: 0, // Don't fail CI build when regressions found
-  includeRules: [/Screener/, /Stylers/, /^Button: Variations/],
+  includeRules: [/Screener/, /Stylers/, /Button: Variations/],
 };

--- a/screener.config.js
+++ b/screener.config.js
@@ -8,5 +8,5 @@ module.exports = {
   storybookConfigDir: ".storybook",
   storybookStaticDir: "./.storybook/assets",
   failureExitCode: 0, // Don't fail CI build when regressions found
-  includeRules: [/Screener/, /^Stylers/, /^Button\/Variations/],
+  includeRules: [/Screener/, /Stylers/, /^Button: Variations/],
 };

--- a/screener.config.js
+++ b/screener.config.js
@@ -8,5 +8,5 @@ module.exports = {
   storybookConfigDir: ".storybook",
   storybookStaticDir: "./.storybook/assets",
   failureExitCode: 0, // Don't fail CI build when regressions found
-  includeRules: [/Screener/, /^Stylers/, /^Button\/Examples: Basic/],
+  includeRules: [/Screener/, /^Stylers/, /^Button\/Variations/],
 };


### PR DESCRIPTION
### Purpose 🚀
Adjust the styling of `<Button.Icon kind='minor' isDisabled>` and the icon in the `<Toast>`.

### Notes ✏️
- Also renamed the `Basic` storybook story to `Variations`, in line with new patterns.
- Also noticed that `<Button.Link isDisabled>` was not actually disabled, so fixed that.
- 💥 Made a small (BREAKING) change to the `<Button.Link>` by renaming `isOpenNewTab` to `shouldOpenNewTab` and changing its default value to `false`.

### Updates 📦
- [x] MAJOR (breaking) change to `@paprika/button`
- [x] PATCH (bug fix) change to `@paprika/toast`

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/RAPRM-353--button-toast-styling-tweaks

### Screenshots 📸
![](https://user-images.githubusercontent.com/14944896/84840913-bebb0f80-aff5-11ea-8ce0-95dcda215454.png)
A variety of disabled buttons for exposition / screener testing to Variations story

### References 🔗
https://aclgrc.atlassian.net/browse/RAPRM-353

<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
