### PR TITLE
RAPRM-373 Propagate Takeover classnames 🐐

### DIFF
--- a/packages/Overlay/src/Overlay.js
+++ b/packages/Overlay/src/Overlay.js
@@ -124,6 +124,7 @@ const Overlay = props => {
   );
 };
 
+Overlay.displayName = "Overlay";
 Overlay.propTypes = propTypes;
 Overlay.defaultProps = defaultProps;
 

--- a/packages/Takeover/src/Takeover.js
+++ b/packages/Takeover/src/Takeover.js
@@ -93,7 +93,7 @@ export default function Takeover(props) {
       data-pka-anchor="takeover"
       role="dialog"
     >
-      {headerExtracted && <sc.Header onClose={onClose} {...headerExtracted.props} />}
+      {headerExtracted && <sc.Header {...headerExtracted.props} onClose={onClose} />}
       {contentExtracted && (
         <sc.ContentWrapper {...contentExtracted.props} role="region" tabIndex="0">
           {contentExtracted}

--- a/packages/Takeover/src/Takeover.js
+++ b/packages/Takeover/src/Takeover.js
@@ -1,8 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
-import Overlay from "@paprika/overlay";
 import { zValue } from "@paprika/stylers/lib/helpers";
 import extractChildren from "@paprika/helpers/lib/extractChildren";
+import Overlay from "@paprika/overlay";
 import FocusLock from "./components/FocusLock";
 import Header from "./components/Header";
 import Content from "./components/Content";
@@ -46,17 +46,12 @@ export default function Takeover(props) {
   const { a11yText, isOpen, onClose, onAfterClose, onAfterOpen, zIndex, ...moreProps } = props;
 
   const {
-    "Takeover.FocusLock": focusLockExtracted,
-    "Takeover.Overlay": overlayExtracted,
-    "Takeover.Header": headerExtracted,
     "Takeover.Content": contentExtracted,
+    "Takeover.FocusLock": focusLockExtracted,
+    "Takeover.Header": headerExtracted,
+    Overlay: overlayExtracted,
     children,
-  } = extractChildren(moreProps.children, [
-    "Takeover.Overlay",
-    "Takeover.Header",
-    "Takeover.Content",
-    "Takeover.FocusLock",
-  ]);
+  } = extractChildren(moreProps.children, ["Takeover.Content", "Takeover.FocusLock", "Takeover.Header", "Overlay"]);
 
   const focusLockProps = focusLockExtracted ? focusLockExtracted.props : {};
   const focusLockOptions = {
@@ -66,24 +61,41 @@ export default function Takeover(props) {
 
   const takeoverOverlay = overlayExtracted || <TakeoverOverlay />;
   const overlayProps = {
-    ...takeoverOverlay.props,
+    zIndex,
     "data-pka-anchor": "takeover.overlay",
-    focusLockOptions,
     hasBackdrop: false,
+    focusLockOptions,
+    ...takeoverOverlay.props,
     isOpen,
     onAfterClose,
     onAfterOpen,
     onClose,
-    zIndex,
   };
 
-  const ariaLabel = a11yText || (headerExtracted ? headerExtracted.props.children : null);
+  function getAriaLabel() {
+    if (a11yText) return a11yText;
+    if (!headerExtracted || typeof headerExtracted.props.children !== "string") {
+      console.error(
+        "Accessibility is important 😇\nThe Takeover requires either an a11yText prop or a Takeover.Header with a string for children."
+      );
+      return null;
+    }
+
+    return headerExtracted.props.children;
+  }
 
   return React.cloneElement(takeoverOverlay, overlayProps, state => (
-    <sc.Wrapper state={state} role="dialog" aria-label={ariaLabel} aria-modal="true" data-pka-anchor="takeover">
-      {headerExtracted && <sc.Header {...headerExtracted.props} onClose={onClose} />}
+    <sc.Wrapper
+      state={state}
+      {...moreProps}
+      aria-label={getAriaLabel()}
+      aria-modal="true"
+      data-pka-anchor="takeover"
+      role="dialog"
+    >
+      {headerExtracted && <sc.Header onClose={onClose} {...headerExtracted.props} />}
       {contentExtracted && (
-        <sc.ContentWrapper role="region" tabIndex="0">
+        <sc.ContentWrapper {...contentExtracted.props} role="region" tabIndex="0">
           {contentExtracted}
         </sc.ContentWrapper>
       )}

--- a/packages/Takeover/src/Takeover.js
+++ b/packages/Takeover/src/Takeover.js
@@ -89,7 +89,7 @@ export default function Takeover(props) {
       state={state}
       {...moreProps}
       aria-label={getAriaLabel()}
-      aria-modal="true"
+      aria-modal
       data-pka-anchor="takeover"
       role="dialog"
       zIndex={zIndex}

--- a/packages/Takeover/src/Takeover.js
+++ b/packages/Takeover/src/Takeover.js
@@ -61,7 +61,6 @@ export default function Takeover(props) {
 
   const takeoverOverlay = overlayExtracted || <TakeoverOverlay />;
   const overlayProps = {
-    zIndex,
     "data-pka-anchor": "takeover.overlay",
     hasBackdrop: false,
     focusLockOptions,
@@ -70,6 +69,7 @@ export default function Takeover(props) {
     onAfterClose,
     onAfterOpen,
     onClose,
+    zIndex,
   };
 
   function getAriaLabel() {
@@ -92,6 +92,7 @@ export default function Takeover(props) {
       aria-modal="true"
       data-pka-anchor="takeover"
       role="dialog"
+      zIndex={zIndex}
     >
       {headerExtracted && <sc.Header {...headerExtracted.props} onClose={onClose} />}
       {contentExtracted && (

--- a/packages/Takeover/src/components/Header.js
+++ b/packages/Takeover/src/components/Header.js
@@ -40,8 +40,8 @@ const Header = React.forwardRef((props, ref) => {
   );
 });
 
+Header.displayName = "Takeover.Header";
 Header.propTypes = propTypes;
 Header.defaultProps = defaultProps;
-Header.displayName = "Takeover.Header";
 
 export default Header;

--- a/packages/Takeover/stories/Takeover.stories.js
+++ b/packages/Takeover/stories/Takeover.stories.js
@@ -32,9 +32,11 @@ const TakeoverStory = ({ children }) => {
   return (
     <LongBlock>
       <Button onClick={toggle}>Open</Button>
-      <Takeover isOpen={isOpen} onClose={toggle} a11yText="Takeover View">
-        <Takeover.Overlay />
+      <Takeover isOpen={isOpen} onClose={toggle} a11yText="Takeover View" className="storybook-takeover">
+        <Takeover.Overlay className="storybook-takeover__overlay" />
+        <Takeover.FocusLock className="storybook-takeover__focuslock" />
         <Takeover.Header
+          className="storybook-takeover__header"
           hasCloseButton={boolean("Has close button", true, "Takeover.Header")}
           kind={select("Kind", ["default", "primary"], "default", "Takeover.Header")}
         >
@@ -74,7 +76,7 @@ storiesOf(storyName, module)
 storiesOf(`${storyName}/Examples`, module)
   .add("Basic", () => (
     <TakeoverStory>
-      <Takeover.Content>
+      <Takeover.Content className="storybook-takeover__content">
         {repeat(100, key => (
           <p key={key}>Some content here</p>
         ))}

--- a/packages/Takeover/stories/Takeover.stories.js
+++ b/packages/Takeover/stories/Takeover.stories.js
@@ -161,7 +161,7 @@ storiesOf(`${storyName}/Backyard/Sandbox`, module)
         `}
       >
         <Button onClick={toggle}>Open Takeover</Button>
-        <Takeover isOpen={isOpen} onClose={toggle} zIndex={999}>
+        <Takeover isOpen={isOpen} onClose={toggle} zIndex={99}>
           <Takeover.Header
             hasCloseButton={boolean("Has close button", true, "Takeover.Header")}
             kind={select("Kind", ["default", "primary"], "default", "Takeover.Header")}


### PR DESCRIPTION
### Purpose 🚀
Implement the propagation of `classNames` for root `<Takeover>` element, as well as `<Takeover.Overlay>` + `<Takeover.Content>`.

### Notes ✏️
- Now propagating all props for Takeover and all Takeover subcomponents via `moreProps`.
- Had to add a `displayName` property to `<Overlay>` for `extractChildren` to work properly.
- Added custom classNames to all subcomponents in the Takeover "Basic" story.
- **BONUS**: avoid errors when the `a11yText` prop is omitted and the children for `Takeover.Header` component is a node by displaying a console.error instead.

### Updates 📦
<!-- - [ ] MAJOR (breaking) change to _these packages_ -->
- [x] MINOR (backward compatible) change to `@paprika/takeover`
- [x] PATCH (bug fix) change to `@paprika/overlay`

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/RAPRM-373--propagate-takeover-props

### References 🔗
https://aclgrc.atlassian.net/browse/RAPRM-373


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
