### PR TITLE
STAR-255-Switch-component-sizes

### DIFF
--- a/packages/Switch/src/Switch.styles.js
+++ b/packages/Switch/src/Switch.styles.js
@@ -8,10 +8,10 @@ const KnobPositionStyles = {
     transform: translateX(12px);
   `,
   medium: css`
-    transform: translate(20px, 0);
+    transform: translate(16px, 0);
   `,
   large: css`
-    transform: translate(28px);
+    transform: translate(20px);
   `,
 };
 
@@ -25,19 +25,19 @@ const KnobSizeStyles = {
     }
   `,
   medium: css`
+    height: 16px;
+    width: 16px;
+
+    &::after {
+      height: 17px;
+    }
+  `,
+  large: css`
     height: 20px;
     width: 20px;
 
     &::after {
       height: 21px;
-    }
-  `,
-  large: css`
-    height: 28px;
-    width: 28px;
-
-    &::after {
-      height: 29px;
     }
   `,
 };
@@ -48,12 +48,12 @@ const UnderlaySizeStyles = {
     width: 28px;
   `,
   medium: css`
-    height: ${stylers.spacer(3)};
-    width: 44px;
+    height: ${stylers.spacer(2.5)};
+    width: 36px;
   `,
   large: css`
-    height: ${stylers.spacer(4)};
-    width: 60px;
+    height: ${stylers.spacer(3)};
+    width: 44px;
   `,
 };
 


### PR DESCRIPTION
### Purpose 🚀
To adjust the sizes of the Paprika Switch component so that it is consistent with the UI Kit.

### Notes ✏️
N/A

### Updates 📦
- [x] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_
- [ ] PATCH (bug fix) change to _these packages_

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/STAR-255-Switch-component-sizes

### Screenshots 📸
Before:
![image](https://user-images.githubusercontent.com/67071090/85071274-17141d80-b16c-11ea-8ed9-65806cc712a7.png)

After:
![image](https://user-images.githubusercontent.com/67071090/85071334-301cce80-b16c-11ea-85d2-404233a13c75.png)


### References 🔗
N/A


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
