### PR TITLE
uxd-59 remove outline on mouse interaction

### DIFF
--- a/packages/Button/stories/examples/Variations.js
+++ b/packages/Button/stories/examples/Variations.js
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import { Rule, Tagline, breaklines, Gap } from "storybook/assets/styles/common.styles";
 import tokens from "@paprika/tokens";
 import Heading from "@paprika/heading";
+import Popover from "@paprika/popover";
 import PlusIcon from "@paprika/icon/lib/Add";
 import InfoIcon from "@paprika/icon/lib/InfoCircle";
 import { ButtonStory } from "../Button.stories.styles";
@@ -19,6 +20,25 @@ const DarkBackground = styled.span`
 function clickHandler() {
   action("Clicked a button")();
 }
+
+const renderTriggerWithTooltip = () => {
+  const content = "Tooltip text example";
+  return (
+    <Popover align="top" isDark isEager offset={8} shouldKeepFocus>
+      <Popover.Trigger tabIndex="-1">
+        <PlusIcon />
+      </Popover.Trigger>
+      {content && (
+        <>
+          <Popover.Content key={content}>
+            <Popover.Card>{content}</Popover.Card>
+          </Popover.Content>
+          <Popover.Tip />
+        </>
+      )}
+    </Popover>
+  );
+};
 
 const ExampleStory = () => (
   <ButtonStory>
@@ -294,6 +314,10 @@ const ExampleStory = () => (
       <DarkBackground>
         <Button.Close onClick={clickHandler} isDark a11yText="dark close" />
       </DarkBackground>
+    </p>
+    <p>
+      <div>Button Icon with tooltip</div>
+      <Button.Icon>{renderTriggerWithTooltip()}</Button.Icon>
     </p>
     {breaklines(34)}
     ...fin.

--- a/packages/RawButton/src/RawButton.styles.js
+++ b/packages/RawButton/src/RawButton.styles.js
@@ -8,6 +8,7 @@ const focusStyles = isInset => css`
 
   [data-whatinput="mouse"] &:not([data-has-forced-focus="true"]):focus {
     box-shadow: none;
+    outline: none;
   }
 `;
 


### PR DESCRIPTION
### Purpose 🚀
Remove outline on Rawbutton when interaction is with mouse and it receives focus

Before:
![image](https://user-images.githubusercontent.com/4040102/88707035-89aade00-d0c6-11ea-9feb-bebda5e49157.png)

After
![image](https://user-images.githubusercontent.com/4040102/88706851-481a3300-d0c6-11ea-8f77-bd8ed2e7753b.png)


### Notes ✏️
Visualizer currently makes use of this pattern in the actionButtons component.
![image](https://user-images.githubusercontent.com/4040102/88707095-9f200800-d0c6-11ea-8fae-eb62db31bdc7.png)


### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_
- [x] PATCH (bug fix) change to _these packages_

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/uxd-59-disable-outline-on-mouse-interaction

### Screenshots 📸
_optional but highly recommended_

### References 🔗
https://aclgrc.atlassian.net/browse/UXD-59


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
