### PR TITLE
RAPRM-373 Fix small Toast + Takeover bugs 🐐

### DIFF
--- a/packages/Takeover/src/Takeover.js
+++ b/packages/Takeover/src/Takeover.js
@@ -96,7 +96,7 @@ export default function Takeover(props) {
     >
       {headerExtracted && <sc.Header {...headerExtracted.props} onClose={onClose} />}
       {contentExtracted && (
-        <sc.ContentWrapper {...contentExtracted.props} role="region" tabIndex="0">
+        <sc.ContentWrapper role="region" tabIndex="0">
           {contentExtracted}
         </sc.ContentWrapper>
       )}

--- a/packages/Toast/package.json
+++ b/packages/Toast/package.json
@@ -17,7 +17,7 @@
     "@babel/runtime-corejs2": "^7.3.1",
     "@paprika/button": "^0.3.1",
     "@paprika/helpers": "^0.2.12",
-    "@paprika/icon": "^0.1.6",
+    "@paprika/icon": "^0.3.3",
     "@paprika/stylers": "^0.2.8",
     "@paprika/tokens": "^0.1.14",
     "prop-types": "^15.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2391,16 +2391,6 @@
   resolved "https://registry.yarnpkg.com/@paprika/helpers/-/helpers-0.1.3.tgz#2606180f2e5df0316e37442930dba5f016aa8697"
   integrity sha512-blM25OcVpnmiGTV7k7egviTjTfVKbir7V1mF/lUPaekJ7w7yD2qPEVhteNMVIPCMbTvbJaLBGI8XqJbndNsPiQ==
 
-"@paprika/icon@^0.1.6":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@paprika/icon/-/icon-0.1.6.tgz#bc77e91a165ff9257ce48d5d0fd60f2326a46323"
-  integrity sha512-q7M3G9gdgLuZ2iblQUNFwdbcqqw6coOo1hmlhfw2/kXrrca9NMe7x4lrbEXHpNBUGoihI+D1sGbO0QyfTjMdJQ==
-  dependencies:
-    "@babel/runtime-corejs2" "^7.3.1"
-    "@paprika/tokens" "^0.1.4"
-    "@svgr/cli" "^4.1.0"
-    prop-types "^15.7.2"
-
 "@paprika/icon@^0.2.15":
   version "0.2.16"
   resolved "https://registry.yarnpkg.com/@paprika/icon/-/icon-0.2.16.tgz#689b394e9828dd624cd825897f20aa9dea82d42d"


### PR DESCRIPTION
### Purpose 🚀

1. The `<Toast>` had a dependency on an old version of the `@paprika/icon` that didn't include the `ColoredCaution` icon.

2. I mistakenly propagated too many props onto `<Takeover.Content>` that was resulting in multiple classNames being applied in a [previous PR](https://github.com/acl-services/paprika/pull/575).


### Updates 📦
- [x] PATCH (bug fix) change to `@paprika/toast` / `@paprika/takeover`

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/RAPRM-373--fix-toast-and-takeover


### References 🔗
https://aclgrc.atlassian.net/browse/RAPRM-373


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
