### PR TITLE
UXD-81 DataGrid - Add title attribute in cell header

### DIFF
--- a/packages/DataGrid/src/DataGrid.Rows.js
+++ b/packages/DataGrid/src/DataGrid.Rows.js
@@ -113,6 +113,7 @@ export const StickyRow = React.memo(({ data: RowData, columnIndex, rowIndex, sty
 export const HeaderRow = React.memo(({ data: RowData, columnIndex, style }) => {
   const { ColumnDefinitions, stickyColumnsIndexes, borderType } = RowData;
   const { header, headerProps } = ColumnDefinitions[columnIndex].props;
+  const headerText = typeof header === "function" ? header() : header;
 
   if (stickyColumnsIndexes.includes(columnIndex)) return null;
   const { style: styleProps = {}, ...moreProps } = typeof headerProps === "function" ? headerProps({ header }) : {};
@@ -123,9 +124,9 @@ export const HeaderRow = React.memo(({ data: RowData, columnIndex, style }) => {
       style={{ ...style, ...styleProps }}
       {...moreProps}
       borderType={borderType}
-      title={typeof header === "function" ? header() : header}
+      title={headerText}
     >
-      {typeof header === "function" ? header() : header}
+      {headerText}
     </CellHeader>
   );
 }, areEqual);
@@ -133,6 +134,7 @@ export const HeaderRow = React.memo(({ data: RowData, columnIndex, style }) => {
 export const StickyHeaderRow = React.memo(({ data: RowData, columnIndex, style }) => {
   const { ColumnDefinitions, borderType } = RowData;
   const { header, headerProps } = ColumnDefinitions[columnIndex].props;
+  const headerText = typeof header === "function" ? header() : header;
 
   const { style: styleProps = {}, ...moreProps } = typeof headerProps === "function" ? headerProps({ header }) : {};
 
@@ -142,9 +144,9 @@ export const StickyHeaderRow = React.memo(({ data: RowData, columnIndex, style }
       style={{ ...style, ...styleProps }}
       {...moreProps}
       borderType={borderType}
-      title={typeof header === "function" ? header() : header}
+      title={headerText}
     >
-      {typeof header === "function" ? header() : header}
+      {headerText}
     </CellHeader>
   );
 }, areEqual);

--- a/packages/DataGrid/src/DataGrid.Rows.js
+++ b/packages/DataGrid/src/DataGrid.Rows.js
@@ -118,7 +118,13 @@ export const HeaderRow = React.memo(({ data: RowData, columnIndex, style }) => {
   const { style: styleProps = {}, ...moreProps } = typeof headerProps === "function" ? headerProps({ header }) : {};
 
   return (
-    <CellHeader role="columnheader" style={{ ...style, ...styleProps }} {...moreProps} borderType={borderType}>
+    <CellHeader
+      role="columnheader"
+      style={{ ...style, ...styleProps }}
+      {...moreProps}
+      borderType={borderType}
+      title={typeof header === "function" ? header() : header}
+    >
       {typeof header === "function" ? header() : header}
     </CellHeader>
   );
@@ -131,7 +137,13 @@ export const StickyHeaderRow = React.memo(({ data: RowData, columnIndex, style }
   const { style: styleProps = {}, ...moreProps } = typeof headerProps === "function" ? headerProps({ header }) : {};
 
   return (
-    <CellHeader role="columnheader" style={{ ...style, ...styleProps }} {...moreProps} borderType={borderType}>
+    <CellHeader
+      role="columnheader"
+      style={{ ...style, ...styleProps }}
+      {...moreProps}
+      borderType={borderType}
+      title={typeof header === "function" ? header() : header}
+    >
       {typeof header === "function" ? header() : header}
     </CellHeader>
   );


### PR DESCRIPTION
### Purpose 🚀
Add title attribute in DataGrid cell header to specify truncated/cut off header label. 

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_
- [ ] PATCH (bug fix) change to _these packages_

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/UXD-81-datagrid-title-attribute

### Screenshots 📸
![datagrid-title-attribute](https://user-images.githubusercontent.com/67071062/89570584-4396fe00-d7db-11ea-922f-bbc422019173.png)



### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
