### PR TITLE
SNP-233 Fix list box internal state for options update

### DIFF
--- a/packages/ListBox/src/hooks/hooks.js
+++ b/packages/ListBox/src/hooks/hooks.js
@@ -15,7 +15,10 @@ export function useChildrenChange(children) {
 
     if (Object.keys(state.options).length === Object.keys(options).length) {
       const difference = Object.values(state.options).find(
-        (prevOption, key) => !isEqual(prevOption.value, options[key].value)
+        (prevOption, key) =>
+          !isEqual(prevOption.value, options[key].value) ||
+          prevOption.isDisabled !== options[key].isDisabled ||
+          prevOption.isSelected !== options[key].isSelected
       );
       if (!difference) return;
     }


### PR DESCRIPTION
### Purpose 🚀

Fix list box internal state when options update

### Notes ✏️

`<Listbox > ` watches the change of its children(which is `<Listbox.Option>` ), before we only check if the `value` prop change, we should also check if `isDisabled` `isSelected` is changed to insure the internal state in the provider sync with other places


### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_
- [x] PATCH (bug fix) change to `@paprika/listbox`

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
