### PR TITLE
STAR-258 Button + ButtonGroup accessibility + styling 🐐

### DIFF
--- a/packages/Button/src/Button.js
+++ b/packages/Button/src/Button.js
@@ -65,7 +65,7 @@ const defaultProps = {
   canPropagate: true,
   children: null,
   icon: null,
-  isActive: false,
+  isActive: null,
   isDisabled: false,
   isDropdown: false,
   isFullWidth: false,
@@ -151,9 +151,9 @@ const Button = React.forwardRef((props, ref) => {
   }
 
   const buttonProps = {
-    tabIndex,
-    "data-pka-anchor": "button",
     "aria-pressed": isActive,
+    "data-pka-anchor": "button",
+    tabIndex,
     ...moreProps,
     "data-has-forced-focus": hasForcedFocus || null,
     isActive,

--- a/packages/Button/src/Button.styles.js
+++ b/packages/Button/src/Button.styles.js
@@ -4,6 +4,28 @@ import { css, keyframes } from "styled-components";
 import { ShirtSizes } from "@paprika/helpers/lib/customPropTypes";
 import Kinds from "./ButtonKinds";
 
+// Borders
+
+const borderColors = {
+  [Kinds.DEFAULT]: tokens.border.color,
+  [Kinds.PRIMARY]: tokens.color.green,
+  [Kinds.SECONDARY]: tokens.color.purple,
+  [Kinds.DESTRUCTIVE]: tokens.color.orange,
+  [Kinds.FLAT]: tokens.border.color,
+  [Kinds.MINOR]: "transparent",
+  [Kinds.LINK]: "transparent",
+};
+
+const borderHoverColors = {
+  [Kinds.DEFAULT]: tokens.border.hoverColor,
+  [Kinds.PRIMARY]: tokens.color.greenDarken10,
+  [Kinds.SECONDARY]: tokens.color.purpleDarken10,
+  [Kinds.DESTRUCTIVE]: tokens.color.orangeDarken10,
+  [Kinds.FLAT]: tokens.border.hoverColor,
+  [Kinds.MINOR]: "transparent",
+  [Kinds.LINK]: "transparent",
+};
+
 // States
 
 const disabledStyles = css`
@@ -51,17 +73,12 @@ const activeStyles = css`
 
 const mouseStyles = css`
   [data-whatinput="mouse"] &:not([data-has-forced-focus="true"]):focus {
-    border-color: ${tokens.border.color};
+    border-color: ${({ kind }) => borderColors[kind]};
     box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1);
+    ${({ kind }) => [Kinds.FLAT, Kinds.MINOR, Kinds.LINK].includes(kind) && "box-shadow: none;"}
 
-    &[kind="minor"],
-    &[kind="link"] {
-      box-shadow: none;
-      border-color: transparent;
-    }
-
-    &[kind="flat"] {
-      box-shadow: none;
+    &:hover {
+      border-color: ${({ kind }) => borderHoverColors[kind]};
     }
   }
 `;
@@ -141,12 +158,10 @@ const kindStyles = props => ({
 
     background-color: ${tokens.color.white};
     background-image: linear-gradient(${tokens.color.blackLighten90}, ${tokens.color.blackLighten70});
-    border-color: ${tokens.border.color};
     color: ${tokens.color.black};
 
     &:hover {
       background: ${tokens.color.blackLighten70};
-      border-color: ${tokens.border.hoverColor};
     }
 
     ${props.isDisabled ? disabledStyles : ""}
@@ -157,11 +172,9 @@ const kindStyles = props => ({
 
     background-color: ${tokens.color.greenLighten10};
     background-image: linear-gradient(${tokens.color.greenLighten10}, ${tokens.color.green});
-    border-color: ${tokens.color.green};
 
     &:hover {
       background: ${tokens.color.green};
-      border-color: ${tokens.border.greenDarken10};
     }
 
     ${props.isDisabled ? disabledStyles : ""}
@@ -172,11 +185,9 @@ const kindStyles = props => ({
 
     background-color: ${tokens.color.purpleLighten10};
     background-image: linear-gradient(${tokens.color.purpleLighten10}, ${tokens.color.purple});
-    border-color: ${tokens.color.purple};
 
     &:hover {
       background: ${tokens.color.purple};
-      border-color: ${tokens.border.purpleDarken10};
     }
 
     ${props.isDisabled ? disabledStyles : ""}
@@ -187,11 +198,9 @@ const kindStyles = props => ({
 
     background-color: ${tokens.color.orangeHighlight};
     background-image: linear-gradient(${tokens.color.orangeHighlight}, ${tokens.color.orange});
-    border-color: ${tokens.color.orange};
 
     &:hover {
       background: ${tokens.color.orange};
-      border-color: ${tokens.border.orangeDarken10};
     }
 
     ${props.isDisabled ? disabledStyles : ""}
@@ -200,13 +209,11 @@ const kindStyles = props => ({
     ${skeuomorphicStyles}
 
     background-color: ${tokens.color.white};
-    border-color: ${tokens.border.color};
     box-shadow: none;
     color: ${tokens.color.black};
 
     &:hover {
       background: ${tokens.color.blackLighten70};
-      border-color: ${tokens.border.hoverColor};
     }
 
     ${props.isDisabled ? disabledStyles : ""}
@@ -255,6 +262,12 @@ const buttonStyles = props => css`
   ${sizeStyles[props.size]}
   ${kindStyles(props)[props.kind]}
   ${props.isFullWidth ? fullWidthStyles : ""}
+
+  border-color: ${({ kind }) => borderColors[kind]};
+  &:not([disabled]):not([aria-disabled="true"]):hover {
+    border-color: ${({ kind }) => borderHoverColors[kind]};
+  }
+
   ${props.isActive ? activeStyles : ""}
 `;
 

--- a/packages/Button/src/Button.styles.js
+++ b/packages/Button/src/Button.styles.js
@@ -4,6 +4,14 @@ import { css, keyframes } from "styled-components";
 import { ShirtSizes } from "@paprika/helpers/lib/customPropTypes";
 import Kinds from "./ButtonKinds";
 
+const dropShadow = "0 1px 2px 0 rgba(0, 0, 0, 0.1)";
+
+const enabled = content => css`
+  &:not([disabled]):not([aria-disabled="true"]) {
+    ${content};
+  }
+`;
+
 // Borders
 
 const borderColors = {
@@ -25,6 +33,16 @@ const borderHoverColors = {
   [Kinds.MINOR]: "transparent",
   [Kinds.LINK]: "transparent",
 };
+
+const borderStyles = css`
+  border-color: ${({ kind }) => borderColors[kind]};
+
+  &:hover {
+    ${enabled(css`
+      border-color: ${({ kind }) => borderHoverColors[kind]};
+    `)}
+  }
+`;
 
 // States
 
@@ -71,15 +89,22 @@ const activeStyles = css`
   ${stylers.focusRing.bordered()}
 `;
 
-const mouseStyles = css`
-  [data-whatinput="mouse"] &:not([data-has-forced-focus="true"]):focus {
-    border-color: ${({ kind }) => borderColors[kind]};
-    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1);
-    ${({ kind }) => [Kinds.FLAT, Kinds.MINOR, Kinds.LINK].includes(kind) && "box-shadow: none;"}
+const inactiveStyles = css`
+  ${borderStyles}
 
-    &:hover {
-      border-color: ${({ kind }) => borderHoverColors[kind]};
-    }
+  [data-whatinput="mouse"] &:not([data-has-forced-focus="true"]):focus {
+    ${enabled(css`
+      ${borderStyles}
+
+      ${({ kind }) =>
+        [Kinds.FLAT, Kinds.MINOR, Kinds.LINK].includes(kind)
+          ? css`
+              box-shadow: none;
+            `
+          : css`
+              box-shadow: ${dropShadow};
+            `}
+    `)}
   }
 `;
 
@@ -104,8 +129,6 @@ const commonStyles = css`
     ${stylers.focusRing.bordered()}
   }
 
-  ${({ isActive }) => (isActive ? activeStyles : mouseStyles)}
-
   &:active {
     box-shadow: ${tokens.highlight.active.noBorder.boxShadow}, inset 0 1px 1px 0 rgba(0, 0, 0, 0.1),
       inset 0 1px 4px 0 rgba(0, 0, 0, 0.3);
@@ -114,7 +137,7 @@ const commonStyles = css`
 `;
 
 const skeuomorphicStyles = css`
-  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1);
+  box-shadow: ${dropShadow};
   cursor: pointer;
   transition-duration: 0.2s;
   transition-property: border;
@@ -261,14 +284,8 @@ const buttonStyles = props => css`
   ${commonStyles}
   ${sizeStyles[props.size]}
   ${kindStyles(props)[props.kind]}
-  ${props.isFullWidth ? fullWidthStyles : ""}
-
-  border-color: ${({ kind }) => borderColors[kind]};
-  &:not([disabled]):not([aria-disabled="true"]):hover {
-    border-color: ${({ kind }) => borderHoverColors[kind]};
-  }
-
-  ${props.isActive ? activeStyles : ""}
+  ${props.isFullWidth && fullWidthStyles}
+  ${({ isActive }) => (isActive ? activeStyles : inactiveStyles)}
 `;
 
 export default buttonStyles;
@@ -296,10 +313,7 @@ const iconColors = {
   [Kinds.LINK]: tokens.textColor.icon,
 };
 
-function getIconColor(props) {
-  if (props.isDisabled) return tokens.color.blackDisabled;
-  return iconColors[props.kind];
-}
+const getIconColor = props => (props.isDisabled ? tokens.color.blackDisabled : iconColors[props.kind]);
 
 export const iconStyles = props => css`
   align-items: center;
@@ -312,11 +326,13 @@ export const iconStyles = props => css`
     vertical-align: -${(stylers.lineHeightValue(-1) - 1) / 2}em;
   }
 
-  ${props.isPending
-    ? css`
-        animation: ${spinKeyframes} 2s infinite linear;
-      `
-    : ""}
+  ${props.isPending &&
+    css`
+      animation: ${spinKeyframes} 2s infinite linear;
+    `}
 
-  ${props.isSuffixIcon ? `margin: 0 0 0 ${tokens.spaceSm};` : ""}
+  ${props.isSuffixIcon &&
+    css`
+      margin: 0 0 0 ${tokens.spaceSm};
+    `}
 `;

--- a/packages/Button/src/Button.styles.js
+++ b/packages/Button/src/Button.styles.js
@@ -187,7 +187,7 @@ const kindStyles = props => ({
       background: ${tokens.color.blackLighten70};
     }
 
-    ${props.isDisabled ? disabledStyles : ""}
+    ${props.isDisabled && disabledStyles}
   `,
   [Kinds.PRIMARY]: css`
     ${skeuomorphicStyles}
@@ -200,7 +200,7 @@ const kindStyles = props => ({
       background: ${tokens.color.green};
     }
 
-    ${props.isDisabled ? disabledStyles : ""}
+    ${props.isDisabled && disabledStyles}
   `,
   [Kinds.SECONDARY]: css`
     ${skeuomorphicStyles}
@@ -213,7 +213,7 @@ const kindStyles = props => ({
       background: ${tokens.color.purple};
     }
 
-    ${props.isDisabled ? disabledStyles : ""}
+    ${props.isDisabled && disabledStyles}
   `,
   [Kinds.DESTRUCTIVE]: css`
     ${skeuomorphicStyles}
@@ -226,7 +226,7 @@ const kindStyles = props => ({
       background: ${tokens.color.orange};
     }
 
-    ${props.isDisabled ? disabledStyles : ""}
+    ${props.isDisabled && disabledStyles}
   `,
   [Kinds.FLAT]: css`
     ${skeuomorphicStyles}
@@ -239,7 +239,7 @@ const kindStyles = props => ({
       background: ${tokens.color.blackLighten70};
     }
 
-    ${props.isDisabled ? disabledStyles : ""}
+    ${props.isDisabled && disabledStyles}
   `,
   [Kinds.MINOR]: css`
     ${textButtonStyles}
@@ -248,7 +248,7 @@ const kindStyles = props => ({
       text-decoration: underline;
     }
 
-    ${props.isDisabled ? disabledTextStyles : ""}
+    ${props.isDisabled && disabledTextStyles}
   `,
   [Kinds.LINK]: css`
     ${textButtonStyles}
@@ -265,7 +265,7 @@ const kindStyles = props => ({
       color: ${tokens.color.blue};
     }
 
-    ${props.isDisabled ? disabledTextStyles : ""}
+    ${props.isDisabled && disabledTextStyles}
   `,
 });
 

--- a/packages/Button/src/Button.styles.js
+++ b/packages/Button/src/Button.styles.js
@@ -46,11 +46,23 @@ const disabledTextStyles = css`
 `;
 
 const activeStyles = css`
-  border-color: ${tokens.highlight.active.noBorder.borderColor};
-  box-shadow: ${tokens.highlight.active.noBorder.boxShadow};
+  ${stylers.focusRing.bordered()}
+`;
 
-  &:hover:not([disabled]):not([aria-disabled="true"]) {
-    border-color: ${tokens.highlight.active.noBorder.borderColor};
+const mouseStyles = css`
+  [data-whatinput="mouse"] &:not([data-has-forced-focus="true"]):focus {
+    border-color: ${tokens.border.color};
+    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1);
+
+    &[kind="minor"],
+    &[kind="link"] {
+      box-shadow: none;
+      border-color: transparent;
+    }
+
+    &[kind="flat"] {
+      box-shadow: none;
+    }
   }
 `;
 
@@ -72,33 +84,10 @@ const commonStyles = css`
   vertical-align: middle;
 
   &:focus {
-    box-shadow: ${tokens.highlight.active.noBorder.boxShadow};
-    border-color: ${tokens.highlight.active.noBorder.borderColor};
-    outline: none;
+    ${stylers.focusRing.bordered()}
   }
 
-  [data-whatinput="mouse"] &:focus {
-    &[data-has-forced-focus="true"] {
-      box-shadow: ${tokens.highlight.active.noBorder.boxShadow};
-    }
-
-    &:not([data-has-forced-focus="true"]) {
-      box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1);
-      border-color: ${tokens.border.color};
-
-      &[kind="minor"],
-      &[kind="link"] {
-        box-shadow: none;
-        border-color: transparent;
-      }
-
-      &[kind="flat"] {
-        box-shadow: none;
-      }
-    }
-
-    ${({ isActive }) => (isActive ? activeStyles : "")}
-  }
+  ${({ isActive }) => (isActive ? activeStyles : mouseStyles)}
 
   &:active {
     box-shadow: ${tokens.highlight.active.noBorder.boxShadow}, inset 0 1px 1px 0 rgba(0, 0, 0, 0.1),

--- a/packages/Button/stories/examples/Variations.js
+++ b/packages/Button/stories/examples/Variations.js
@@ -88,6 +88,24 @@ const ExampleStory = () => (
     </p>
     <Rule />
     <p>
+      <Button onClick={clickHandler} isActive>
+        active button
+      </Button>
+      <Button onClick={clickHandler} isActive kind="primary">
+        active button
+      </Button>
+      <Button onClick={clickHandler} isActive kind="flat">
+        active button
+      </Button>
+      <Button onClick={clickHandler} isActive kind="minor">
+        active button
+      </Button>
+      <Button onClick={clickHandler} isActive kind="link">
+        active button
+      </Button>
+    </p>
+    <Rule />
+    <p>
       <Button.Link onClick={clickHandler} kind="primary" href="https://youtu.be/IdkCEioCp24?t=92">
         Link
       </Button.Link>

--- a/packages/ButtonGroup/src/ButtonGroup.js
+++ b/packages/ButtonGroup/src/ButtonGroup.js
@@ -74,11 +74,9 @@ const ButtonGroup = React.forwardRef((props, ref) => {
 
   React.useImperativeHandle(ref, () => ({
     focus: () => {
-      const firstEnabledIndex = getEnabledIndexes()[0];
-      const firstEnabledItemRef = itemRefs[firstEnabledIndex];
-      if (firstEnabledItemRef) {
-        firstEnabledItemRef.current.focus();
-        setFocusIndex(firstEnabledIndex);
+      if (currentFocusIndex !== null) {
+        const currentFocusRef = itemRefs[currentFocusIndex];
+        if (currentFocusRef) currentFocusRef.current.focus();
       }
     },
   }));

--- a/packages/ButtonGroup/src/components/Item/Item.styles.js
+++ b/packages/ButtonGroup/src/components/Item/Item.styles.js
@@ -14,8 +14,14 @@ const activeStyles = css`
     background-color: ${tokens.color.blueLighten40};
   }
 
-  &:hover:not([disabled]):not([aria-disabled="true"]) {
-    background-color: ${tokens.color.blueLighten50};
+  &:not([disabled]):not([aria-disabled="true"]) {
+    &,
+    &:focus {
+      border-color: ${tokens.color.blue};
+    }
+    &:hover {
+      background-color: ${tokens.color.blueLighten50};
+    }
   }
 `;
 

--- a/packages/ButtonGroup/stories/examples/Sandbox.js
+++ b/packages/ButtonGroup/stories/examples/Sandbox.js
@@ -23,33 +23,41 @@ const buttonGroupProps = () => ({
   size: select("size", ShirtSizes.DEFAULT, ShirtSizes.MEDIUM),
 });
 
-const ExampleStory = props => (
-  <Story>
-    <Heading level={1} displayLevel={2} isLight>
-      Testing Sandbox
-    </Heading>
-    <Rule />
-    <p>
-      <button>Pre</button>
-    </p>
-    <ButtonGroup {...props}>
-      <ButtonGroup.Item value="one" kind="primary">
-        One
-      </ButtonGroup.Item>
-      <ButtonGroup.Item value="two" isDisabled defaultIsActive>
-        Two
-      </ButtonGroup.Item>
-      <>
-        <ButtonGroup.Item value={3}>Three Three Three Three Three Three</ButtonGroup.Item>
-        <ButtonGroup.Item value="four">
-          <Calendar />
+const ExampleStory = props => {
+  const refButtonGroup = React.createRef();
+
+  const handleFocus = () => {
+    refButtonGroup.current.focus();
+  };
+
+  return (
+    <Story>
+      <Heading level={1} displayLevel={2} isLight>
+        Testing Sandbox
+      </Heading>
+      <Rule />
+      <p>
+        <button onClick={handleFocus}>Focus Pre</button>
+      </p>
+      <ButtonGroup {...props} ref={refButtonGroup}>
+        <ButtonGroup.Item value="one" kind="primary">
+          One
         </ButtonGroup.Item>
-      </>
-    </ButtonGroup>
-    <p>
-      <button>Post</button>
-    </p>
-  </Story>
-);
+        <ButtonGroup.Item value="two" isDisabled defaultIsActive>
+          Two
+        </ButtonGroup.Item>
+        <>
+          <ButtonGroup.Item value={3}>Three Three Three Three Three Three</ButtonGroup.Item>
+          <ButtonGroup.Item value="four">
+            <Calendar />
+          </ButtonGroup.Item>
+        </>
+      </ButtonGroup>
+      <p>
+        <button onClick={handleFocus}>Focus Post</button>
+      </p>
+    </Story>
+  );
+};
 
 export default () => <ExampleStory {...buttonGroupProps()} />;

--- a/packages/RawButton/src/RawButton.js
+++ b/packages/RawButton/src/RawButton.js
@@ -45,9 +45,10 @@ const defaultProps = {
   tabIndex: null,
 };
 
+const isTriggerKey = key => [" ", "Enter"].includes(key);
+
 const RawButton = React.forwardRef((props, ref) => {
   const { a11yText, canPropagate, children, isActive, isDisabled, onClick, tabIndex, ...moreProps } = props;
-  if (a11yText) moreProps["aria-label"] = a11yText;
 
   const rawButtonRef = React.useRef(null);
   const [hasForcedFocus, setHasForcedFocus] = React.useState(false);
@@ -66,30 +67,24 @@ const RawButton = React.forwardRef((props, ref) => {
   };
 
   function handleBlur() {
-    if ("onBlur" in moreProps) {
-      moreProps.onBlur();
-    }
+    if (moreProps.onBlur) moreProps.onBlur();
     setHasForcedFocus(false);
   }
 
   const handleKeyDown = event => {
-    if (
-      // Prevent scrolling the page with a spacerbar keypress
-      event.key === " " ||
-      // Prevent submitting forms in IE/Edge with and enter keypress
-      event.key === "Enter"
-    ) {
-      event.preventDefault();
-    }
+    // Prevent scrolling the page with a spacerbar keypress
+    // Prevent submitting forms in IE/Edge with and enter keypress
+    if (isTriggerKey(event.key)) event.preventDefault();
+    const shouldHandle = canPropagate || event.target === rawButtonRef.current;
+    if (shouldHandle && moreProps.onKeyDown) moreProps.onKeyDown(event);
   };
 
   const handleKeyUp = event => {
     const shouldHandle = canPropagate || event.target === rawButtonRef.current;
-    const isTriggerKey = event.key === " " || event.key === "Enter";
-
-    if (!isDisabled && shouldHandle && isTriggerKey) {
+    if (!isDisabled && shouldHandle && isTriggerKey(event.key)) {
       onClick(event);
     }
+    if (shouldHandle && moreProps.onKeyUp) moreProps.onKeyUp(event);
   };
 
   const bestTabIndex = isDisabled && tabIndex === null ? -1 : tabIndex || 0;
@@ -99,6 +94,7 @@ const RawButton = React.forwardRef((props, ref) => {
       aria-pressed={isActive}
       data-pka-anchor="raw-button"
       tabIndex={bestTabIndex}
+      aria-label={a11yText}
       {...moreProps}
       aria-disabled={isDisabled}
       css={rawButtonStyles}

--- a/packages/RawButton/src/RawButton.js
+++ b/packages/RawButton/src/RawButton.js
@@ -18,6 +18,9 @@ const propTypes = {
   /** If the visual focus ring should be displayed with an inset style. */
   hasInsetFocusStyle: PropTypes.bool,
 
+  /** If the button is in an "active" or "selected" state. */
+  isActive: PropTypes.bool,
+
   /** If the button is disabled. */
   isDisabled: PropTypes.bool,
 
@@ -34,6 +37,7 @@ const propTypes = {
 const defaultProps = {
   a11yText: null,
   canPropagate: true,
+  isActive: null,
   isDisabled: false,
   hasInsetFocusStyle: false,
   onClick: () => {},
@@ -42,7 +46,7 @@ const defaultProps = {
 };
 
 const RawButton = React.forwardRef((props, ref) => {
-  const { a11yText, canPropagate, children, isDisabled, onClick, tabIndex, ...moreProps } = props;
+  const { a11yText, canPropagate, children, isActive, isDisabled, onClick, tabIndex, ...moreProps } = props;
   if (a11yText) moreProps["aria-label"] = a11yText;
 
   const rawButtonRef = React.useRef(null);
@@ -92,18 +96,20 @@ const RawButton = React.forwardRef((props, ref) => {
 
   return (
     <span
+      aria-pressed={isActive}
+      data-pka-anchor="raw-button"
+      tabIndex={bestTabIndex}
+      {...moreProps}
       aria-disabled={isDisabled}
       css={rawButtonStyles}
-      data-pka-anchor="raw-button"
+      data-has-forced-focus={hasForcedFocus || null}
+      isActive={isActive}
       isDisabled={isDisabled}
       onBlur={handleBlur}
       onClick={handleClick}
       onKeyDown={handleKeyDown}
       onKeyUp={handleKeyUp}
       ref={rawButtonRef}
-      tabIndex={bestTabIndex}
-      {...moreProps}
-      data-has-forced-focus={hasForcedFocus || null}
     >
       {children}
     </span>

--- a/packages/RawButton/src/RawButton.styles.js
+++ b/packages/RawButton/src/RawButton.styles.js
@@ -1,23 +1,13 @@
 import { css } from "styled-components";
-import tokens from "@paprika/tokens";
-
-const focusStyle = tokens.highlight.active.withBorder.boxShadow;
-const insetFocusStyle = tokens.highlight.active.withBorder.insetBoxShadow;
+import stylers from "@paprika/stylers";
 
 const focusStyles = isInset => css`
   &:focus {
-    box-shadow: ${isInset ? insetFocusStyle : focusStyle};
-    outline: none;
+    ${stylers.focusRing(isInset)}
   }
 
-  [data-whatinput="mouse"] &:focus {
-    &[data-has-forced-focus="true"] {
-      box-shadow: ${tokens.highlight.active.noBorder.boxShadow};
-    }
-
-    &:not([data-has-forced-focus="true"]) {
-      box-shadow: none;
-    }
+  [data-whatinput="mouse"] &:not([data-has-forced-focus="true"]):focus {
+    box-shadow: none;
   }
 `;
 
@@ -32,8 +22,9 @@ const disabledStyles = css`
 const rawButtonStyles = css`
   cursor: pointer;
   display: inline-block;
-  ${({ hasInsetFocusStyle }) => focusStyles(hasInsetFocusStyle)};
-  ${({ isDisabled }) => (isDisabled ? disabledStyles : null)};
+  ${({ hasInsetFocusStyle, isActive }) =>
+    isActive ? stylers.focusRing(hasInsetFocusStyle) : focusStyles(hasInsetFocusStyle)};
+  ${({ isDisabled }) => isDisabled && disabledStyles};
 `;
 
 export default rawButtonStyles;

--- a/packages/RawButton/stories/examples/Basic.js
+++ b/packages/RawButton/stories/examples/Basic.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { action } from "@storybook/addon-actions";
-import { Story, Small, Rule, breaklines } from "storybook/assets/styles/common.styles";
+import { Story, Small, Gap, breaklines } from "storybook/assets/styles/common.styles";
 import RawButton from "../../src";
 
 function clickHandler() {
@@ -24,7 +24,13 @@ const ExampleStory = () => {
       <p>
         <RawButton onClick={clickHandler}>RawButton</RawButton>
       </p>
-      <Rule />
+      <Gap />
+      <p>
+        <RawButton isActive onClick={clickHandler}>
+          Active RawButton
+        </RawButton>
+      </p>
+      <Gap />
       <p>
         <RawButton
           a11yText="ceci n'est pas un bouton"
@@ -39,17 +45,21 @@ const ExampleStory = () => {
       <p>
         <Small>This RawButton will capture the focus after 1 second.</Small>
       </p>
-      <Rule />
+      <Gap />
       <p>
         <RawButton isDisabled onClick={clickHandler}>
           Disabled RawButton
         </RawButton>
       </p>
-      <Rule />
+      <Gap />
       <p>
         <RawButton isDisabled tabIndex={0} onClick={clickHandler}>
           Disabled but tabbable
         </RawButton>
+      </p>
+      <Gap />
+      <p>
+        <button type="button">Post</button>
       </p>
       {breaklines(34)}
       ...fin.


### PR DESCRIPTION
### Purpose 🚀
1. The `<Button>` should not be interpreted as a "toggle button" if the `isActive` prop is not explicitly provided.
2. The `<ButtonGroup>` `focus()` method should focus on the last focused item, not necessarily the _first_ item.


### Notes ✏️
- Also, the styling of various button states has been adjusted to match the intended design (it was a bit off after the introduction of the `whatinput` logic).


### Updates 📦
- [x] PATCH (bug fix) change to `button` / `button-group` / `raw-button`


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/STAR-258--button-buttongroup-a11y-styling/?path=/story/commands-button--variations


### References 🔗
https://aclgrc.atlassian.net/browse/STAR-258



<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
