### PR TITLE
Tw 670 button link default styling resilient to global styles

### DIFF
--- a/packages/Button/CHANGELOG.md
+++ b/packages/Button/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+Updated DEFAULT hover,visited styles to be resilient to global styling, [@tristanjasper](https://github.com/tristanjasper).
+
 ## [0.3.0] - 2020-06-16
 
 ### Changed

--- a/packages/Button/src/Button.styles.js
+++ b/packages/Button/src/Button.styles.js
@@ -182,13 +182,14 @@ export const sizeStyles = {
 export const kindStyles = ({ isDisabled }) => ({
   [types.DEFAULT]: css`
     ${skeuomorphicStyles}
-
     background-color: ${tokens.color.white};
     background-image: linear-gradient(${tokens.color.blackLighten90}, ${tokens.color.blackLighten70});
     color: ${tokens.color.black};
 
-    &:hover {
+    &:hover, &:visited {
       background: ${tokens.color.blackLighten70};
+      color: ${tokens.color.black};
+      text-decoration: none;
     }
 
     ${isDisabled && disabledStyles}

--- a/packages/Button/src/Button.styles.js
+++ b/packages/Button/src/Button.styles.js
@@ -182,14 +182,17 @@ export const sizeStyles = {
 export const kindStyles = ({ isDisabled }) => ({
   [types.DEFAULT]: css`
     ${skeuomorphicStyles}
-    background-color: ${tokens.color.white};
-    background-image: linear-gradient(${tokens.color.blackLighten90}, ${tokens.color.blackLighten70});
-    color: ${tokens.color.black};
 
-    &:hover, &:visited {
-      background: ${tokens.color.blackLighten70};
+    &, &:hover, &:active, &:visited {
+      background-color: ${tokens.color.white};
+      background-image: linear-gradient(${tokens.color.blackLighten90}, ${tokens.color.blackLighten70});
       color: ${tokens.color.black};
       text-decoration: none;
+    }
+
+    &:hover,
+    &:active {
+      background: ${tokens.color.blackLighten70};
     }
 
     ${isDisabled && disabledStyles}


### PR DESCRIPTION
### Purpose 🚀
Ensure `button.Links` with default button styling are not having their `hover` or `visited` states overridden by common global styles in consuming applications. 

Currently this covers any `a` tag hover, visited styles. 

As required to fix https://aclgrc.atlassian.net/browse/TW-670

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_
- [x] PATCH (bug fix) change to Button

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/TW-670-Button-link-default-styling

### Screenshots 📸
_optional but highly recommended_

### References 🔗
https://aclgrc.atlassian.net/browse/TW-670


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
