### PR TITLE
Tw 353 radio remove readonly

### DIFF
--- a/packages/Radio/CHANGELOG.md
+++ b/packages/Radio/CHANGELOG.md
@@ -9,3 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Added tabIndex prop which is forwarded to input [@tristanjasper](https://github.com/tristanjasper).
+
+## [0.1.24] - 2020-06-26
+
+### Added
+
+- Remove readonly true prop from input (fix safari focus) [@tristanjasper](https://github.com/tristanjasper).

--- a/packages/Radio/src/Radio.js
+++ b/packages/Radio/src/Radio.js
@@ -91,7 +91,6 @@ function Radio(props) {
 
   const inputProps = {
     "aria-describedby": ariaDescribedBy,
-    readOnly: true,
     onClick,
     checked: isChecked,
     disabled: isDisabled,


### PR DESCRIPTION
### Purpose 🚀
Removing Readonly true on the radio component as this is won't allow input focus in safari.
When used with formElement the radio can now be focused in Safari.

### Notes ✏️
Did some research and I don't believe readonly should ever have been added to this input type and can make it unusable.

### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_
- [x] PATCH (bug fix) change to Radio

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/tw-353-radio-remove-readonly

### Screenshots 📸
_optional but highly recommended_

### References 🔗
https://aclgrc.atlassian.net/browse/TW-268
https://aclgrc.atlassian.net/browse/TW-353


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
