### PR TITLE
add default font styles on th

### DIFF
--- a/packages/Table/CHANGELOG.md
+++ b/packages/Table/CHANGELOG.md
@@ -5,3 +5,5 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+
+- Add default font styles on th [@tristanjasper](https://github.com/tristanjasper).

--- a/packages/Table/package.json
+++ b/packages/Table/package.json
@@ -20,6 +20,7 @@
     "@paprika/helpers": "0.2.13",
     "@paprika/pill": "^0.2.25",
     "@paprika/tokens": "^0.1.14",
+    "@paprika/stylers": "^0.2.8",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {

--- a/packages/Table/src/Table.styles.js
+++ b/packages/Table/src/Table.styles.js
@@ -1,5 +1,6 @@
 import styled, { css } from "styled-components";
 import tokens from "@paprika/tokens";
+import { fontSize } from "@paprika/stylers/lib/helpers";
 import types from "./types";
 
 export const Table = styled.table`
@@ -58,9 +59,9 @@ export const TD = styled.td(({ borderType }) => {
 
 export const TH = styled.th(({ borderType }) => {
   return css`
+    ${fontSize()}
     ${borderType in borderTypesStyles ? borderTypesStyles[borderType] : ""}
-    font-size: 16px;
-    font-weight: 600;
+    font-weight: bold;
     padding: ${tokens.space};
     text-align: left;
   `;

--- a/packages/Table/src/Table.styles.js
+++ b/packages/Table/src/Table.styles.js
@@ -59,6 +59,8 @@ export const TD = styled.td(({ borderType }) => {
 export const TH = styled.th(({ borderType }) => {
   return css`
     ${borderType in borderTypesStyles ? borderTypesStyles[borderType] : ""}
+    font-size: 16px;
+    font-weight: 600;
     padding: ${tokens.space};
     text-align: left;
   `;


### PR DESCRIPTION
### Purpose 🚀
Add default font styling on th elements in Table Component

As discussed - https://github.com/acl-services/acl-exception/pull/7873/files#diff-ea428be058ad84e7b18651badfc2b143R7

### Notes ✏️
No visible changes to the component in storybook as the styles were already coming from other style sources. In a consuming application however that may not be the case

### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_
- [x] PATCH (bug fix) change to Table

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/UXD-162-Table-th-default-styling

### Screenshots 📸
_optional but highly recommended_

### References 🔗
https://aclgrc.atlassian.net/browse/UXD-162


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
