### PR TITLE
PDTVT-337 add custom icon for clear

### DIFF
--- a/packages/Input/src/Input.js
+++ b/packages/Input/src/Input.js
@@ -13,6 +13,8 @@ const propTypes = {
   /** Sets the class for the input. */
   className: PropTypes.string,
 
+  clearIcon: PropTypes.node,
+
   /** Sets the default input value  */
   defaultValue: PropTypes.string,
 
@@ -51,6 +53,7 @@ const propTypes = {
 
 const defaultProps = {
   a11yText: null,
+  clearIcon: <TimesCircleIcon />,
   className: null,
   defaultValue: "",
   hasClearButton: false,
@@ -77,6 +80,7 @@ const Input = props => {
     const { hasClearButton, isDisabled, isReadOnly, size, value } = props;
     if (!hasClearButton || isDisabled || isReadOnly || !value) return null;
     const iconSize = size === ShirtSizes.LARGE ? ShirtSizes.MEDIUM : ShirtSizes.SMALL;
+
     return (
       <Button.Icon
         a11yText="Clear Input" // TODO: add L10n
@@ -85,7 +89,7 @@ const Input = props => {
         size={iconSize}
         onClick={inputClearHandler}
       >
-        <TimesCircleIcon />
+        {props.clearIcon}
       </Button.Icon>
     );
   };

--- a/packages/Input/src/Input.js
+++ b/packages/Input/src/Input.js
@@ -13,6 +13,7 @@ const propTypes = {
   /** Sets the class for the input. */
   className: PropTypes.string,
 
+  /** Custom icon for the clear action in the input. */
   clearIcon: PropTypes.node,
 
   /** Sets the default input value  */

--- a/packages/Input/src/Input.js
+++ b/packages/Input/src/Input.js
@@ -54,7 +54,7 @@ const propTypes = {
 
 const defaultProps = {
   a11yText: null,
-  clearIcon: <TimesCircleIcon />,
+  clearIcon: null,
   className: null,
   defaultValue: "",
   hasClearButton: false,
@@ -78,7 +78,7 @@ const Input = props => {
   };
 
   const renderClear = () => {
-    const { hasClearButton, isDisabled, isReadOnly, size, value } = props;
+    const { clearIcon, hasClearButton, isDisabled, isReadOnly, size, value } = props;
     if (!hasClearButton || isDisabled || isReadOnly || !value) return null;
     const iconSize = size === ShirtSizes.LARGE ? ShirtSizes.MEDIUM : ShirtSizes.SMALL;
 
@@ -90,7 +90,7 @@ const Input = props => {
         size={iconSize}
         onClick={inputClearHandler}
       >
-        {props.clearIcon}
+        {clearIcon || <TimesCircleIcon />}
       </Button.Icon>
     );
   };

--- a/packages/Input/stories/Input.stories.js
+++ b/packages/Input/stories/Input.stories.js
@@ -9,6 +9,7 @@ import ShowcaseStory from "./examples/Showcase";
 import SizesStory from "./examples/Sizes";
 import WithContentStory from "./examples/WithContent";
 import WithIconStory from "./examples/WithIcon";
+import WithCustomClearIconStory from "./examples/WithCustomClearIconStory";
 import WithDisabledReadOnlyStory from "./examples/WithDisabledReadOnly";
 import TypesStory from "./examples/Types";
 import WithRef from "./examples/WithRef";
@@ -25,6 +26,7 @@ storiesOf(`${storyName}/Examples`, module)
   .add("Sizes", () => <SizesStory />)
   .add("With content", () => <WithContentStory />)
   .add("With decorative icon", () => <WithIconStory />)
+  .add("With custom clear icon", () => <WithCustomClearIconStory />)
   .add("With isDisabled / isReadOnly", () => <WithDisabledReadOnlyStory />)
   .add("Types", () => <TypesStory />)
   .add("With Ref", () => <WithRef />)

--- a/packages/Input/stories/examples/WithCustomClearIconStory.js
+++ b/packages/Input/stories/examples/WithCustomClearIconStory.js
@@ -1,0 +1,19 @@
+import React from "react";
+import SearchIcon from "@paprika/icon/lib/Search";
+import InputExample from "./InputExample";
+import { InputStory } from "../Input.stories.styles";
+
+const WithCustomClearIconStory = () => {
+  return (
+    <InputStory>
+      <h3>
+        <small>
+          <code>custom clear icon</code>
+        </small>
+      </h3>
+      <InputExample hasClearButton clearIcon={<SearchIcon />} placeholder="Search" />
+    </InputStory>
+  );
+};
+
+export default WithCustomClearIconStory;


### PR DESCRIPTION
### Purpose 🚀
- adding an option to pass in a custom icon for the clear button

### Notes ✏️
**Why?**
- in mission control bulk update, clicking the clear button acts as a "reset" action, so we want to use the reset icon here.

### Updates 📦
- [x] MINOR (backward compatible) change to _Input_

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/PDTVT-337-update-input-icon

### Screenshots 📸
<img width="353" alt="Screen Shot 2020-07-22 at 11 37 54 AM" src="https://user-images.githubusercontent.com/19940076/88215985-52918400-cc11-11ea-86c0-71283eb25ce0.png">
