### PR TITLE
PDTVT-366 Fix ColumnsArrangement overlapping content

### DIFF
--- a/packages/ActionBar/src/components/ColumnsArrangement/ColumnsArrangement.styles.js
+++ b/packages/ActionBar/src/components/ColumnsArrangement/ColumnsArrangement.styles.js
@@ -30,6 +30,7 @@ export const ColumnLabel = styled.span`
 
 export const Switch = styled(PaprikaSwitch)`
   flex-shrink: 0;
+  margin-left: ${tokens.spaceSm};
 `;
 
 const hasColumnsHiddenStyles = css`


### PR DESCRIPTION
### Purpose 🚀
Fix ColumnsArrangement overlapping content
### Notes ✏️
Add space between text and switch component `margin-left: ${tokens.spaceSm}`
### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_
- [x] PATCH (bug fix) change to _these packages_

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/PDTVT-366-columns-arrangement-overlap
### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
