### PR TITLE
UXD-224 Refactor Styling Card Issue

### DIFF
--- a/packages/Card/stories/examples/BasicCardContent.js
+++ b/packages/Card/stories/examples/BasicCardContent.js
@@ -69,7 +69,7 @@ export default () => {
         {card.map(card => {
           return (
             <div style={{ margin: "10px", width: "240px" }}>
-              <Card>
+              <Card size={Card.types.size.SMALL}>
                 <Card.Content>
                   <Card.Title>{card.title}</Card.Title>
                   <Card.Metadata>


### PR DESCRIPTION
### Purpose 🚀
One of the Card's stories size did not match the desired size based on Figma designs.

### Notes ✏️
- Card had no defined size, therefore it was set to a default value of auto. Added `size={Card.types.size.SMALL}`

### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_
- [x] PATCH (bug fix) change to _these packages_

### Storybook 📕
http://storybooks.highbond-s3.com/paprikaUXD-224-refactor-styling-Card-fail

### Screenshots 📸
![image](https://user-images.githubusercontent.com/67071090/92513399-14522300-f1c5-11ea-9cb3-8f9853cbf1f9.png)


### References 🔗
https://aclgrc.atlassian.net/browse/UXD-224


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
