### PR TITLE
UXD-64 Update test with deprecation warnings

### DIFF
--- a/packages/ActionBar/src/components/Filter/Filter.js
+++ b/packages/ActionBar/src/components/Filter/Filter.js
@@ -24,7 +24,7 @@ const propTypes = {
   onClose: PropTypes.func,
   onOpen: PropTypes.func,
   operator: PropTypes.oneOf([logicalFilterOperators.AND, logicalFilterOperators.OR]),
-  rulesByType: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.oneOf(rules))),
+  rulesByType: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.objectOf(rules))),
 };
 
 const defaultProps = {

--- a/packages/Button/test/Button.spec.js
+++ b/packages/Button/test/Button.spec.js
@@ -1,7 +1,7 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
 
 import React from "react";
-import { render, fireEvent } from "@testing-library/react";
+import { render, fireEvent, act } from "@testing-library/react";
 import Button from "../src";
 
 const noop = () => {};
@@ -109,7 +109,7 @@ describe("Button", () => {
   it("Is focussable via ref", () => {
     const buttonRef = React.createRef();
     renderComponent({ ref: buttonRef });
-    buttonRef.current.focus();
+    act(() => buttonRef.current.focus());
 
     expect(document.activeElement.tagName.toLowerCase()).toEqual("button");
   });
@@ -120,7 +120,7 @@ describe("Button", () => {
       buttonRef = component;
     };
     renderComponent({ ref: setRef });
-    buttonRef.focus();
+    act(() => buttonRef.focus());
 
     expect(document.activeElement.tagName.toLowerCase()).toEqual("button");
   });

--- a/packages/Confirmation/test/confirmation.spec.js
+++ b/packages/Confirmation/test/confirmation.spec.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, configure, fireEvent, wait } from "@testing-library/react";
+import { render, configure, fireEvent, waitFor } from "@testing-library/react";
 import Confirmation from "../src";
 
 configure({ testIdAttribute: "data-pka-anchor" });
@@ -32,7 +32,7 @@ describe("Confirmation", () => {
     fireEvent.click(getByText(/trigger/i));
     fireEvent.click(getByText(/confirm delete/i));
     expect(onConfirmFunc).toHaveBeenCalled();
-    await wait(() => {
+    await waitFor(() => {
       expect(onCloseFunc).not.toHaveBeenCalled();
     });
   });
@@ -44,7 +44,7 @@ describe("Confirmation", () => {
     });
     fireEvent.click(getByText(/trigger/i));
     fireEvent.click(getByText(/cancel/i));
-    await wait(() => {
+    await waitFor(() => {
       expect(onCloseFunc).toHaveBeenCalled();
     });
   });

--- a/packages/DateInput/test/DateInput.spec.js
+++ b/packages/DateInput/test/DateInput.spec.js
@@ -1,6 +1,6 @@
 import React from "react";
 import moment from "moment";
-import { render as renderReactTestingLibrary, configure, fireEvent, wait } from "@testing-library/react";
+import { render as renderReactTestingLibrary, configure, fireEvent, waitFor } from "@testing-library/react";
 import DateInput from "../src";
 
 configure({ testIdAttribute: "data-pka-anchor" });
@@ -67,7 +67,7 @@ describe("DateInput", () => {
 
     getByTestId("dateinput").blur();
 
-    await wait(() => expect(getByTestId("dateinput").value).toEqual("January 02, 2019"));
+    await waitFor(() => expect(getByTestId("dateinput").value).toEqual("January 02, 2019"));
   });
 
   it("should render date correctly with different timezones", () => {

--- a/packages/DropdownMenu/test/dropdownMenu.spec.js
+++ b/packages/DropdownMenu/test/dropdownMenu.spec.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, configure, fireEvent, wait } from "@testing-library/react";
+import { render, configure, fireEvent, waitFor } from "@testing-library/react";
 import L10n from "@paprika/l10n";
 import Confirmation from "@paprika/confirmation";
 import DropdownMenu from "../src";
@@ -82,7 +82,7 @@ describe("DropdownMenu", () => {
     it("should hide all dropdown menus when replacement cancel button is clicked", async () => {
       fireEvent.click(getByText(/cancel/i));
 
-      await wait(() => {
+      await waitFor(() => {
         expect(queryByText(/confirm delete/i)).not.toBeInTheDocument();
         expect(queryByText(/edit/i)).not.toBeInTheDocument();
       });

--- a/packages/ListBox/test/specs/multi/ListBox.multi.spec.js
+++ b/packages/ListBox/test/specs/multi/ListBox.multi.spec.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { configure, render, fireEvent } from "@testing-library/react";
+import { configure, render, fireEvent, waitFor } from "@testing-library/react";
 
 import ListBox from "../../../src";
 import { ControlledIsSelected } from "../../../stories/examples/multi";
@@ -90,7 +90,9 @@ describe("Listbox multi select", () => {
     const { getByTestId, openSelect } = renderComponent(null, [<ListBox.Filter key="filter" />, [...childrenContent]]);
 
     openSelect();
-    expect(getByTestId("list-filter")).toBeInTheDocument();
+    waitFor(() => {
+      expect(getByTestId("list-filter")).toBeInTheDocument();
+    });
   });
 
   it("should display message when filter input does not find a match", () => {
@@ -101,8 +103,10 @@ describe("Listbox multi select", () => {
 
     openSelect();
     fireEvent.change(getByTestId("list-filter-input"), { target: { value: "g" } });
-    expect(getByTestId("no-results")).toBeInTheDocument();
-    expect(getByText("No match")).toBeInTheDocument();
+    waitFor(() => {
+      expect(getByTestId("no-results")).toBeInTheDocument();
+      expect(getByText("No match")).toBeInTheDocument();
+    });
   });
 
   it("should have custom height of 500", () => {

--- a/packages/ListBox/test/specs/single/ListBox.Option.spec.js
+++ b/packages/ListBox/test/specs/single/ListBox.Option.spec.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { configure, render, fireEvent } from "@testing-library/react";
+import { configure, render, fireEvent, waitFor } from "@testing-library/react";
 import ListBox from "../../../src";
 
 configure({ testIdAttribute: "data-pka-anchor" });
@@ -77,7 +77,9 @@ describe("ListBox.Option", () => {
 
     fireEvent.click(getByTestId("listbox-trigger"));
     fireEvent.click(getByAltText("planetvenus"));
-    expect(getByTestId("listbox-trigger")).toHaveTextContent(/venus/i);
+    waitFor(() => {
+      expect(getByTestId("listbox-trigger")).toHaveTextContent(/venus/i);
+    });
   });
 
   it("should prevent default selection ability", () => {

--- a/packages/ListBox/test/specs/single/ListBox.single.spec.js
+++ b/packages/ListBox/test/specs/single/ListBox.single.spec.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, fireEvent, configure } from "@testing-library/react";
+import { render, fireEvent, configure, waitFor } from "@testing-library/react";
 import ListBox from "../../../src";
 import { ControlledIsSelected as ListBoxControlled, OnChange } from "../../../stories/examples/single";
 
@@ -84,7 +84,9 @@ describe("Listbox single select", () => {
     );
 
     fireEvent.click(getByText(/Select/));
-    expect(getByTestId("list-filter")).toBeInTheDocument();
+    waitFor(() => {
+      expect(getByTestId("list-filter")).toBeInTheDocument();
+    });
   });
 
   it("should have custom height of 500", () => {
@@ -177,8 +179,10 @@ describe("Listbox single select", () => {
 
     fireEvent.click(getByText(/Select/));
     fireEvent.change(getByTestId("list-filter-input"), { target: { value: "g" } });
-    expect(getByTestId("no-results")).toBeInTheDocument();
-    expect(getByText("No match")).toBeInTheDocument();
+    waitFor(() => {
+      expect(getByTestId("no-results")).toBeInTheDocument();
+      expect(getByText("No match")).toBeInTheDocument();
+    });
   });
 
   it("placeholder should display default label when no option is selected", () => {

--- a/packages/Modal/tests/Modal.spec.js
+++ b/packages/Modal/tests/Modal.spec.js
@@ -70,7 +70,7 @@ describe("Modal", () => {
     given("isOpen", () => false);
 
     it("renders nothing", () => {
-      expect(given.rendered.container).toBeEmpty();
+      expect(given.rendered.container).toBeEmptyDOMElement();
     });
 
     it("does not trigger onClose when ESC press", () => {

--- a/packages/RawButton/test/RawButton.spec.js
+++ b/packages/RawButton/test/RawButton.spec.js
@@ -1,7 +1,7 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
 
 import React from "react";
-import { render, fireEvent } from "@testing-library/react";
+import { render, fireEvent, act } from "@testing-library/react";
 import RawButton from "../src";
 
 const noop = () => {};
@@ -112,7 +112,7 @@ describe("RawButton", () => {
   it("Is focussable via ref", () => {
     const buttonRef = React.createRef();
     renderComponent({ ref: buttonRef });
-    buttonRef.current.focus();
+    act(() => buttonRef.current.focus());
 
     expect(document.activeElement.getAttribute("role")).toEqual("button");
   });
@@ -123,7 +123,7 @@ describe("RawButton", () => {
       buttonRef = component;
     };
     renderComponent({ ref: setRef });
-    buttonRef.focus();
+    act(() => buttonRef.focus());
 
     expect(document.activeElement.getAttribute("role")).toEqual("button");
   });

--- a/packages/Takeover/tests/Takeover.spec.js
+++ b/packages/Takeover/tests/Takeover.spec.js
@@ -7,11 +7,13 @@ const noop = () => {};
 describe("Takeover", () => {
   given("children", () => "some content");
   given("onClose", () => noop);
+  given("a11yText", () => "takeover story");
 
   given("props", () => ({
     isOpen: given.isOpen,
     onClose: given.onClose,
     children: given.children,
+    a11yText: given.a11yText,
   }));
 
   given("rendered", () => renderReactTestingLibrary(<Takeover {...given.props} />));
@@ -57,7 +59,7 @@ describe("Takeover", () => {
     given("isOpen", () => false);
 
     it("renders nothing", () => {
-      expect(given.rendered.container).toBeEmpty();
+      expect(given.rendered.container).toBeEmptyDOMElement();
     });
 
     it("does not trigger onClose when ESC press", () => {


### PR DESCRIPTION
### Purpose 🚀
Update spec test files with deprecation warnings

### Notes ✏️
Not updated

1. Datepicker `Warning: React does not recognize the clearIcon prop on a DOM element..., spell it as lowercase clearicon instead`
2. DataGrid console output messages
3. DateInput `Warning: value provided is not in a recognized RFC2822 or ISO format.` _Testing string value_
### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_
- [ ] PATCH (bug fix) change to _these packages_

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/UXD-64-update-tests

### Screenshots 📸
<img width="598" alt="01-update-test" src="https://user-images.githubusercontent.com/67071062/89319529-13155f80-d635-11ea-9a06-dd0446eb3719.png">
<img width="577" alt="02-update-test" src="https://user-images.githubusercontent.com/67071062/89319540-17da1380-d635-11ea-8664-d092f2fdd25b.png">
<img width="578" alt="03-update-test" src="https://user-images.githubusercontent.com/67071062/89319543-1872aa00-d635-11ea-9047-58c3a823abb8.png">
<img width="578" alt="04-update-test" src="https://user-images.githubusercontent.com/67071062/89319545-19a3d700-d635-11ea-81af-d0e988b92047.png">


### References 🔗
Issue #611 


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
