### PR TITLE
RAPRM-373 Disabled styling of Button.Icon 🐐

### DIFF
--- a/.storybook/assets/styles/common.styles.js
+++ b/.storybook/assets/styles/common.styles.js
@@ -43,7 +43,7 @@ const LargeGap = styled.div`
 const SmallGap = styled.div`
   height: ${stylers.spacer(2)};
 `;
-const InlineGap = styled.div`
+const InlineGap = styled.span`
   display: inline-flex;
   width: ${tokens.space};
 `;

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -27,20 +27,23 @@ module.exports = {
     "@storybook/addon-cssresources",
   ],
   webpackFinal: async config => {
-    config.module.rules.push(
-      {
-        resolve: {
-          alias: {
-            storybook: path.resolve("./.storybook/"),
-          },
+    if (!config) config = {};
+    if (config.module) {
+      config.module.rules = [
+        ...config.module.rules,
+        {
+          test: /\.scss$/,
+          loaders: ["style-loader", "css-loader", "sass-loader"],
+          include: path.resolve(__dirname, "../"),
         },
-      },
-      {
-        test: /\.scss$/,
-        loaders: ["style-loader", "css-loader", "sass-loader"],
-        include: path.resolve(__dirname, "../"),
-      }
-    );
+      ];
+    }
+    if (config.resolve) {
+      config.resolve.alias = {
+        ...config.resolve.alias,
+        storybook: path.resolve("./.storybook/"),
+      };
+    }
     config.output = {
       ...config.output,
       globalObject: "self",

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -27,23 +27,18 @@ module.exports = {
     "@storybook/addon-cssresources",
   ],
   webpackFinal: async config => {
-    if (!config) config = {};
-    if (config.module) {
-      config.module.rules = [
-        ...config.module.rules,
-        {
-          test: /\.scss$/,
-          loaders: ["style-loader", "css-loader", "sass-loader"],
-          include: path.resolve(__dirname, "../"),
-        },
-      ];
-    }
-    if (config.resolve) {
-      config.resolve.alias = {
-        ...config.resolve.alias,
-        storybook: path.resolve("./.storybook/"),
-      };
-    }
+    config.module.rules = [
+      ...config.module.rules,
+      {
+        test: /\.scss$/,
+        loaders: ["style-loader", "css-loader", "sass-loader"],
+        include: path.resolve(__dirname, "../"),
+      },
+    ];
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      storybook: path.resolve("./.storybook/"),
+    };
     config.output = {
       ...config.output,
       globalObject: "self",

--- a/.storybook/storyTree.js
+++ b/.storybook/storyTree.js
@@ -59,6 +59,7 @@ const storyTree = [
       "ListBoxBrowser",
       "DateInput",
       "DatePicker",
+      "Calendar",
     ],
   },
   {

--- a/packages/Button/src/Button.js
+++ b/packages/Button/src/Button.js
@@ -87,12 +87,8 @@ const buttonDefaultProps = {
   children: null,
 };
 
-const ButtonIcon = props =>
-  props.children ? (
-    <span css={iconStyles} {...props}>
-      {props.children}
-    </span>
-  ) : null;
+export const ButtonIcon = props =>
+  props.children ? <span css={iconStyles} data-pka-anchor="button.icon" {...props} /> : null;
 
 const Button = React.forwardRef((props, ref) => {
   const {
@@ -184,11 +180,11 @@ const Button = React.forwardRef((props, ref) => {
 
   return (
     <span css={buttonStyles} as={isSemantic ? "button" : RawButton} {...buttonProps}>
-      <ButtonIcon {...iconProps} isPending={isPending} data-pka-anchor="button.icon">
+      <ButtonIcon {...iconProps} isPending={isPending}>
         {isPending ? <RefreshIcon /> : icon}
       </ButtonIcon>
       {children}
-      <ButtonIcon {...iconProps} isDropdown data-pka-anchor="button.icon">
+      <ButtonIcon {...iconProps} isSuffixIcon>
         {isDropdown && <DownIcon />}
       </ButtonIcon>
     </span>

--- a/packages/Button/src/Button.styles.js
+++ b/packages/Button/src/Button.styles.js
@@ -247,13 +247,6 @@ const kindStyles = props => ({
     }
 
     ${props.isDisabled ? disabledTextStyles : ""}
-
-    > [data-pka-anchor="icon"] {
-      ${stylers.fontSize(-3)}
-      color: ${tokens.textColor.icon};
-      margin-left: ${tokens.spaceSm};
-      margin-top: -${tokens.spaceSm};
-    }
   `,
 });
 
@@ -323,5 +316,5 @@ export const iconStyles = props => css`
       `
     : ""}
 
-  ${props.isDropdown ? `margin: 0 0 0 ${tokens.spaceSm};` : ""}
+  ${props.isSuffixIcon ? `margin: 0 0 0 ${tokens.spaceSm};` : ""}
 `;

--- a/packages/Button/src/CloseButton.styles.js
+++ b/packages/Button/src/CloseButton.styles.js
@@ -1,5 +1,4 @@
 import { css } from "styled-components";
-
 import tokens from "@paprika/tokens";
 import stylers from "@paprika/stylers";
 

--- a/packages/Button/src/IconButton.styles.js
+++ b/packages/Button/src/IconButton.styles.js
@@ -37,7 +37,7 @@ const minorStyles = css`
           &,
           &:hover,
           &:active {
-            [data-pka-anchor="icon"] {
+            [data-pka-anchor="button.icon"] svg {
               color: ${tokens.color.blackDisabled};
             }
           }
@@ -57,7 +57,6 @@ const iconButtonStyles = css`
   ${({ size }) => iconButtonSizes[size]}
   ${({ kind }) => (kind === Button.Kinds.MINOR ? minorStyles : "")}
 
-  
   [data-pka-anchor="button.icon"] {
     color: inherit;
     margin: 0;

--- a/packages/Button/src/LinkButton.js
+++ b/packages/Button/src/LinkButton.js
@@ -26,13 +26,13 @@ const defaultProps = {
   suffixIcon: <NewTabIcon />,
 };
 
-const shouldOpenNewTabProps = {
-  target: "_blank",
-  rel: "noopener noreferrer",
-};
-
 const LinkButton = React.forwardRef((props, ref) => {
   const { a11yText, children, href, isDisabled, shouldOpenNewTab, kind, size, suffixIcon, ...moreProps } = props;
+
+  const shouldOpenNewTabProps = {
+    target: "_blank",
+    rel: "noopener noreferrer",
+  };
 
   const iconProps = {
     isDisabled,

--- a/packages/Button/src/LinkButton.js
+++ b/packages/Button/src/LinkButton.js
@@ -4,8 +4,9 @@ import { ShirtSizes } from "@paprika/helpers/lib/customPropTypes";
 import NewTabIcon from "@paprika/icon/lib/NewTab";
 import Button from "./Button";
 import buttonStyles from "./Button.styles";
+import * as sc from "./LinkButton.styles";
 
-const LinkPropTypes = {
+const propTypes = {
   a11yText: PropTypes.string,
   children: PropTypes.node.isRequired,
   href: PropTypes.string.isRequired,
@@ -16,7 +17,7 @@ const LinkPropTypes = {
   suffixIcon: PropTypes.node,
 };
 
-const LinkDefaultProps = {
+const defaultProps = {
   a11yText: null,
   isDisabled: false,
   kind: Button.Kinds.LINK,
@@ -30,31 +31,38 @@ const shouldOpenNewTabProps = {
   rel: "noopener noreferrer",
 };
 
-const LinkButton = React.forwardRef(
-  ({ a11yText, children, href, isDisabled, shouldOpenNewTab, kind, size, suffixIcon, ...moreProps }, ref) => {
-    return (
-      <a
-        aria-label={a11yText}
-        css={buttonStyles}
-        href={!isDisabled && href}
-        isDisabled={isDisabled}
-        kind={kind}
-        size={size}
-        {...(shouldOpenNewTab ? shouldOpenNewTabProps : {})}
-        {...moreProps}
-        as={isDisabled ? "span" : "a"}
-        ref={ref}
-      >
-        {children}
-        {kind === Button.Kinds.LINK && shouldOpenNewTab ? suffixIcon : null}
-      </a>
-    );
-  }
-);
+const LinkButton = React.forwardRef((props, ref) => {
+  const { a11yText, children, href, isDisabled, shouldOpenNewTab, kind, size, suffixIcon, ...moreProps } = props;
 
-LinkButton.Kinds = Button.Kinds;
+  const iconProps = {
+    isDisabled,
+    kind,
+  };
+
+  return (
+    <a
+      aria-label={a11yText}
+      css={buttonStyles}
+      href={!isDisabled ? href : null}
+      isDisabled={isDisabled}
+      kind={kind}
+      size={size}
+      {...(shouldOpenNewTab ? shouldOpenNewTabProps : {})}
+      {...moreProps}
+      as={isDisabled ? "span" : "a"}
+      ref={ref}
+    >
+      {children}
+      <sc.LinkButtonIcon {...iconProps} isSuffixIcon>
+        {kind === Button.Kinds.LINK && shouldOpenNewTab && suffixIcon}
+      </sc.LinkButtonIcon>
+    </a>
+  );
+});
+
 LinkButton.displayName = "LinkButton";
-LinkButton.propTypes = LinkPropTypes;
-LinkButton.defaultProps = LinkDefaultProps;
+LinkButton.propTypes = propTypes;
+LinkButton.defaultProps = defaultProps;
+LinkButton.Kinds = Button.Kinds;
 
 export default LinkButton;

--- a/packages/Button/src/LinkButton.styles.js
+++ b/packages/Button/src/LinkButton.styles.js
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+import tokens from "@paprika/tokens";
+import stylers from "@paprika/stylers";
+import { ButtonIcon } from "./Button";
+
+export const LinkButtonIcon = styled(ButtonIcon)`
+  ${stylers.fontSize(-3)}
+  color: ${tokens.textColor.icon};
+  margin-top: -${tokens.spaceSm};
+`;

--- a/packages/Button/stories/examples/Variations.js
+++ b/packages/Button/stories/examples/Variations.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { action } from "@storybook/addon-actions";
 import styled from "styled-components";
-import { Rule, Tagline, breaklines } from "storybook/assets/styles/common.styles";
+import { Rule, Tagline, breaklines, Gap } from "storybook/assets/styles/common.styles";
 import tokens from "@paprika/tokens";
 import Heading from "@paprika/heading";
 import PlusIcon from "@paprika/icon/lib/Add";
@@ -190,6 +190,74 @@ const ExampleStory = () => (
       <Button.Link href="https://youtu.be/IdkCEioCp24?t=92" isDisabled>
         disabled Button.Link
       </Button.Link>
+    </p>
+    <p>
+      <Button.Icon onClick={clickHandler}>
+        <InfoIcon />
+      </Button.Icon>
+      <Button.Icon onClick={clickHandler} isDisabled>
+        <InfoIcon />
+      </Button.Icon>
+      <Button.Icon onClick={clickHandler} kind="primary">
+        <InfoIcon />
+      </Button.Icon>
+      <Button.Icon onClick={clickHandler} kind="primary" isDisabled>
+        <InfoIcon />
+      </Button.Icon>
+      <Button.Icon onClick={clickHandler} kind="link">
+        <InfoIcon />
+      </Button.Icon>
+      <Button.Icon onClick={clickHandler} kind="link" isDisabled>
+        <InfoIcon />
+      </Button.Icon>
+      <Button.Icon onClick={clickHandler} kind="minor">
+        <InfoIcon />
+      </Button.Icon>
+      <Button.Icon onClick={clickHandler} kind="minor" isDisabled>
+        <InfoIcon />
+      </Button.Icon>
+      <Gap.Inline />
+      <Gap.Inline />
+      <Gap.Inline />
+      <Button.Icon
+        onClick={clickHandler}
+        kind="minor"
+        css={`
+          color: ${tokens.color.gold};
+        `}
+      >
+        <InfoIcon />
+      </Button.Icon>
+      <Button.Icon
+        onClick={clickHandler}
+        kind="minor"
+        css={`
+          color: ${tokens.color.gold};
+        `}
+        isDisabled
+      >
+        <InfoIcon />
+      </Button.Icon>
+      <Button.Icon onClick={clickHandler} kind="minor">
+        <InfoIcon
+          css={`
+            color: ${tokens.color.gold};
+          `}
+        />
+      </Button.Icon>
+      <Button.Icon onClick={clickHandler} kind="minor" isDisabled>
+        <InfoIcon
+          css={`
+            color: ${tokens.color.gold};
+          `}
+        />
+      </Button.Icon>
+      <Button.Icon onClick={clickHandler} kind="minor">
+        <InfoIcon color={tokens.color.gold} />
+      </Button.Icon>
+      <Button.Icon onClick={clickHandler} kind="minor" isDisabled>
+        <InfoIcon color={tokens.color.gold} />
+      </Button.Icon>
     </p>
     <Rule />
     <p>

--- a/packages/Calendar/stories/Calendar.stories.js
+++ b/packages/Calendar/stories/Calendar.stories.js
@@ -2,16 +2,20 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 import { withKnobs } from "@storybook/addon-knobs";
 import { Story } from "storybook/assets/styles/common.styles";
+import { getStoryName } from "storybook/storyTree";
 import moment from "moment";
 import L10n from "@paprika/l10n";
 import DateRangeCalendar from "../src/DateRangeCalendar";
 import SingleDateCalendar from "../src/SingleDateCalendar";
 import { START_DATE } from "../src/tokens";
 
-moment.locale("en");
+const storyName = getStoryName("Calendar");
+
 const noop = () => {};
 
-storiesOf("Calendar", module)
+moment.locale("en");
+
+storiesOf(storyName, module)
   .addDecorator(withKnobs)
   .add("SingleDateCalendar Showcase", () => {
     const [date, setDate] = React.useState(null);

--- a/packages/Calendar/stories/cypress.stories.js
+++ b/packages/Calendar/stories/cypress.stories.js
@@ -2,13 +2,16 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 import moment from "moment";
 import L10n from "@paprika/l10n";
+import { getStoryName } from "storybook/storyTree";
 import SingleDateCalendar from "../src/SingleDateCalendar";
 import DateRangeCalendar from "../src/DateRangeCalendar";
 import { START_DATE } from "../src/tokens";
 
+const storyName = getStoryName("Calendar");
+
 const noop = () => {};
 
-storiesOf("Calendar / cypress", module)
+storiesOf(`${storyName}/Backyard/Tests/Cypress`, module)
   .add("SingleDateCalendar test", () => {
     const [date, setDate] = React.useState(null);
 

--- a/packages/Calendar/stories/screener.stories.js
+++ b/packages/Calendar/stories/screener.stories.js
@@ -2,14 +2,17 @@ import React from "react";
 import moment from "moment";
 import { storiesOf } from "@storybook/react";
 import L10n from "@paprika/l10n";
+import { getStoryName } from "storybook/storyTree";
 import SingleDateCalendar from "../src/SingleDateCalendar";
 import DateRangeCalendar from "../src/DateRangeCalendar";
 import ShortCutPanel from "../src/internal/ShortcutPanel";
 import { START_DATE } from "../src/tokens";
 
+const storyName = getStoryName("Calendar");
+
 const noop = () => {};
 
-storiesOf("Calendar / screener", module)
+storiesOf(`${storyName}/Backyard/Tests/Screener`, module)
   .add("SingleDateCalendar", () => (
     <L10n>
       <SingleDateCalendar date={moment("2019-01-01", "YYYY-MM-DD")} onSelect={noop} />

--- a/packages/Calendar/tests/DateRangeCalendar.cypress.js
+++ b/packages/Calendar/tests/DateRangeCalendar.cypress.js
@@ -4,7 +4,7 @@ describe("<DateRangeCalendar />", () => {
   const today = moment();
 
   beforeEach(() => {
-    cy.visitStorybook("calendar-cypress--daterangecalendar-test");
+    cy.visitStorybook("forms-calendar-backyard-tests-cypress--daterangecalendar-test");
   });
 
   it("should be initialized with current month", () => {

--- a/packages/Calendar/tests/SingleDateCalendar.cypress.js
+++ b/packages/Calendar/tests/SingleDateCalendar.cypress.js
@@ -7,7 +7,7 @@ describe("<SingleDateCalendar />", () => {
     .date(1);
 
   beforeEach(() => {
-    cy.visitStorybook("calendar-cypress--singledatecalendar-test");
+    cy.visitStorybook("forms-calendar-backyard-tests-cypress--singledatecalendar-test");
   });
 
   const selectADateByClick = () => {

--- a/packages/DataGrid/stories/DataGrid.resize.stories.js
+++ b/packages/DataGrid/stories/DataGrid.resize.stories.js
@@ -1,11 +1,13 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import * as Sbook from "storybook/assets/styles/common.styles";
+import { getStoryName } from "storybook/storyTree";
 import Heading from "@paprika/heading";
 import ActionBar, { ColumnsArrangement, useColumnsArrangement } from "../../ActionBar/src";
-
 import DataGrid from "../src";
 import fixtures from "./helpers/fixtures";
+
+const storyName = getStoryName("DataGrid");
 
 const data = fixtures(10);
 
@@ -120,7 +122,7 @@ function AppWithActionBar() {
   );
 }
 
-storiesOf("DataGrid / resize", module).add("Resize", () => (
+storiesOf(`${storyName}/Examples`, module).add("Resize", () => (
   <>
     <MultipleCanGrow />
     <CanGrowStressing />


### PR DESCRIPTION
### Purpose 🚀
Make sure you can supply a custom colour for the icon in `<Button.Icon kind='minor'>` but without overriding the disabled colour.


### Notes ✏️
- Also refactored the `<Button.Link>` icon styling.
- **BONUS**: Adjusted the Storybook webpack config, as suggested by @alexzherdev.
- **BONUS**: Tidy up of Storybook stories.


### Updates 📦
- [x] PATCH (bug fix) change to `@paprika/button`

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/RAPRM-373--disabled-icon-button-styling/?path=/story/commands-button--variations


### Screenshots 📸
<img width="597" alt="Screen Shot 2020-06-19 at 4 35 43 PM" src="https://user-images.githubusercontent.com/14944896/85186080-d4c20d80-b24b-11ea-8e14-1670ca18227a.png">


### References 🔗
https://aclgrc.atlassian.net/browse/RAPRM-373


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
