### PR TITLE
Uxd-478 form element margins

### DIFF
--- a/packages/FormElement/CHANGELOG.md
+++ b/packages/FormElement/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+28-10-20
+
+### Changed
+
+- FormElement Margin, removed content only margin and applied top margin to Descriptino and Error components [@tristanjasper](https://github.com/tristanjasper).
+
 ## [0.3.0] - 2020-01-17
 
 ### Added

--- a/packages/FormElement/src/FormElement.styles.js
+++ b/packages/FormElement/src/FormElement.styles.js
@@ -1,6 +1,5 @@
 import styled, { css } from "styled-components";
 import stylers from "@paprika/stylers";
-import tokens from "@paprika/tokens";
 
 const FontSizes = {
   small: stylers.fontSize(-2),
@@ -25,7 +24,7 @@ export const FormElement = styled.div(
     ${isInline && inlineFormElementStyles};
     ${isDisabled && `opacity: 0.5;`}
     border: none;
-    margin: 0 0 ${tokens.space} 0;
+    margin: 0;
     padding: 0;
   `
 );

--- a/packages/FormElement/src/FormElement.styles.js
+++ b/packages/FormElement/src/FormElement.styles.js
@@ -1,5 +1,6 @@
 import styled, { css } from "styled-components";
 import stylers from "@paprika/stylers";
+import tokens from "@paprika/tokens";
 
 const FontSizes = {
   small: stylers.fontSize(-2),
@@ -24,6 +25,7 @@ export const FormElement = styled.div(
     ${isInline && inlineFormElementStyles};
     ${isDisabled && `opacity: 0.5;`}
     border: none;
+    margin: 0 0 ${tokens.space} 0;
     padding: 0;
   `
 );

--- a/packages/FormElement/src/components/Content/Content.js
+++ b/packages/FormElement/src/components/Content/Content.js
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { RefOf } from "@paprika/helpers/lib/customPropTypes";
-import * as sc from "./Content.styles";
 
 const propTypes = {
   children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]).isRequired,
@@ -26,9 +25,9 @@ function Content(props) {
   }
 
   return (
-    <sc.ContentContainer data-pka-anchor="form-element.content" {...moreProps}>
+    <div data-pka-anchor="form-element.content" {...moreProps}>
       {typeof children === "function" ? children({ idForLabel, refLabel, ariaDescribedBy }) : children}
-    </sc.ContentContainer>
+    </div>
   );
 }
 

--- a/packages/FormElement/src/components/Content/Content.styles.js
+++ b/packages/FormElement/src/components/Content/Content.styles.js
@@ -1,6 +1,0 @@
-import styled from "styled-components";
-import tokens from "@paprika/tokens";
-
-export const ContentContainer = styled.div`
-  margin-bottom: ${tokens.spaceLg};
-`;

--- a/packages/FormElement/src/components/Description/Description.styles.js
+++ b/packages/FormElement/src/components/Description/Description.styles.js
@@ -5,4 +5,5 @@ import tokens from "@paprika/tokens";
 export const Description = styled.div`
   ${stylers.lineHeight(-1)}
   color: ${tokens.color.blackLighten20};
+  margin: ${tokens.space} 0 0 0;
 `;

--- a/packages/FormElement/src/components/ErrorMessage/ErrorMessage.styles.js
+++ b/packages/FormElement/src/components/ErrorMessage/ErrorMessage.styles.js
@@ -5,7 +5,7 @@ import stylers from "@paprika/stylers";
 
 export const iconStyles = css`
   margin-right: ${tokens.spaceSm};
-  margin-top: 2px;
+  margin-top: ${tokens.spaceSm};
 `;
 
 const errorMessageStyles = css`

--- a/packages/FormElement/src/components/ErrorMessage/ErrorMessage.styles.js
+++ b/packages/FormElement/src/components/ErrorMessage/ErrorMessage.styles.js
@@ -4,8 +4,7 @@ import tokens from "@paprika/tokens";
 import stylers from "@paprika/stylers";
 
 export const iconStyles = css`
-  margin-right: ${tokens.spaceSm};
-  margin-top: ${tokens.spaceSm};
+  margin: 2px ${tokens.spaceSm} 0 0;
 `;
 
 const errorMessageStyles = css`


### PR DESCRIPTION
### Purpose 🚀

1. Ensure formElement has margins applied so that application css won't override. (eg in the case of a fieldset)
2. Cleanup margins on subcomponents

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_
- [x] PATCH (bug fix) change to FormElement

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/uxd-478-formElement-margins

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
