### PR TITLE
STAR-265 bug(ListBox) working incorrectly with Enter keydown

### DIFF
--- a/packages/DataGrid/src/components/Cell/Cell.js
+++ b/packages/DataGrid/src/components/Cell/Cell.js
@@ -59,9 +59,7 @@ export default function Cell(props) {
     };
 
     return () => {
-      console.log("before:", Object.keys(window.paprika.dataGridRef).length);
       delete window.paprika.dataGridRef[key];
-      console.log("after:", Object.keys(window.paprika.dataGridRef).length);
     };
   }, []); // eslint-disable-line
 

--- a/packages/ListBox/CHANGELOG.md
+++ b/packages/ListBox/CHANGELOG.md
@@ -1,1 +1,12 @@
 # CHANGELOG
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [0.9.0] - 2020-06-16
+
+### Changed
+
+- Add onKeyUp event for `SPACE`, `ESC` and `ENTER` before onKeyDown was handling all key interaction now its only responsible for `↑`,`↓` keys.
+  this might break testing that depends onKeyDown event.

--- a/packages/ListBox/src/components/Content/Content.js
+++ b/packages/ListBox/src/components/Content/Content.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import Popover from "@paprika/popover";
 import { getDOMAttributesForListBoxContainer } from "../../helpers/DOMAttributes";
-import handleKeyboardKeys from "../../helpers/handleKeyboardKeys";
+import { handleKeyUpKeyboardKeys, handleKeyDownKeyboardKeys } from "../../helpers/handleKeyboardKeys";
 import useListBox from "../../useListBox";
 import { OnChangeContext } from "../../store/OnChangeProvider";
 import { ContentStyled } from "./Content.styles";
@@ -68,7 +68,8 @@ export default function Content(props) {
         onBlur={() => {
           handleContentFocusChange(false, dispatch);
         }}
-        onKeyDown={handleKeyboardKeys({ state, dispatch, onChangeContext })}
+        onKeyDown={handleKeyDownKeyboardKeys({ state, dispatch, onChangeContext })}
+        onKeyUp={handleKeyUpKeyboardKeys({ state, dispatch, onChangeContext })}
         ref={refListBoxContainer}
         data-pka-anchor="listbox-content-inline"
       >
@@ -82,7 +83,8 @@ export default function Content(props) {
       onBlur={handleBlur(state, dispatch, props.onCancelFooter)}
       ref={refListBoxContainer}
       {...getDOMAttributesForListBoxContainer()}
-      onKeyDown={handleKeyboardKeys({ state, dispatch, onChangeContext })}
+      onKeyDown={handleKeyDownKeyboardKeys({ state, dispatch, onChangeContext })}
+      onKeyUp={handleKeyUpKeyboardKeys({ state, dispatch, onChangeContext })}
     >
       {props.children}
     </Popover.Content>

--- a/packages/ListBox/src/components/Trigger/Trigger.js
+++ b/packages/ListBox/src/components/Trigger/Trigger.js
@@ -7,7 +7,7 @@ import CaretDownIcon from "@paprika/icon/lib/CaretDown";
 import CaretUpIcon from "@paprika/icon/lib/CaretUp";
 import TimesCircleIcon from "@paprika/icon/lib/TimesCircle";
 import Label from "../Label";
-import handleKeyboardKeys from "../../helpers/handleKeyboardKeys";
+import { handleKeyDownKeyboardKeys, handleKeyUpKeyboardKeys } from "../../helpers/handleKeyboardKeys";
 import useListBox from "../../useListBox";
 import { OnChangeContext } from "../../store/OnChangeProvider";
 
@@ -154,8 +154,8 @@ export default function Trigger(props) {
         id={triggerButtonId.current}
         onClick={handleClick}
         ref={refTrigger}
-        onKeyDown={handleKeyboardKeys({ state, dispatch, onChangeContext })}
-        onKeyUp={() => {}}
+        onKeyDown={handleKeyDownKeyboardKeys({ state, dispatch, onChangeContext })}
+        onKeyUp={handleKeyUpKeyboardKeys({ state, dispatch, onChangeContext })}
         isDisabled={isDisabled}
         data-pka-anchor="listbox-trigger"
         aria-describedby={formElementLabelDescribedBy}

--- a/packages/ListBox/src/helpers/handleKeyboardKeys.js
+++ b/packages/ListBox/src/helpers/handleKeyboardKeys.js
@@ -6,8 +6,6 @@ export const handleKeyDownKeyboardKeys = ({ state, dispatch, onChangeContext }) 
     return;
   }
 
-  console.log("PRESS DOWN");
-
   switch (event.key) {
     case "ArrowUp":
       handleArrowKeys({ event, state, dispatch, onChangeContext, isArrowDown: false });
@@ -27,8 +25,6 @@ export const handleKeyUpKeyboardKeys = ({ state, dispatch, onChangeContext }) =>
     return;
   }
 
-  console.log("PRESS UP");
-
   switch (event.key) {
     case "Escape":
       if (!state.isOpen) break;
@@ -41,7 +37,6 @@ export const handleKeyUpKeyboardKeys = ({ state, dispatch, onChangeContext }) =>
 
     case "Enter":
     case " ":
-      console.log("ENTER");
       handleEnterOrSpace({ event, state, dispatch, onChangeContext });
       break;
 

--- a/packages/ListBox/src/helpers/handleKeyboardKeys.js
+++ b/packages/ListBox/src/helpers/handleKeyboardKeys.js
@@ -1,10 +1,12 @@
 import { handleEnterOrSpace, handleArrowKeys } from "../components/Options/helpers/options";
 import useListBox from "../useListBox";
 
-const handleKeyboardKeys = ({ state, dispatch, onChangeContext }) => event => {
+export const handleKeyDownKeyboardKeys = ({ state, dispatch, onChangeContext }) => event => {
   if (state.isDisabled) {
     return;
   }
+
+  console.log("PRESS DOWN");
 
   switch (event.key) {
     case "ArrowUp":
@@ -15,6 +17,19 @@ const handleKeyboardKeys = ({ state, dispatch, onChangeContext }) => event => {
       handleArrowKeys({ event, state, dispatch, onChangeContext, isArrowDown: true });
       break;
 
+    default:
+      break;
+  }
+};
+
+export const handleKeyUpKeyboardKeys = ({ state, dispatch, onChangeContext }) => event => {
+  if (state.isDisabled) {
+    return;
+  }
+
+  console.log("PRESS UP");
+
+  switch (event.key) {
     case "Escape":
       if (!state.isOpen) break;
       if (state.hasFooter) {
@@ -26,6 +41,7 @@ const handleKeyboardKeys = ({ state, dispatch, onChangeContext }) => event => {
 
     case "Enter":
     case " ":
+      console.log("ENTER");
       handleEnterOrSpace({ event, state, dispatch, onChangeContext });
       break;
 
@@ -33,5 +49,3 @@ const handleKeyboardKeys = ({ state, dispatch, onChangeContext }) => event => {
       break;
   }
 };
-
-export default handleKeyboardKeys;

--- a/packages/ListBox/stories/listBox.stories.js
+++ b/packages/ListBox/stories/listBox.stories.js
@@ -3,7 +3,8 @@ import { storiesOf } from "@storybook/react";
 import { getStoryName } from "storybook/storyTree";
 import Heading from "@paprika/heading";
 import { Story, Rule, Tagline } from "storybook/assets/styles/common.styles";
-import ListBox from "../src";
+import { Basic as BasicSingle } from "./examples/single";
+import { Basic as BasicMulti } from "./examples/multi";
 
 const storyName = getStoryName("ListBox");
 
@@ -16,7 +17,11 @@ const Example = () => (
       <b>Showcase</b> – a stubby little story
     </Tagline>
     <Rule />
-    <ListBox />
+    <h3>Single</h3>
+    <BasicSingle />
+    <Rule />
+    <h3>Multi</h3>
+    <BasicMulti />
   </Story>
 );
 

--- a/packages/ListBox/test/cypress/ListBox.cypress.js
+++ b/packages/ListBox/test/cypress/ListBox.cypress.js
@@ -10,6 +10,37 @@ describe("ListBox single select", () => {
     toggleDropdown();
   });
 
+  it.only("should toggle the list-box popover while triggering enter on the keyboard", () => {
+    const anchor = cy.get("[data-pka-anchor='listbox-trigger']");
+    anchor.should("be.visible");
+    const joker = /The Joker/i;
+    const darth = /Darth Vader/i;
+    const hannibal = /Hannibal/i;
+
+    cy.contains(joker);
+    cy.contains(darth);
+    cy.contains(hannibal);
+
+    anchor.trigger("keyup", { key: "Enter" });
+
+    cy.should("not.contain", joker);
+    cy.should("not.contain", darth);
+    cy.should("not.contain", hannibal);
+
+    anchor.trigger("keyup", { key: "Enter" });
+
+    cy.contains(joker);
+    cy.contains(darth);
+    cy.contains(hannibal);
+  });
+});
+
+describe("ListBox single select", () => {
+  beforeEach(() => {
+    cy.visitStorybook(`${storyPrefix}-examples-single--basic`);
+    toggleDropdown();
+  });
+
   it("should select option and clear it", () => {
     const character = "Spiderman";
     cy.contains(character).click();

--- a/packages/ListBox/test/cypress/ListBox.cypress.js
+++ b/packages/ListBox/test/cypress/ListBox.cypress.js
@@ -10,7 +10,7 @@ describe("ListBox single select", () => {
     toggleDropdown();
   });
 
-  it.only("should toggle the list-box popover while triggering enter on the keyboard", () => {
+  it("should toggle the list-box popover while triggering enter on the keyboard", () => {
     const anchor = cy.get("[data-pka-anchor='listbox-trigger']");
     anchor.should("be.visible");
     const joker = /The Joker/i;


### PR DESCRIPTION
 / 🦄.

### Purpose 🚀
Before this PR  the onkeydown event for `↑`,`↓` , `SPACE`, `ESC` and `ENTER` where under the same function and under onKeyDown event, this creates an interesting behaviour for the Enter key where toggle the listbox opening and closing it when trying it to opening.

The reason why were bound into onKeyDown was because  ↑↓→←  have to have to ability to scroll up and down without lifting the key. 

With this PR this behaviour has been splitted between keydown and keyup, keydown will manage the arrow keys while the keyup will handle Space, Enter and Esc.

This results in a nicer behaviour.   



### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
- [x] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_
- [ ] PATCH (bug fix) change to _these packages_

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/STAR-265-Listbox-on-enter

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
