### PR TITLE
Issue 794  overflow focus

### DIFF
--- a/packages/OverflowMenu/package.json
+++ b/packages/OverflowMenu/package.json
@@ -26,7 +26,8 @@
     "@paprika/stylers": "^1.0.0",
     "@paprika/tokens": "^1.0.0",
     "prop-types": "^15.7.2",
-    "uuid": "^3.3.2"
+    "uuid": "^3.3.2",
+    "what-input": "^5.2.10"
   },
   "peerDependencies": {
     "@paprika/l10n": "^0.2.5",

--- a/packages/OverflowMenu/src/OverflowMenu.js
+++ b/packages/OverflowMenu/src/OverflowMenu.js
@@ -55,7 +55,7 @@ function OverflowMenu(props) {
     setFocusIndex(index);
   }
 
-  const handleCloseMenu = (key) => {
+  const handleCloseMenu = key => {
     setIsOpen(false);
 
     if (isConfirming) {
@@ -92,7 +92,7 @@ function OverflowMenu(props) {
   const overflowLastItemIndex =
     React.Children.toArray(
       extractedChildren.filter(
-        (child) =>
+        child =>
           child.type &&
           (child.type.displayName === "OverflowMenu.Item" || child.type.displayName === "OverflowMenu.LinkItem")
       )
@@ -116,9 +116,9 @@ function OverflowMenu(props) {
     }
   };
 
-  const handleShowConfirmation = (renderConfirmation) => () => {
-    setIsConfirming((prevIsConfirmingState) => !prevIsConfirmingState);
-    setRenderConfirmation((prevIsConfirmingState) => (prevIsConfirmingState ? null : renderConfirmation));
+  const handleShowConfirmation = renderConfirmation => () => {
+    setIsConfirming(prevIsConfirmingState => !prevIsConfirmingState);
+    setRenderConfirmation(prevIsConfirmingState => (prevIsConfirmingState ? null : renderConfirmation));
   };
 
   const renderTrigger = () => {
@@ -136,7 +136,7 @@ function OverflowMenu(props) {
 
   const getClonedChild = (child, childKey, additionalProps = {}) =>
     React.cloneElement(child, {
-      onKeyDown: (e) => onKeyDown(e, currentFocusIndex),
+      onKeyDown: e => onKeyDown(e, currentFocusIndex),
       ...childKey,
       ...additionalProps,
     });

--- a/packages/OverflowMenu/src/OverflowMenu.js
+++ b/packages/OverflowMenu/src/OverflowMenu.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import uuid from "uuid/v4";
+import "what-input";
 import Popover from "@paprika/popover";
 import extractChildren from "@paprika/helpers/lib/extractChildren";
 import Content from "./components/Content";
@@ -71,11 +72,12 @@ function OverflowMenu(props) {
 
   const handleOpenMenu = () => {
     setIsOpen(true);
-    // https://github.com/acl-services/paprika/issues/316
-    // Todo Should focus the first item via an onAfterOpen event callback in popover
-    setTimeout(() => {
-      focusAndSetIndex(0);
-    }, 250);
+
+    if (document.querySelector("html").getAttribute("data-whatinput") === "keyboard") {
+      setTimeout(() => {
+        focusAndSetIndex(0);
+      }, 250);
+    }
   };
 
   const {
@@ -88,7 +90,7 @@ function OverflowMenu(props) {
   const overflowLastItemIndex =
     React.Children.toArray(
       extractedChildren.filter(
-        child =>
+        (child) =>
           child.type &&
           (child.type.displayName === "OverflowMenu.Item" || child.type.displayName === "OverflowMenu.LinkItem")
       )
@@ -112,9 +114,9 @@ function OverflowMenu(props) {
     }
   };
 
-  const handleShowConfirmation = renderConfirmation => () => {
-    setIsConfirming(prevIsConfirmingState => !prevIsConfirmingState);
-    setRenderConfirmation(prevIsConfirmingState => (prevIsConfirmingState ? null : renderConfirmation));
+  const handleShowConfirmation = (renderConfirmation) => () => {
+    setIsConfirming((prevIsConfirmingState) => !prevIsConfirmingState);
+    setRenderConfirmation((prevIsConfirmingState) => (prevIsConfirmingState ? null : renderConfirmation));
   };
 
   const renderTrigger = () => {
@@ -132,7 +134,7 @@ function OverflowMenu(props) {
 
   const getClonedChild = (child, childKey, additionalProps = {}) =>
     React.cloneElement(child, {
-      onKeyDown: e => onKeyDown(e, currentFocusIndex),
+      onKeyDown: (e) => onKeyDown(e, currentFocusIndex),
       ...childKey,
       ...additionalProps,
     });

--- a/packages/OverflowMenu/src/OverflowMenu.js
+++ b/packages/OverflowMenu/src/OverflowMenu.js
@@ -55,7 +55,7 @@ function OverflowMenu(props) {
     setFocusIndex(index);
   }
 
-  const handleCloseMenu = () => {
+  const handleCloseMenu = (key) => {
     setIsOpen(false);
 
     if (isConfirming) {
@@ -63,7 +63,9 @@ function OverflowMenu(props) {
       setRenderConfirmation(null);
     }
 
-    if (triggerRef.current) triggerRef.current.focus();
+    if (triggerRef.current && key === "Tab") {
+      triggerRef.current.focus();
+    }
 
     if (onClose) {
       onClose();
@@ -110,7 +112,7 @@ function OverflowMenu(props) {
     } else if (event.key === "Enter" || event.key === " ") {
       // do nothing
     } else {
-      handleCloseMenu();
+      handleCloseMenu(event.key);
     }
   };
 

--- a/packages/OverflowMenu/stories/OverflowMenu.stories.js
+++ b/packages/OverflowMenu/stories/OverflowMenu.stories.js
@@ -13,6 +13,7 @@ import OverflowMenuTriggerExample from "./examples/OverflowMenuTriggerExample";
 import OverflowMenuOnCloseExample from "./examples/OverflowMenuOnCloseExample";
 import OverflowMenuWithCustomClassExample from "./examples/OverflowMenuWithCustomClassExample";
 import ZIndexExample from "./examples/ZIndex";
+import AutoFocusExample from "./examples/AutoFocusExample";
 
 const storyName = getStoryName("OverflowMenu");
 
@@ -64,10 +65,16 @@ storiesOf(`${storyName}/Examples`, module)
     </OverflowMenuStory>
   ));
 
-storiesOf(`${storyName}/Backyard/Sandbox`, module).add("Z Index", () => (
-  <OverflowMenuStory>
-    <ZIndexExample />
-  </OverflowMenuStory>
-));
+storiesOf(`${storyName}/Backyard/Sandbox`, module)
+  .add("Z Index", () => (
+    <OverflowMenuStory>
+      <ZIndexExample />
+    </OverflowMenuStory>
+  ))
+  .add("Auto-focus", () => (
+    <OverflowMenuStory>
+      <AutoFocusExample />
+    </OverflowMenuStory>
+  ));
 
 storiesOf(`${storyName}/Backyard/Tests`, module).add("Cypress", () => <OverflowMenuExample />);

--- a/packages/OverflowMenu/stories/examples/AutoFocusExample.js
+++ b/packages/OverflowMenu/stories/examples/AutoFocusExample.js
@@ -4,9 +4,11 @@ import OverflowMenu from "../../src";
 const AutoFocusExample = () => {
   return (
     <div>
+      <p>Use the mouse to open the OverflowMenu; focus should NOT be put on the first element.</p>
       <p>
-        Use the keyboard to tab over the links and expand the OverflowMenu. Then tab out of the OverflowMenu and see
-        where the focus goes -- it should NOT go back onto the OverflowMenu.
+        Use the keyboard to tab past the links and expand the OverflowMenu; focus SHOULD be put on the first element.
+        Then press tab to leave the OverflowMenu and see where the focus goes -- it should NOT go back onto the
+        OverflowMenu.
       </p>
       <hr />
       <h3>Default Trigger Type (Simple)</h3>

--- a/packages/OverflowMenu/stories/examples/AutoFocusExample.js
+++ b/packages/OverflowMenu/stories/examples/AutoFocusExample.js
@@ -1,0 +1,43 @@
+import React from "react";
+import OverflowMenu from "../../src";
+
+const AutoFocusExample = () => {
+  return (
+    <div>
+      <p>
+        Use the keyboard to tab over the links and expand the OverflowMenu. Then tab out of the OverflowMenu and see
+        where the focus goes -- it should NOT go back onto the OverflowMenu.
+      </p>
+      <hr />
+      <h3>Default Trigger Type (Simple)</h3>
+      <a href="http://google.ca">Link 1</a>&nbsp;
+      <OverflowMenu align="bottom">
+        <OverflowMenu.Trigger>Open/Close</OverflowMenu.Trigger>
+        <OverflowMenu.Item onClick={() => {}}>First Item</OverflowMenu.Item>
+        <OverflowMenu.Item onClick={() => {}}>Second Item</OverflowMenu.Item>
+      </OverflowMenu>
+      &nbsp;<a href="http://google.ca">Link 2</a>
+      <hr />
+      <h3>Icon Trigger Type</h3>
+      <a href="http://google.ca">Link 1</a>&nbsp;
+      <OverflowMenu align="bottom">
+        <OverflowMenu.Trigger buttonType={OverflowMenu.Trigger.types.button.ICON}>x</OverflowMenu.Trigger>
+        <OverflowMenu.Item onClick={() => {}}>First Item</OverflowMenu.Item>
+        <OverflowMenu.Item onClick={() => {}}>Second Item</OverflowMenu.Item>
+      </OverflowMenu>
+      &nbsp;<a href="http://google.ca">Link 2</a>
+      <hr />
+      <h3>Raw Trigger Type</h3>
+      <a href="http://google.ca">Link 1</a>&nbsp;
+      <OverflowMenu align="bottom">
+        <OverflowMenu.Trigger buttonType={OverflowMenu.Trigger.types.button.RAW}> X </OverflowMenu.Trigger>
+        <OverflowMenu.Item onClick={() => {}}>First Item</OverflowMenu.Item>
+        <OverflowMenu.Item onClick={() => {}}>Second Item</OverflowMenu.Item>
+      </OverflowMenu>
+      &nbsp;<a href="http://google.ca">Link 2</a>
+      <hr />
+    </div>
+  );
+};
+
+export default AutoFocusExample;

--- a/yarn.lock
+++ b/yarn.lock
@@ -18046,7 +18046,7 @@ webpack@^4.43.0:
     watchpack "^1.6.1"
     webpack-sources "^1.4.1"
 
-what-input@^5.2.6:
+what-input@^5.2.10, what-input@^5.2.6:
   version "5.2.10"
   resolved "https://registry.yarnpkg.com/what-input/-/what-input-5.2.10.tgz#f79f5b65cf95d75e55e6d580bb0a6b98174cad4e"
   integrity sha512-7AQoIMGq7uU8esmKniOtZG3A+pzlwgeyFpkS3f/yzRbxknSL68tvn5gjE6bZ4OMFxCPjpaBd2udUTqlZ0HwrXQ==


### PR DESCRIPTION
### Purpose 🚀
1. Dont focus on first element when expand OverflowMenu using mouse
2. Dont focus on OverflowMenu trigger when exit OverflowMenu by pressing the Tab key.

### Notes ✏️
This is related to this ticket: https://aclgrc.atlassian.net/browse/UXD-464
The two issues can be seen here: https://github.com/acl-services/paprika/issues/794

### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_
- [x] PATCH (bug fix) change to _these packages_

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/issue-794--overflow-focus

### Screenshots 📸
Before can be seen here: https://github.com/acl-services/paprika/issues/794

After:
![after4](https://user-images.githubusercontent.com/23224777/99304926-ea8e2b80-2807-11eb-8ebd-713bc76e43e7.gif)
