### PR TITLE
Uxd 464 expose onclose and card

### DIFF
--- a/packages/DropdownMenu/README.md
+++ b/packages/DropdownMenu/README.md
@@ -72,6 +72,7 @@ import Confirmation from "@paprika/confirmation";
 
 <DropdownMenu>
   <DropdownMenu.Trigger>Trigger</DropdownMenu.Trigger>
+  <DropdownMenu.Content className="my-popover-classname" />
   <DropdownMenu.Item onClick={() => {}}>Edit</DropdownMenu.Item>
   <DropdownMenu.LinkItem isExternal link="http://www.wegalvanize.com">
     External link

--- a/packages/DropdownMenu/README.md
+++ b/packages/DropdownMenu/README.md
@@ -22,12 +22,13 @@ npm install @paprika/dropdown-menu
 
 ### DropdownMenu
 
-| Prop     | Type   | required | default                     | Description                                                  |
-| -------- | ------ | -------- | --------------------------- | ------------------------------------------------------------ |
-| align    | custom | false    | Popover.defaultProps.align  | Alignment of the Popover                                     |
-| children | node   | true     | -                           | Children should consist of <Dropdown.Item />                 |
-| edge     | custom | false    | Popover.defaultProps.edge   | If provided, will align Popover to specified edge of Trigger |
-| zIndex   | custom | false    | Popover.defaultProps.zIndex | The z-index for the popover / confirmation                   |
+| Prop     | Type   | required | default                      | Description                                                  |
+| -------- | ------ | -------- | ---------------------------- | ------------------------------------------------------------ |
+| align    | custom | false    | Popover.defaultProps.align   | Alignment of the Popover                                     |
+| children | node   | true     | -                            | Children should consist of <Dropdown.Item />                 |
+| edge     | custom | false    | Popover.defaultProps.edge    | If provided, will align Popover to specified edge of Trigger |
+| onClose  | custom | false    | Popover.defaultProps.onClose | If provided, will fire when the Popover is closed            |
+| zIndex   | custom | false    | Popover.defaultProps.zIndex  | The z-index for the popover / confirmation                   |
 
 ### DropdownMenu.Item
 

--- a/packages/DropdownMenu/src/DropdownMenu.js
+++ b/packages/DropdownMenu/src/DropdownMenu.js
@@ -22,6 +22,9 @@ const propTypes = {
   /** If provided, will fire when the Popover is closed */
   onClose: Popover.propTypes.onClose,
 
+  /** If provided, this class will get applied to the Popover component */
+  popoverClassName: PropTypes.string,
+
   /** The z-index for the popover / confirmation */
   zIndex: Popover.propTypes.zIndex,
 };
@@ -30,13 +33,14 @@ const defaultProps = {
   align: Popover.defaultProps.align,
   edge: Popover.defaultProps.edge,
   onClose: Popover.defaultProps.onClose,
+  popoverClassName: "",
   zIndex: Popover.defaultProps.zIndex,
 };
 
 const popoverOffset = 4;
 
 function DropdownMenu(props) {
-  const { align, children, edge, onClose, zIndex, ...moreProps } = props;
+  const { align, children, edge, onClose, popoverClassName, zIndex, ...moreProps } = props;
 
   const [isOpen, setIsOpen] = React.useState(false);
   const [isConfirming, setIsConfirming] = React.useState(false);
@@ -180,7 +184,7 @@ function DropdownMenu(props) {
       }}
     >
       <Popover.Trigger>{renderTrigger()}</Popover.Trigger>
-      <Popover.Content id={menuId.current} role={!isConfirming ? "menu" : null}>
+      <Popover.Content id={menuId.current} role={!isConfirming ? "menu" : null} className={popoverClassName}>
         {isOpen && renderContent()}
       </Popover.Content>
     </Popover>

--- a/packages/DropdownMenu/src/DropdownMenu.js
+++ b/packages/DropdownMenu/src/DropdownMenu.js
@@ -19,6 +19,9 @@ const propTypes = {
   /** If provided, will align Popover to specified edge of Trigger */
   edge: Popover.propTypes.edge,
 
+  /** If provided, will fire when the Popover is closed */
+  onClose: Popover.propTypes.onClose,
+
   /** The z-index for the popover / confirmation */
   zIndex: Popover.propTypes.zIndex,
 };
@@ -26,13 +29,14 @@ const propTypes = {
 const defaultProps = {
   align: Popover.defaultProps.align,
   edge: Popover.defaultProps.edge,
+  onClose: Popover.defaultProps.onClose,
   zIndex: Popover.defaultProps.zIndex,
 };
 
 const popoverOffset = 4;
 
 function DropdownMenu(props) {
-  const { align, children, edge, zIndex, ...moreProps } = props;
+  const { align, children, edge, onClose, zIndex, ...moreProps } = props;
 
   const [isOpen, setIsOpen] = React.useState(false);
   const [isConfirming, setIsConfirming] = React.useState(false);
@@ -58,6 +62,10 @@ function DropdownMenu(props) {
     }
 
     if (triggerRef.current) triggerRef.current.focus();
+
+    if (onClose) {
+      onClose();
+    }
   };
 
   const handleOpenMenu = () => {

--- a/packages/DropdownMenu/src/DropdownMenu.js
+++ b/packages/DropdownMenu/src/DropdownMenu.js
@@ -78,12 +78,15 @@ function DropdownMenu(props) {
     }, 250);
   };
 
-  const extractedChildren = extractChildren(children, ["DropdownMenu.Trigger", "DropdownMenu.Content"]);
-  const Content = extractedChildren["DropdownMenu.Content"];
+  const {
+    "DropdownMenu.Trigger": Trigger,
+    "DropdownMenu.Content": Content,
+    children: extractedChildren,
+  } = extractChildren(children, ["DropdownMenu.Trigger", "DropdownMenu.Content"]);
 
   const dropdownLastItemIndex =
     React.Children.toArray(
-      extractedChildren.children.filter(
+      extractedChildren.filter(
         child =>
           child.type &&
           (child.type.displayName === "DropdownMenu.Item" || child.type.displayName === "DropdownMenu.LinkItem")
@@ -117,7 +120,7 @@ function DropdownMenu(props) {
     // wrapping the returned item in a function to avoid needing to tab twice
     // https://github.com/acl-services/paprika/issues/126
     return () =>
-      React.cloneElement(extractedChildren["DropdownMenu.Trigger"], {
+      React.cloneElement(Trigger, {
         isOpen,
         onOpenMenu: handleOpenMenu,
         triggerRef,
@@ -150,7 +153,7 @@ function DropdownMenu(props) {
     return (
       <Popover.Card>
         <sc.Content ref={dropdownListRef}>
-          {extractedChildren.children.map((child, index) => {
+          {extractedChildren.map((child, index) => {
             const childKey = { key: `DropdownMenuItem${index}` };
             if (child && child.type && child.type.displayName === "DropdownMenu.Item") {
               if (child.props.renderConfirmation) {

--- a/packages/DropdownMenu/src/DropdownMenu.js
+++ b/packages/DropdownMenu/src/DropdownMenu.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import uuid from "uuid/v4";
 import Popover from "@paprika/popover";
 import extractChildren from "@paprika/helpers/lib/extractChildren";
+import Content from "./components/Content";
 import Divider from "./components/Divider";
 import Trigger from "./components/Trigger";
 import LinkItem from "./components/LinkItem";
@@ -22,9 +23,6 @@ const propTypes = {
   /** If provided, will fire when the Popover is closed */
   onClose: Popover.propTypes.onClose,
 
-  /** If provided, this class will get applied to the Popover component */
-  popoverClassName: PropTypes.string,
-
   /** The z-index for the popover / confirmation */
   zIndex: Popover.propTypes.zIndex,
 };
@@ -33,14 +31,13 @@ const defaultProps = {
   align: Popover.defaultProps.align,
   edge: Popover.defaultProps.edge,
   onClose: Popover.defaultProps.onClose,
-  popoverClassName: "",
   zIndex: Popover.defaultProps.zIndex,
 };
 
 const popoverOffset = 4;
 
 function DropdownMenu(props) {
-  const { align, children, edge, onClose, popoverClassName, zIndex, ...moreProps } = props;
+  const { align, children, edge, onClose, zIndex, ...moreProps } = props;
 
   const [isOpen, setIsOpen] = React.useState(false);
   const [isConfirming, setIsConfirming] = React.useState(false);
@@ -81,7 +78,8 @@ function DropdownMenu(props) {
     }, 250);
   };
 
-  const extractedChildren = extractChildren(children, ["DropdownMenu.Trigger"]);
+  const extractedChildren = extractChildren(children, ["DropdownMenu.Trigger", "DropdownMenu.Content"]);
+  const Content = extractedChildren["DropdownMenu.Content"];
 
   const dropdownLastItemIndex =
     React.Children.toArray(
@@ -184,7 +182,7 @@ function DropdownMenu(props) {
       }}
     >
       <Popover.Trigger>{renderTrigger()}</Popover.Trigger>
-      <Popover.Content id={menuId.current} role={!isConfirming ? "menu" : null} className={popoverClassName}>
+      <Popover.Content id={menuId.current} role={!isConfirming ? "menu" : null} {...Content.props}>
         {isOpen && renderContent()}
       </Popover.Content>
     </Popover>
@@ -195,6 +193,7 @@ DropdownMenu.displayName = "DropdownMenu";
 DropdownMenu.propTypes = propTypes;
 DropdownMenu.defaultProps = defaultProps;
 
+DropdownMenu.Content = Content;
 DropdownMenu.Divider = Divider;
 DropdownMenu.LinkItem = LinkItem;
 DropdownMenu.Item = Item;

--- a/packages/DropdownMenu/src/DropdownMenu.js
+++ b/packages/DropdownMenu/src/DropdownMenu.js
@@ -83,6 +83,7 @@ function DropdownMenu(props) {
     "DropdownMenu.Content": Content,
     children: extractedChildren,
   } = extractChildren(children, ["DropdownMenu.Trigger", "DropdownMenu.Content"]);
+  const ContentProps = Content && Content.props ? Content.props : null;
 
   const dropdownLastItemIndex =
     React.Children.toArray(
@@ -185,7 +186,7 @@ function DropdownMenu(props) {
       }}
     >
       <Popover.Trigger>{renderTrigger()}</Popover.Trigger>
-      <Popover.Content id={menuId.current} role={!isConfirming ? "menu" : null} {...Content.props}>
+      <Popover.Content id={menuId.current} role={!isConfirming ? "menu" : null} {...ContentProps}>
         {isOpen && renderContent()}
       </Popover.Content>
     </Popover>

--- a/packages/DropdownMenu/src/components/Content/Content.js
+++ b/packages/DropdownMenu/src/components/Content/Content.js
@@ -1,5 +1,3 @@
-// import React from "react";
-
 export default function Content() {
   return null;
 }

--- a/packages/DropdownMenu/src/components/Content/Content.js
+++ b/packages/DropdownMenu/src/components/Content/Content.js
@@ -1,0 +1,7 @@
+// import React from "react";
+
+export default function Content() {
+  return null;
+}
+
+Content.displayName = "DropdownMenu.Content";

--- a/packages/DropdownMenu/src/components/Content/Content.js
+++ b/packages/DropdownMenu/src/components/Content/Content.js
@@ -1,5 +1,7 @@
+import React from "react";
+
 export default function Content() {
-  return null;
+  return <React.Fragment />;
 }
 
 Content.displayName = "DropdownMenu.Content";

--- a/packages/DropdownMenu/src/components/Content/index.js
+++ b/packages/DropdownMenu/src/components/Content/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Content";

--- a/packages/DropdownMenu/src/index.d.ts
+++ b/packages/DropdownMenu/src/index.d.ts
@@ -9,6 +9,8 @@ interface DropdownMenuProps {
   children: React.ReactNode;
   /** If provided, will align Popover to specified edge of Trigger */
   edge?: custom;
+  /** If provided, will fire when the Popover is closed */
+  onClose?: custom;
   /** The z-index for the popover / confirmation */
   zIndex?: custom;
 }

--- a/packages/DropdownMenu/stories/DropdownMenu.stories.js
+++ b/packages/DropdownMenu/stories/DropdownMenu.stories.js
@@ -12,6 +12,7 @@ import DropdownMenuDividersExample from "./examples/DropdownMenuDividersExample"
 import DropdownMenuLongestExample from "./examples/DropdownMenuLongestExample";
 import DropdownMenuTriggerExample from "./examples/DropdownMenuTriggerExample";
 import DropdownMenuOnCloseExample from "./examples/DropdownMenuOnCloseExample";
+import DropdownMenuWithCustomClassExample from "./examples/DropdownMenuWithCustomClassExample";
 import ZIndexExample from "./examples/ZIndex";
 
 const storyName = getStoryName("DropdownMenu");
@@ -61,6 +62,11 @@ storiesOf(`${storyName}/Examples`, module)
   .add("with onClose", () => (
     <DropdownMenuStory>
       <DropdownMenuOnCloseExample />
+    </DropdownMenuStory>
+  ))
+  .add("with custom class on Popover content", () => (
+    <DropdownMenuStory>
+      <DropdownMenuWithCustomClassExample />
     </DropdownMenuStory>
   ));
 

--- a/packages/DropdownMenu/stories/DropdownMenu.stories.js
+++ b/packages/DropdownMenu/stories/DropdownMenu.stories.js
@@ -11,6 +11,7 @@ import DropdownMenuDisabledExample from "./examples/DropdownMenuDisabledExample"
 import DropdownMenuDividersExample from "./examples/DropdownMenuDividersExample";
 import DropdownMenuLongestExample from "./examples/DropdownMenuLongestExample";
 import DropdownMenuTriggerExample from "./examples/DropdownMenuTriggerExample";
+import DropdownMenuOnCloseExample from "./examples/DropdownMenuOnCloseExample";
 import ZIndexExample from "./examples/ZIndex";
 
 const storyName = getStoryName("DropdownMenu");
@@ -55,6 +56,11 @@ storiesOf(`${storyName}/Examples`, module)
   .add("with trigger examples", () => (
     <DropdownMenuStory>
       <DropdownMenuTriggerExample />
+    </DropdownMenuStory>
+  ))
+  .add("with onClose", () => (
+    <DropdownMenuStory>
+      <DropdownMenuOnCloseExample />
     </DropdownMenuStory>
   ));
 

--- a/packages/DropdownMenu/stories/examples/DropdownMenuOnCloseExample.js
+++ b/packages/DropdownMenu/stories/examples/DropdownMenuOnCloseExample.js
@@ -5,22 +5,20 @@ const DropdownMenuOnCloseExample = () => {
   const [isOpen, setIsOpen] = React.useState(false);
 
   return (
-    <React.Fragment>
-      <DropdownMenu
-        onClose={() => {
-          setIsOpen(false);
-        }}
-      >
-        <DropdownMenu.Trigger buttonType={DropdownMenu.Trigger.types.button.RAW}>
-          <button type="button" onClick={() => setIsOpen(true)}>
-            {isOpen ? "Click away to close" : "Click to open"}
-          </button>
-        </DropdownMenu.Trigger>
-        <DropdownMenu.Item onClick={null}>Item 1</DropdownMenu.Item>
-        <DropdownMenu.Item onClick={null}>Item 2</DropdownMenu.Item>
-        <DropdownMenu.Item onClick={null}>Item 3</DropdownMenu.Item>
-      </DropdownMenu>
-    </React.Fragment>
+    <DropdownMenu
+      onClose={() => {
+        setIsOpen(false);
+      }}
+    >
+      <DropdownMenu.Trigger buttonType={DropdownMenu.Trigger.types.button.RAW}>
+        <button type="button" onClick={() => setIsOpen(true)}>
+          {isOpen ? "Click away to close" : "Click to open"}
+        </button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Item onClick={null}>Item 1</DropdownMenu.Item>
+      <DropdownMenu.Item onClick={null}>Item 2</DropdownMenu.Item>
+      <DropdownMenu.Item onClick={null}>Item 3</DropdownMenu.Item>
+    </DropdownMenu>
   );
 };
 

--- a/packages/DropdownMenu/stories/examples/DropdownMenuOnCloseExample.js
+++ b/packages/DropdownMenu/stories/examples/DropdownMenuOnCloseExample.js
@@ -1,0 +1,27 @@
+import React from "react";
+import DropdownMenu from "../../src";
+
+const DropdownMenuOnCloseExample = () => {
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  return (
+    <React.Fragment>
+      <DropdownMenu
+        onClose={() => {
+          setIsOpen(false);
+        }}
+      >
+        <DropdownMenu.Trigger buttonType={DropdownMenu.Trigger.types.button.RAW}>
+          <button type="button" onClick={() => setIsOpen(true)}>
+            {isOpen ? "Click away to close" : "Click to open"}
+          </button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Item onClick={null}>Item 1</DropdownMenu.Item>
+        <DropdownMenu.Item onClick={null}>Item 2</DropdownMenu.Item>
+        <DropdownMenu.Item onClick={null}>Item 3</DropdownMenu.Item>
+      </DropdownMenu>
+    </React.Fragment>
+  );
+};
+
+export default DropdownMenuOnCloseExample;

--- a/packages/DropdownMenu/stories/examples/DropdownMenuWithCustomClassExample.js
+++ b/packages/DropdownMenu/stories/examples/DropdownMenuWithCustomClassExample.js
@@ -1,0 +1,22 @@
+import React from "react";
+import DropdownMenu from "../../src";
+
+const DropdownMenuWithCustomClassExample = () => {
+  return (
+    <React.Fragment>
+      <p>
+        Inspect the content of the Popover that is revealed by expanding the DropdownMenu and you will see our class
+        added to it.
+      </p>
+      <DropdownMenu>
+        <DropdownMenu.Trigger>Open</DropdownMenu.Trigger>
+        <DropdownMenu.Content className="myCustomClassName" />
+        <DropdownMenu.Item onClick={null}>Item 1</DropdownMenu.Item>
+        <DropdownMenu.Item onClick={null}>Item 2</DropdownMenu.Item>
+        <DropdownMenu.Item onClick={null}>Item 3</DropdownMenu.Item>
+      </DropdownMenu>
+    </React.Fragment>
+  );
+};
+
+export default DropdownMenuWithCustomClassExample;


### PR DESCRIPTION
### Purpose 🚀
I added two things to `<DropdownMenu />`:

1. You can now pass in an `onClose` prop that is fired after the component is closed.  I need this so I can change the active state of the trigger that opened it.
2. You can now add a `<DropdownMenu.Content />` as a child of `<DropdownMenu>` to add props (e.g. a "className") to the internal `Popover.Card`:

![Screen Shot 2020-10-28 at 10 18 45 AM](https://user-images.githubusercontent.com/23224777/97472796-77c81980-1907-11eb-8b33-eb04b15dc8bc.png)

 I need this so I can target the Popover for style changes, i.e. remove this gap:
![Screen Shot 2020-10-27 at 4 11 59 PM](https://user-images.githubusercontent.com/23224777/97375099-283a0d00-1877-11eb-86d9-19a9df3b5830.png)