### PR TITLE
Tw 612 support icon button link

### DIFF
--- a/packages/Button/CHANGELOG.md
+++ b/packages/Button/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+Added support for icon in ButtonLink component [@tristanjasper](https://github.com/tristanjasper).
+
 ## [0.3.0] - 2020-06-16
 
 ### Changed

--- a/packages/Button/src/LinkButton.js
+++ b/packages/Button/src/LinkButton.js
@@ -4,19 +4,26 @@ import NewTabIcon from "@paprika/icon/lib/NewTab";
 import * as constants from "@paprika/constants/lib/Constants";
 import * as types from "./types";
 import * as sc from "./LinkButton.styles";
+import { ButtonIcon } from "./Button";
 
 const LinkButton = React.forwardRef((props, ref) => {
-  const { a11yText, children, href, isDisabled, shouldOpenNewTab, kind, size, suffixIcon, ...moreProps } = props;
+  const { a11yText, children, href, isDisabled, shouldOpenNewTab, kind, icon, size, suffixIcon, ...moreProps } = props;
 
   const shouldOpenNewTabProps = {
     target: "_blank",
     rel: "noopener noreferrer",
   };
 
-  const iconProps = {
-    isDisabled,
-    kind,
-  };
+  function renderSuffix({ kind, isDisabled, suffixIcon, shouldOpenNewTab }) {
+    if (kind === types.LINK && shouldOpenNewTab && suffixIcon) {
+      return (
+        <sc.LinkButtonIcon isDisabled={isDisabled} kind={types.LINK} isSuffixIcon>
+          {suffixIcon}
+        </sc.LinkButtonIcon>
+      );
+    }
+    return null;
+  }
 
   return (
     <sc.LinkButton
@@ -30,10 +37,9 @@ const LinkButton = React.forwardRef((props, ref) => {
       as={isDisabled ? "span" : "a"}
       ref={ref}
     >
+      {icon ? <ButtonIcon isDisabled={isDisabled}>{icon}</ButtonIcon> : null}
       {children}
-      <sc.LinkButtonIcon {...iconProps} isSuffixIcon>
-        {kind === types.LINK && shouldOpenNewTab && suffixIcon}
-      </sc.LinkButtonIcon>
+      {renderSuffix(props)}
     </sc.LinkButton>
   );
 });
@@ -44,10 +50,22 @@ LinkButton.types = {
 };
 
 const propTypes = {
+  /** Descriptive a11y text for assistive technologies. By default, text from children node will be used. */
   a11yText: PropTypes.string,
+
+  /** Body content of the button. */
   children: PropTypes.node.isRequired,
+
+  /** Url for the link. */
   href: PropTypes.string.isRequired,
+
+  /** An icon to be included to the left of children content. */
+  icon: PropTypes.node,
+
+  /** If the button is disabled. */
   isDisabled: PropTypes.bool,
+
+  /** The visual style of the button. */
   kind: PropTypes.oneOf([
     LinkButton.types.kind.DEFAULT,
     LinkButton.types.kind.PRIMARY,
@@ -57,13 +75,20 @@ const propTypes = {
     LinkButton.types.kind.MINOR,
     LinkButton.types.kind.LINK,
   ]),
+
+  /** Size of the button (font size, min-height, padding, etc). */
   size: PropTypes.oneOf([LinkButton.types.size.SMALL, LinkButton.types.size.MEDIUM, LinkButton.types.size.LARGE]),
+
+  /** Whether the link should open a new tab. */
   shouldOpenNewTab: PropTypes.bool,
+
+  /** Size of the button (font size, min-height, padding, etc). */
   suffixIcon: PropTypes.node,
 };
 
 const defaultProps = {
   a11yText: null,
+  icon: null,
   isDisabled: false,
   kind: LinkButton.types.kind.LINK,
   shouldOpenNewTab: false,

--- a/packages/Button/stories/examples/Variations.js
+++ b/packages/Button/stories/examples/Variations.js
@@ -142,6 +142,9 @@ const ExampleStory = () => (
       <Button.Link href="https://youtu.be/IdkCEioCp24?t=92" shouldOpenNewTab>
         Link in new tab
       </Button.Link>
+      <Button.Link kind="secondary" icon={<PlusIcon />} href="https://youtu.be/IdkCEioCp24?t=92" shouldOpenNewTab>
+        Button link with icon
+      </Button.Link>
     </p>
     <Rule />
     <p>


### PR DESCRIPTION
### Purpose 🚀
Allow the `ButtonLink` component (part of the `Button` package) to support an icon. (Required for results design in new collections homepage)

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_
- [x] PATCH (bug fix) change to `Button`

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/tw-612-support-icon-button-link

### Screenshots 📸
After

![image](https://user-images.githubusercontent.com/4040102/92531482-32c71700-f1e3-11ea-9d97-e2e8d1a9e718.png)


### References 🔗
https://aclgrc.atlassian.net/browse/TW-612


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
