### PR TITLE
UXD-115 - Collapsible - Different default Icon depends on position

### DIFF
--- a/packages/Collapsible/src/Collapsible.js
+++ b/packages/Collapsible/src/Collapsible.js
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import RightArrowIcon from "@paprika/icon/lib/ArrowRight";
 import DownArrowIcon from "@paprika/icon/lib/ArrowDown";
+import UpArrowIcon from "@paprika/icon/lib/ArrowUp";
 import useI18n from "@paprika/l10n/lib/useI18n";
 import RawButton from "@paprika/raw-button";
 import collapsibleStyles from "./Collapsible.styles";
@@ -52,7 +53,16 @@ const defaultProps = {
 const Collapsible = props => {
   const I18n = useI18n();
   let hasWarnedForA11yText = false;
-  const collapsedIcon = [props.iconExpand, props.iconCollapse];
+
+  const [collapsedIcon, setCollapsedIcon] = React.useState([props.iconExpand, props.iconCollapse]);
+
+  React.useEffect(() => {
+    if (props.iconAlign === "right") {
+      setCollapsedIcon([<UpArrowIcon />, <DownArrowIcon />]);
+    } else {
+      setCollapsedIcon([props.iconExpand, props.iconCollapse]);
+    }
+  }, []);
 
   const checkPropsError = () => {
     if (!props.a11yText && !(I18n && I18n.t) && !hasWarnedForA11yText) {

--- a/packages/Collapsible/src/Collapsible.js
+++ b/packages/Collapsible/src/Collapsible.js
@@ -54,15 +54,8 @@ const Collapsible = props => {
   const I18n = useI18n();
   let hasWarnedForA11yText = false;
 
-  const [collapsedIcon, setCollapsedIcon] = React.useState([props.iconExpand, props.iconCollapse]);
-
-  React.useEffect(() => {
-    if (props.iconAlign === "right") {
-      setCollapsedIcon([<UpArrowIcon />, <DownArrowIcon />]);
-    } else {
-      setCollapsedIcon([props.iconExpand, props.iconCollapse]);
-    }
-  }, []);
+  const collapsedIcon =
+    props.iconAlign === "right" ? [<UpArrowIcon />, <DownArrowIcon />] : [props.iconExpand, props.iconCollapse];
 
   const checkPropsError = () => {
     if (!props.a11yText && !(I18n && I18n.t) && !hasWarnedForA11yText) {


### PR DESCRIPTION
### Purpose 🚀
To match current design guidelines for Collapsible. Adjust chevron icon to be an UpArrow when alligned right and expanded and to be a DownArrow when alligned right and collapsed. 

### Notes ✏️
N/A

### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_
- [x] PATCH (bug fix) change to _these packages_

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/UXD-115-Collapsible-default-chevron

### Screenshots 📸
![image](https://user-images.githubusercontent.com/67071090/90168698-54eb8780-dd52-11ea-9788-2236b8eb3280.png)

### References 🔗
N/A


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
