### PR TITLE
PDTVT-293 Update Columns Arrangement defaultProps

### DIFF
--- a/packages/ActionBar/src/components/ColumnsArrangement/ColumnsArrangement.js
+++ b/packages/ActionBar/src/components/ColumnsArrangement/ColumnsArrangement.js
@@ -21,7 +21,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-  renderTriggerButton: () => {},
+  renderTriggerButton: null,
 };
 
 function getLabelText(numberOfHiddenColumn, I18n) {

--- a/packages/ActionBar/stories/ShowcaseApp/ShowcaseApp.js
+++ b/packages/ActionBar/stories/ShowcaseApp/ShowcaseApp.js
@@ -116,7 +116,7 @@ export default function App() {
           })}
         </Sort>
 
-        <ColumnsArrangement orderedColumnIds={orderedColumnIds} {...handlers} renderTriggerButton>
+        <ColumnsArrangement orderedColumnIds={orderedColumnIds} {...handlers}>
           {columnsSettings.map(column => (
             <ColumnsArrangement.ColumnDefinition
               id={column.id}


### PR DESCRIPTION
### Purpose 🚀
- Update Columns Arrangement defaultProps `renderTriggerButton: null`
- To render the raw button trigger by default

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_
- [ ] PATCH (bug fix) change to _these packages_

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
