### PR TITLE
RAPRM-760  Propagate Table.ColumnDefinition moreProps to TH 🐐

### DIFF
--- a/packages/Table/CHANGELOG.md
+++ b/packages/Table/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Propagate `<Table.ColumnDefinition>` `moreProps` to the `<th>` elements. [@mikrotron](https://github.com/mikrotron)
+- BREAKING: Propagate `<Table.ColumnDefinition>` `moreProps` to the `<th>` elements. This could introduce a breaking change since props that were applied to `<td>` elements will now ALSO be applied to `<th>` elements. [@mikrotron](https://github.com/mikrotron)
 
 ## [0.1.3] - 2020-08-27
 

--- a/packages/Table/CHANGELOG.md
+++ b/packages/Table/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - default border has been changed from grid to horizontal. [@kaan.darcey](https://github.com/KDarcey).
 
+### Added
+
+- Propagate `<Table.ColumnDefinition>` `moreProps` to the `<th>` elements. [@mikrotron](https://github.com/mikrotron)
+
 ## [0.1.3] - 2020-08-27
 
 - Add default font styles on th [@tristanjasper](https://github.com/tristanjasper).

--- a/packages/Table/README.md
+++ b/packages/Table/README.md
@@ -42,7 +42,9 @@ npm install @paprika/table
 
 ## Basic
 
-To create a basic Table simply add the `<Table>` component and set the `data` property to the data object you wish to pass in. Inside your table you can create columns by adding the `<Table.ColumnDefinition />` sub component. Add a header name with the `header` property and set the `cell` property to specify the data object property name you wish to pas into said column.
+To create a basic Table simply add the `<Table>` component and set the `data` property to the data object you wish to pass in.
+
+Inside your table you can create columns by adding the `<Table.ColumnDefinition />` sub component. Add a header name with the `header` property and set the `cell` property to specify the data object property name you wish to pas into said column. You can add additional attributes like `className` which will be applied to both the header element (`th`) and the cells (`td`).
 
 ```js
 <Table data={data}>

--- a/packages/Table/src/Table.js
+++ b/packages/Table/src/Table.js
@@ -26,17 +26,17 @@ export default function Table(props) {
       <sc.Thead>
         <tr>
           {ColumnDefinitions.map((columnDefinition, columnIndex) => {
-            const { header } = columnDefinition.props;
+            const { cell, header, ...moreColumnProps } = columnDefinition.props;
 
             if (typeof header === "function")
               return (
-                <sc.TH borderType={borderType} key={columnIndex}>
+                <sc.TH borderType={borderType} key={columnIndex} {...moreColumnProps}>
                   {header({ header: columnDefinition.props, columnIndex })}
                 </sc.TH>
               );
             if (typeof header === "string")
               return (
-                <sc.TH borderType={borderType} key={columnIndex}>
+                <sc.TH borderType={borderType} key={columnIndex} {...moreColumnProps}>
                   {header}
                 </sc.TH>
               );
@@ -50,17 +50,17 @@ export default function Table(props) {
           return (
             <tr key={rowIndex}>
               {ColumnDefinitions.map((columnDefinition, columnIndex) => {
-                const { cell, ...moreProps } = columnDefinition.props;
+                const { cell, header, ...moreColumnProps } = columnDefinition.props;
 
                 if (typeof cell === "function")
                   return (
-                    <sc.TD borderType={borderType} key={columnIndex} {...moreProps}>
+                    <sc.TD borderType={borderType} key={columnIndex} {...moreColumnProps}>
                       {cell({ row, rowIndex, columnIndex })}
                     </sc.TD>
                   );
                 if (typeof cell === "string")
                   return (
-                    <sc.TD borderType={borderType} key={columnIndex} {...moreProps}>
+                    <sc.TD borderType={borderType} key={columnIndex} {...moreColumnProps}>
                       {typeof row[cell] !== "undefined" ? row[cell] : `Error: ${cell} doesn't exist`}
                     </sc.TD>
                   );


### PR DESCRIPTION
### Purpose 🚀
Propagate `<Table.ColumnDefinition>` `moreProps` attributes to the table header (`<th>`) elements.

### Notes ✏️
- `moreProps` were already being propagated to the cell elements (`<td>`), this applies them to the headers too, so that `classNames`, `test-ids`, etc can also be applied to the `th`, which is especially important for an empty table.
- Added a note to the `README` that explains how `<Table.ColumnDefinition>` `moreProps` are handled.
- Did not add to the MDX `Docs` page – the `README` will be added to that page in another upcoming task. 

### Updates 📦
- [x] MAJOR (breaking) change to `@paprika/table`

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/RAPRM-760--table-moreprops

### References 🔗
https://aclgrc.atlassian.net/browse/RAPRM-760

This came as a request from @robyn3choi:
> I'm having a problem with `Table` right now, and maybe this is something that's missing in the docs, or just a missing feature. But it doesn't look like there's a way to control the column header widths when there are no cells in the table. So when cells get added, the column headers shift around. I saw in a storybook example that `Table.ColumnDefinition` accepts a `width` prop (it would be good to add this prop to the docs), but this doesn't kick in until cells are added.



<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
