### PR TITLE
uxd-53 Ensure onblur event data passed in event

### DIFF
--- a/packages/RawButton/CHANGELOG.md
+++ b/packages/RawButton/CHANGELOG.md
@@ -9,3 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Add support for imperative focus api [@tristanjasper](https://github.com/tristanjasper).
+
+## [0.2.15] - 2020-07-24
+
+### Added
+
+- Ensure event data being passed in onblur event [@tristanjasper](https://github.com/tristanjasper).

--- a/packages/RawButton/src/RawButton.js
+++ b/packages/RawButton/src/RawButton.js
@@ -66,8 +66,8 @@ const RawButton = React.forwardRef((props, ref) => {
     if (!isDisabled) onClick(event);
   };
 
-  function handleBlur() {
-    if (moreProps.onBlur) moreProps.onBlur();
+  function handleBlur(event) {
+    if (moreProps.onBlur) moreProps.onBlur(event);
     setHasForcedFocus(false);
   }
 


### PR DESCRIPTION
### Purpose 🚀
Currently raw button component doesnt' send event data in onBlur event which can lead to errors working with the popover component

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_
- [x] PATCH (bug fix) change to raw button

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/uxd-53-fix-raw-button-onblur-pass-event-data

### Screenshots 📸
![image](https://user-images.githubusercontent.com/4040102/88414054-1b49e100-cd91-11ea-8b26-3e573ee40772.png)


### References 🔗
https://aclgrc.atlassian.net/browse/UXD-53


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
