### PR TITLE
UXD-451 form element spacing tweaks

### DIFF
--- a/packages/FormElement/CHANGELOG.md
+++ b/packages/FormElement/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Added
 
-- Changed label spacing, cleanup instructions margins [@tristanjasper](https://github.com/tristanjasper).
+- Changed label spacing, cleanup instructions margins. Moved Help tooltip to fix z-index issue [@tristanjasper](https://github.com/tristanjasper).
 
 ## [0.3.0] - 2020-01-17
 

--- a/packages/FormElement/CHANGELOG.md
+++ b/packages/FormElement/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 2020-10-27
 
-# Added
+# Changed
 
 - Changed label spacing, cleanup instructions margins. Moved Help tooltip to fix z-index issue [@tristanjasper](https://github.com/tristanjasper).
 

--- a/packages/FormElement/CHANGELOG.md
+++ b/packages/FormElement/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 2020-10-27
 
-# Changed
+### Changed
 
 - Changed label spacing, cleanup instructions margins. Moved Help tooltip to fix z-index issue [@tristanjasper](https://github.com/tristanjasper).
 

--- a/packages/FormElement/CHANGELOG.md
+++ b/packages/FormElement/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+2020-10-27
+
+# Added
+
+- Changed label spacing, cleanup instructions margins [@tristanjasper](https://github.com/tristanjasper).
+
 ## [0.3.0] - 2020-01-17
 
 ### Added

--- a/packages/FormElement/src/FormElement.js
+++ b/packages/FormElement/src/FormElement.js
@@ -97,7 +97,6 @@ function FormElement(props) {
       {...moreProps}
     >
       <Label
-        hasInstructionsShowing={extractedChildren[subComponentDisplayNames.Instructions]}
         hasOptionalLabel={hasRequiredLabel ? false : hasOptionalLabel}
         hasRequiredLabel={hasRequiredLabel}
         help={extractedChildren[subComponentDisplayNames.Help]}

--- a/packages/FormElement/src/components/Help/Help.js
+++ b/packages/FormElement/src/components/Help/Help.js
@@ -28,9 +28,9 @@ function Help(props) {
         <InfoCircleIcon css={iconStyles} aria-hidden type="exclamation-circle" />
       </StyledTrigger>
       <Popover.Content>
-        <Popover.Tip zIndex={moreProps.zIndex ? moreProps.zIndex + 1 : undefined} />
         <Popover.Card>{children}</Popover.Card>
       </Popover.Content>
+      <Popover.Tip />
     </Popover>
   );
 }

--- a/packages/FormElement/src/components/Instructions/Instructions.styles.js
+++ b/packages/FormElement/src/components/Instructions/Instructions.styles.js
@@ -1,7 +1,6 @@
 import styled from "styled-components";
 import tokens from "@paprika/tokens";
 import stylers from "@paprika/stylers";
-import { toInt } from "@paprika/stylers/lib/helpers";
 
 export const Instructions = styled.div`
   ${stylers.lineHeight(-1)}

--- a/packages/FormElement/src/components/Instructions/Instructions.styles.js
+++ b/packages/FormElement/src/components/Instructions/Instructions.styles.js
@@ -6,5 +6,5 @@ import { toInt } from "@paprika/stylers/lib/helpers";
 export const Instructions = styled.div`
   ${stylers.lineHeight(-1)}
   color: ${tokens.color.blackLighten20};
-  margin: ${tokens.space} 0 ${toInt(tokens.space) * 2}px 0;
+  margin: ${tokens.space} 0 ${stylers.spacer(2)} 0;
 `;

--- a/packages/FormElement/src/components/Instructions/Instructions.styles.js
+++ b/packages/FormElement/src/components/Instructions/Instructions.styles.js
@@ -6,5 +6,5 @@ import { toInt } from "@paprika/stylers/lib/helpers";
 export const Instructions = styled.div`
   ${stylers.lineHeight(-1)}
   color: ${tokens.color.blackLighten20};
-  margin: ${toInt(tokens.space) + toInt(tokens.spaceSm)}px 0 ${toInt(tokens.space) * 2}px 0;
+  margin: ${tokens.space} 0 ${toInt(tokens.space) * 2}px 0;
 `;

--- a/packages/FormElement/src/components/Instructions/Instructions.styles.js
+++ b/packages/FormElement/src/components/Instructions/Instructions.styles.js
@@ -6,5 +6,5 @@ import { toInt } from "@paprika/stylers/lib/helpers";
 export const Instructions = styled.div`
   ${stylers.lineHeight(-1)}
   color: ${tokens.color.blackLighten20};
-  margin: 0 0 ${toInt(tokens.space) * 2}px 0;
+  margin: ${toInt(tokens.space) + toInt(tokens.spaceSm)}px 0 ${toInt(tokens.space) * 2}px 0;
 `;

--- a/packages/FormElement/src/components/Label/Label.styles.js
+++ b/packages/FormElement/src/components/Label/Label.styles.js
@@ -1,20 +1,18 @@
 import { css } from "styled-components";
 import tokens from "@paprika/tokens";
 import stylers from "@paprika/stylers";
-import { toInt } from "@paprika/stylers/lib/helpers";
 
 export const ruleStyles = css`
   color: ${tokens.textColor.subtle};
   font-weight: normal;
 `;
 
-const labelStyles = ({ hasInstructionsShowing, isVisuallyHidden }) => css`
+const labelStyles = ({ isVisuallyHidden }) => css`
   color: ${tokens.textColor.default};
   display: inline-block;
   font-size: inherit;
   font-weight: bold;
-  margin: 0 ${stylers.spacer(4)}
-    ${hasInstructionsShowing ? toInt(tokens.space) + toInt(tokens.spaceSm) : toInt(tokens.space) * 2}px 0;
+  margin: 0 ${stylers.spacer(4)} ${tokens.spaceSm} 0;
   padding: 0;
   position: relative;
 

--- a/packages/FormElement/stories/examples/ButtonGroupExample.js
+++ b/packages/FormElement/stories/examples/ButtonGroupExample.js
@@ -1,5 +1,6 @@
 import React from "react";
 import ButtonGroup from "@paprika/button-group";
+import stylers from "@paprika/stylers";
 import FormElement from "../../src/FormElement";
 
 export default function ButtonGroupExample() {
@@ -14,7 +15,11 @@ export default function ButtonGroupExample() {
   return (
     <FormElement label="Form Label" onClickLabel={() => refButtonGroup.current.focus()}>
       <FormElement.Content>
-        {() => <ButtonGroup ref={refButtonGroup}>{buttonGroupOptions}</ButtonGroup>}
+        {() => (
+          <ButtonGroup style={{ marginTop: stylers.spacer(2) }} ref={refButtonGroup}>
+            {buttonGroupOptions}
+          </ButtonGroup>
+        )}
       </FormElement.Content>
     </FormElement>
   );

--- a/packages/FormElement/stories/examples/CheckboxExample.js
+++ b/packages/FormElement/stories/examples/CheckboxExample.js
@@ -1,6 +1,8 @@
 import React from "react";
 import * as constants from "@paprika/constants/lib/Constants";
 import Checkbox from "@paprika/checkbox";
+import styled from "styled-components";
+import stylers from "@paprika/stylers";
 import FormElement from "../../src/FormElement";
 
 export default function CheckboxExample() {
@@ -15,10 +17,16 @@ export default function CheckboxExample() {
       </Checkbox>
     ));
 
+  const CheckboxGroup = styled.div`
+    margin-top: ${stylers.spacer(2)};
+  `;
+
   return (
     <FormElement hasFieldSet label="Form Label">
       <FormElement.Content>
-        {({ ariaDescribedBy: ariaDescribedByOuter }) => getCheckboxOptions(ariaDescribedByOuter)}
+        {({ ariaDescribedBy: ariaDescribedByOuter }) => (
+          <CheckboxGroup>{getCheckboxOptions(ariaDescribedByOuter)}</CheckboxGroup>
+        )}
       </FormElement.Content>
     </FormElement>
   );

--- a/packages/FormElement/stories/examples/NestedExample.js
+++ b/packages/FormElement/stories/examples/NestedExample.js
@@ -1,4 +1,5 @@
 import React from "react";
+import stylers from "@paprika/stylers";
 import FormElement from "../../src/FormElement";
 
 export default function NestedExample() {
@@ -12,7 +13,7 @@ export default function NestedExample() {
       <FormElement.Content>
         {({ ariaDescribedBy: ariaDescribedByOuter }) => (
           <>
-            <FormElement isInline label="Sub Label">
+            <FormElement style={{ marginTop: stylers.spacer(2) }} isInline label="Sub Label">
               <FormElement.Content>
                 {({ idForLabel, ariaDescribedBy }) => (
                   <>

--- a/packages/FormElement/stories/examples/RadioExample.js
+++ b/packages/FormElement/stories/examples/RadioExample.js
@@ -2,6 +2,7 @@ import React from "react";
 import * as constants from "@paprika/constants/lib/Constants";
 import { action } from "@storybook/addon-actions";
 import Radio from "@paprika/radio";
+import stylers from "@paprika/stylers";
 import FormElement from "../../src/FormElement";
 
 export default function RadioExample() {
@@ -11,6 +12,7 @@ export default function RadioExample() {
 
   const getRadioOptions = ariaDescribedBy => (
     <Radio.Group
+      style={{ marginTop: stylers.spacer(2) }}
       onChange={activeIndex => {
         action(`Radio index selected is ${activeIndex}`)();
       }}

--- a/packages/Radio/CHANGELOG.md
+++ b/packages/Radio/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 2020-10-27
 
-# Added
+# Changed (Breaking)
 
 - Moved moreGroupProps to be spread on Group component rather than children [@tristanjasper](https://github.com/tristanjasper).
 

--- a/packages/Radio/CHANGELOG.md
+++ b/packages/Radio/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+2020-10-27
+
+# Added
+
+- Moved moreGroupProps to be spread on Group component rather than children [@tristanjasper](https://github.com/tristanjasper).
+
 ## [0.1.6] - 2020-01-31
 
 ### Added

--- a/packages/Radio/CHANGELOG.md
+++ b/packages/Radio/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 2020-10-27
 
-# Changed (Breaking)
+### Changed (Breaking)
 
 - Moved moreGroupProps to be spread on Group component rather than children [@tristanjasper](https://github.com/tristanjasper).
 

--- a/packages/Radio/src/components/Group/Group.js
+++ b/packages/Radio/src/components/Group/Group.js
@@ -49,7 +49,7 @@ function Group(props) {
   };
 
   return (
-    <div role="radiogroup" aria-labelledby={a11yText} data-pka-anchor="radio.group">
+    <div role="radiogroup" aria-labelledby={a11yText} data-pka-anchor="radio.group" {...moreGroupProps}>
       {React.Children.map(children, (child, index) => {
         if (child && child.type && child.type.displayName === "Radio") {
           const childKey = { key: `Radio${index}` };
@@ -60,7 +60,6 @@ function Group(props) {
             canDeselect,
             name: child.props.name || name,
             ...childKey,
-            ...moreGroupProps,
           });
         }
         return child;


### PR DESCRIPTION
### Purpose 🚀
Ticket: https://aclgrc.atlassian.net/browse/UXD-451
Addressing the design requirements in https://aclgrc.atlassian.net/browse/UX-797

Changing the spacing around the formElement label so that content is closer by default. If increased spacing is required around the content then it is up to the consumer to add that necessary margin.

These changes will be required in results questionnaires.

Spacing changes include:

FormElement label has smaller bottom margin to content.
Instructions spacing adjusted.

Before:
![image](https://user-images.githubusercontent.com/4040102/97241128-63700980-17ad-11eb-8095-b43c2a0cb148.png)

After:
![image](https://user-images.githubusercontent.com/4040102/97329532-6235ef80-1834-11eb-89b3-b9ad99de187e.png)



### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
- [x] MAJOR (breaking) change to Radio
- [ ] MINOR (backward compatible) change to _these packages_
- [x] PATCH (bug fix) change to FormElement, Radio

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/uxd-451-formElement-spacing-tweaks

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
