### PR TITLE
STAR-241 bug(DataGrid) fixing scroll horizontal misaligned  / 🦄.

### DIFF
--- a/packages/DataGrid/src/DataGrid.js
+++ b/packages/DataGrid/src/DataGrid.js
@@ -203,36 +203,33 @@ const DataGrid = React.forwardRef((props, ref) => {
     [i18n]
   );
 
-  const handleScroll = React.useCallback(
-    parameters => {
-      const { scrollLeft, scrollTop } = parameters;
+  const handleScroll = React.useCallback(parameters => {
+    const { scrollLeft, scrollTop } = parameters;
 
-      if (refScrollHeader.current && stickyColumnsIndexes.length) {
-        refScrollHeader.current.scrollTo({ left: scrollLeft, top: 0 });
-      }
+    if (refScrollHeader.current) {
+      refScrollHeader.current.scrollTo({ left: scrollLeft, top: 0 });
+    }
 
-      // prevent re-scrolling when this scrollbar gets sync with the one in the sticky column
-      if (refScrollHappenedBy.current === null && stickyColumnsIndexes.length) {
-        refScrollHappenedBy.current = "handleScroll";
-        if (refScrollStickyColumns.current) {
-          refScrollStickyColumns.current.scrollTo({ left: 0, top: scrollTop });
-        }
-      } else {
-        refScrollHappenedBy.current = null;
+    // prevent re-scrolling when this scrollbar gets sync with the one in the sticky column
+    if (refScrollHappenedBy.current === null) {
+      refScrollHappenedBy.current = "handleScroll";
+      if (refScrollStickyColumns.current) {
+        refScrollStickyColumns.current.scrollTo({ left: 0, top: scrollTop });
       }
+    } else {
+      refScrollHappenedBy.current = null;
+    }
 
-      if (
-        refScrollGrid.current &&
-        refEnd.current &&
-        refScrollGrid.current.scrollTop + refScrollGrid.current.offsetHeight >= refScrollGrid.current.scrollHeight
-      ) {
-        refEnd.current.onScrollBarReachedBottom(true);
-      } else if (refEnd.current) {
-        refEnd.current.onScrollBarReachedBottom(false);
-      }
-    },
-    [stickyColumnsIndexes.length]
-  );
+    if (
+      refScrollGrid.current &&
+      refEnd.current &&
+      refScrollGrid.current.scrollTop + refScrollGrid.current.offsetHeight >= refScrollGrid.current.scrollHeight
+    ) {
+      refEnd.current.onScrollBarReachedBottom(true);
+    } else if (refEnd.current) {
+      refEnd.current.onScrollBarReachedBottom(false);
+    }
+  }, []);
 
   const handleScrollStickyColumns = React.useCallback(
     parameters => {
@@ -431,6 +428,7 @@ const DataGrid = React.forwardRef((props, ref) => {
   return (
     <>
       <sc.Grid
+        $width={gridWidth}
         aria-colcount={columnCount}
         gridId={gridId}
         onBlur={handleBlurGrid}
@@ -440,8 +438,8 @@ const DataGrid = React.forwardRef((props, ref) => {
         onMouseUp={handleMouseUpGrid}
         ref={refContainer}
         role="grid"
+        scrollBarWidth={scrollBarWidth}
         tabIndex={0}
-        $width={gridWidth}
         {...moreProps}
       >
         <sc.Flex>

--- a/packages/DataGrid/src/DataGrid.styles.js
+++ b/packages/DataGrid/src/DataGrid.styles.js
@@ -40,6 +40,8 @@ export const Grid = styled.div.attrs(({ $width }) => {
         /** header grid doesn't need overflow on the x side */
         overflow: hidden !important;
         /** let the vertical scroll overflow appears if the main grid has a scroll */
+        /** https://stackoverflow.com/questions/23200639/transparent-scrollbar-with-css */
+        /** https://developer.mozilla.org/en-US/docs/Web/CSS/overflow#Values ¯\_ツ_/¯ */
         overflow-y: ${scrollBarWidth > 0 ? "overlay" : "hidden"} !important;
       }
 

--- a/packages/DataGrid/src/DataGrid.styles.js
+++ b/packages/DataGrid/src/DataGrid.styles.js
@@ -30,14 +30,18 @@ export const Grid = styled.div.attrs(({ $width }) => {
   position: relative;
   box-shadow: 0 0 0 1px ${tokens.border.color};
 
-  ${({ gridId }) => {
+  ${({ gridId, scrollBarWidth }) => {
+    console.log("scrollBarWidth", scrollBarWidth);
     return css`
       .grid-${gridId} {
         overflow: auto !important;
       }
 
       .${gridId}-header {
+        /** header grid doesn't need overflow on the x side */
         overflow: hidden !important;
+        /** let the vertical scroll overflow appears if the main grid has a scroll */
+        overflow-y: ${scrollBarWidth > 0 ? "scroll" : "hidden"} !important;
       }
 
       .${gridId}-sticky-columns {

--- a/packages/DataGrid/src/DataGrid.styles.js
+++ b/packages/DataGrid/src/DataGrid.styles.js
@@ -31,7 +31,6 @@ export const Grid = styled.div.attrs(({ $width }) => {
   box-shadow: 0 0 0 1px ${tokens.border.color};
 
   ${({ gridId, scrollBarWidth }) => {
-    console.log("scrollBarWidth", scrollBarWidth);
     return css`
       .grid-${gridId} {
         overflow: auto !important;

--- a/packages/DataGrid/src/DataGrid.styles.js
+++ b/packages/DataGrid/src/DataGrid.styles.js
@@ -40,7 +40,7 @@ export const Grid = styled.div.attrs(({ $width }) => {
         /** header grid doesn't need overflow on the x side */
         overflow: hidden !important;
         /** let the vertical scroll overflow appears if the main grid has a scroll */
-        overflow-y: ${scrollBarWidth > 0 ? "scroll" : "hidden"} !important;
+        overflow-y: ${scrollBarWidth > 0 ? "overlay" : "hidden"} !important;
       }
 
       .${gridId}-sticky-columns {


### PR DESCRIPTION
### Purpose 🚀
After introducing a dynamic scrollbar #566 , a bug was introduced preventing the header to synchronize with the body of the DataGrid, as well as a misaligned between the header and the content when scrolling full to the right side see images.

### Notes ✏️

### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [x] MINOR (backward compatible) change to _these packages_
- [ ] PATCH (bug fix) change to _these packages_

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/STAR-241-scrolling-horizontal-fix


### Screenshots 📸
**before**
![Screen Shot 2020-06-26 at 1 32 53 PM](https://user-images.githubusercontent.com/19418590/85899297-b8c1ed00-b7b2-11ea-8cf3-a1ad7846ac58.png)

**after**
![Screen Shot 2020-06-26 at 1 32 41 PM](https://user-images.githubusercontent.com/19418590/85899292-b790c000-b7b2-11ea-9e9a-d6a7d24f6e34.png)

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
