### PR TITLE
UXD-196 Fix Input showcase storybook example

### DIFF
--- a/packages/Input/stories/examples/Showcase.js
+++ b/packages/Input/stories/examples/Showcase.js
@@ -6,7 +6,7 @@ import InfoIcon from "@paprika/icon/lib/InfoCircle";
 import Heading from "@paprika/heading";
 import CodeViewer from "storybook/components/CodeViewer";
 import * as types from "../../src/types";
-import Input from "../../src";
+import InputExample from "./InputExample";
 
 const iconSelections = {
   none: null,
@@ -37,7 +37,7 @@ const ExampleStory = props => {
       <Tagline>Use the knobs to tinker with the props.</Tagline>
       <Rule />
       <CodeViewer>
-        <Input {...inputProps} />
+        <InputExample {...inputProps} />
       </CodeViewer>
     </Story>
   );


### PR DESCRIPTION
### Purpose 🚀
Input showcase example wasn't updating when changing some props such as `showClearButton` this is because it was using a proper consumer implementation with state like the other examples are.

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_
- [ ] PATCH (bug fix) change to Input

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
