### PR TITLE
RAPRM-926  Fix Radio.Group size prop 🐐

### DIFF
--- a/packages/Radio/CHANGELOG.md
+++ b/packages/Radio/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Added size prop from Radio.Group to Radio children via cloneElement() [@mikrotron](https://github.com/mikrotron).
+
+### Removed
+
+- Removed unnecessary Radio.Group a11yText prop [@mikrotron](https://github.com/mikrotron).
+
 ## [0.1.6] - 2020-01-31
 
 ### Added

--- a/packages/Radio/src/components/Group/Group.js
+++ b/packages/Radio/src/components/Group/Group.js
@@ -4,9 +4,6 @@ import nanoid from "nanoid";
 import types from "../../types";
 
 const propTypes = {
-  /** aria-labelledby prop on the containing group element */
-  a11yText: PropTypes.string,
-
   /** Can deselect any radio */
   canDeselect: PropTypes.bool,
 
@@ -24,7 +21,6 @@ const propTypes = {
 };
 
 const defaultProps = {
-  a11yText: "",
   canDeselect: false,
   children: null,
   isDisabled: false,
@@ -32,16 +28,16 @@ const defaultProps = {
 };
 
 function Group(props) {
-  const { a11yText, canDeselect, children, isDisabled, onChange, ...moreGroupProps } = props;
+  const { canDeselect, children, isDisabled, onChange, size, ...moreGroupProps } = props;
   const defaultCheckedIndex = React.Children.toArray(children).findIndex(child => child.props.defaultIsChecked);
   const selectedIndex = React.Children.toArray(children).findIndex(child => child.props.isChecked);
+  const generatedName = React.useRef(nanoid()).current;
 
   const [checkedIndex, setCheckedIndex] = React.useState(defaultCheckedIndex);
   if (selectedIndex !== -1 && selectedIndex !== checkedIndex) {
     setCheckedIndex(selectedIndex);
   }
 
-  const name = nanoid();
   const getDeselectableIndex = index => (checkedIndex === index ? null : index);
   const handleRadioClick = index => {
     onChange(index);
@@ -49,17 +45,17 @@ function Group(props) {
   };
 
   return (
-    <div role="radiogroup" aria-labelledby={a11yText} data-pka-anchor="radio.group" {...moreGroupProps}>
+    <div data-pka-anchor="radio.group" {...moreGroupProps}>
       {React.Children.map(children, (child, index) => {
         if (child && child.type && child.type.displayName === "Radio") {
-          const childKey = { key: `Radio${index}` };
           return React.cloneElement(child, {
             onClick: () => handleRadioClick(index),
             isChecked: checkedIndex === index,
             isDisabled: isDisabled || child.props.isDisabled,
             canDeselect,
-            name: child.props.name || name,
-            ...childKey,
+            size,
+            name: child.props.name || generatedName,
+            key: child.props.name || generatedName,
           });
         }
         return child;

--- a/packages/Radio/stories/Radio.examples.stories.js
+++ b/packages/Radio/stories/Radio.examples.stories.js
@@ -1,0 +1,32 @@
+import React from "react";
+import { getStoryName } from "storybook/storyTree";
+import ExampleStory from "storybook/components/ExampleStory";
+import { exampleStoryParameters } from "storybook/assets/storyParameters";
+import ControlledExample from "./examples/Controlled";
+import UncontrolledExample from "./examples/Uncontrolled";
+
+const storyName = getStoryName("Radio");
+
+export default {
+  title: `${storyName}/Examples`,
+};
+
+export const UncontrolledStory = () => (
+  <ExampleStory component="Radio" storyName="Uncontrolled Radio" fileName="examples/Uncontrolled.js">
+    <UncontrolledExample />
+  </ExampleStory>
+);
+UncontrolledStory.story = {
+  name: "Uncontrolled",
+  parameters: exampleStoryParameters,
+};
+
+export const ControlledStory = () => (
+  <ExampleStory component="Radio" storyName="Controlled Radio" fileName="examples/Controlled.js">
+    <ControlledExample />
+  </ExampleStory>
+);
+ControlledStory.story = {
+  name: "Controlled",
+  parameters: exampleStoryParameters,
+};

--- a/packages/Radio/stories/Radio.stories.js
+++ b/packages/Radio/stories/Radio.stories.js
@@ -1,13 +1,24 @@
-import { storiesOf } from "@storybook/react";
+import React from "react";
 import { withKnobs } from "@storybook/addon-knobs";
 import { getStoryName } from "storybook/storyTree";
-import ShowcaseStory from "./examples/Showcase";
-import ControlledStory from "./examples/Controlled";
+import { showcaseStoryParameters } from "storybook/assets/storyParameters";
+import ExampleStory from "storybook/components/ExampleStory";
+import Showcase from "./examples/Showcase";
 
 const storyName = getStoryName("Radio");
 
-storiesOf(storyName, module)
-  .addDecorator(withKnobs)
-  .add("Showcase", ShowcaseStory);
+export default {
+  title: storyName,
+};
 
-storiesOf(`${storyName}/Examples`, module).add("Controlled", ControlledStory);
+export const showcase = () => (
+  <ExampleStory storyName="Radio" tagline={ExampleStory.defaultTaglines.showcase}>
+    <Showcase />
+  </ExampleStory>
+);
+
+showcase.story = {
+  name: "Showcase",
+  decorators: [withKnobs],
+  parameters: showcaseStoryParameters,
+};

--- a/packages/Radio/stories/Radio.stories.styles.js
+++ b/packages/Radio/stories/Radio.stories.styles.js
@@ -1,8 +1,0 @@
-import styled from "styled-components";
-import { Story } from "storybook/assets/styles/common.styles";
-
-// Common Radio story styles
-
-export const RadioStory = styled(Story)`
-  max-width: 300px;
-`;

--- a/packages/Radio/stories/examples/Controlled.js
+++ b/packages/Radio/stories/examples/Controlled.js
@@ -1,49 +1,32 @@
 import React from "react";
 import { action } from "@storybook/addon-actions";
-import { Rule } from "storybook/assets/styles/common.styles";
-import Heading from "@paprika/heading";
-import { RadioStory } from "../Radio.stories.styles";
+import { Gap } from "storybook/assets/styles/common.styles";
+import StoryHeading from "storybook/components/StoryHeading";
 import Radio from "../../src/Radio";
 
-export const radioItems = ["Radio 1", "Radio 2 label", "Radio 3 option"];
+const radioItems = ["Radio 1", "Radio 2", "Radio 3"];
 
-const ExampleStory = props => {
+const ExampleStory = () => {
   const [checkedIndex, setCheckedIndex] = React.useState(1);
-  const handleIndexChange = e => {
-    setCheckedIndex(Number(e.target.value));
-  };
+
+  function handleIndexChange(event) {
+    setCheckedIndex(Number(event.target.value));
+  }
+
+  function handleRadioChange(activeIndex) {
+    setCheckedIndex(activeIndex);
+    action("Radio selection changed to index ")(activeIndex);
+  }
+
   return (
-    <RadioStory>
-      <Heading level={2} displayLevel={3} isLight>
-        Setting a item as default checked
-      </Heading>
-      <Rule />
-      <Radio.Group
-        onChange={activeIndex => {
-          action("Radio selection changed to index ")(activeIndex);
-        }}
-        {...props}
-      >
-        {radioItems.map((item, index) => {
-          return (
-            <Radio key={item} isDisabled={index === 1} defaultIsChecked={index === 2}>
-              {item}
-            </Radio>
-          );
-        })}
-      </Radio.Group>
-      <Rule />
-      <Heading level={2} displayLevel={3} isLight>
-        Controlling which item is checked
-      </Heading>
-      <Rule />
-      <Radio.Group
-        onChange={activeIndex => {
-          setCheckedIndex(activeIndex);
-          action("Radio selection changed to index ")(activeIndex);
-        }}
-        {...props}
-      >
+    <>
+      <StoryHeading level={3}>
+        <span>
+          Controlling selection with <code>isChecked</code>
+        </span>
+      </StoryHeading>
+      <Gap.Small />
+      <Radio.Group onChange={handleRadioChange}>
         {radioItems.map((item, index) => {
           return (
             <Radio key={item} isChecked={index === checkedIndex}>
@@ -52,9 +35,8 @@ const ExampleStory = props => {
           );
         })}
       </Radio.Group>
-      <br />
-      Set Checked Index
-      <br />
+      <Gap />
+      Set selection state:{" "}
       <select value={checkedIndex} onChange={handleIndexChange}>
         {radioItems.map((item, index) => (
           <option key={item} value={index}>
@@ -62,8 +44,8 @@ const ExampleStory = props => {
           </option>
         ))}
       </select>
-    </RadioStory>
+    </>
   );
 };
 
-export default () => <ExampleStory />;
+export default ExampleStory;

--- a/packages/Radio/stories/examples/Showcase.js
+++ b/packages/Radio/stories/examples/Showcase.js
@@ -1,9 +1,6 @@
 import React from "react";
-import { boolean, select, text } from "@storybook/addon-knobs";
+import { boolean, select } from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
-import { Rule, Tagline } from "storybook/assets/styles/common.styles";
-import Heading from "@paprika/heading";
-import { RadioStory } from "../Radio.stories.styles";
 import Radio from "../../src/Radio";
 import types from "../../src/types";
 
@@ -11,17 +8,11 @@ const getKnobs = () => ({
   size: select("size", [types.size.SMALL, types.size.MEDIUM, types.size.LARGE], "medium"),
   isDisabled: boolean("Is Group Disabled", false),
   canDeselect: boolean("canDeselect", false),
-  a11yText: text("a11yText", ""),
 });
 
-const ExampleStory = props => {
+const Showcase = props => {
   return (
-    <RadioStory>
-      <Heading level={1} displayLevel={2} isLight>
-        Showcase
-      </Heading>
-      <Tagline>Use the knobs to tinker with the props.</Tagline>
-      <Rule />
+    <>
       <Radio.Group
         onChange={activeIndex => {
           action("Radio selection changed to index ")(activeIndex);
@@ -33,9 +24,8 @@ const ExampleStory = props => {
         <Radio>Radio 3</Radio>
         <Radio isDisabled>Radio 4</Radio>
       </Radio.Group>
-      <Rule />
-    </RadioStory>
+    </>
   );
 };
 
-export default () => <ExampleStory {...getKnobs()} />;
+export default () => <Showcase {...getKnobs()} />;

--- a/packages/Radio/stories/examples/Showcase.js
+++ b/packages/Radio/stories/examples/Showcase.js
@@ -7,7 +7,7 @@ import { RadioStory } from "../Radio.stories.styles";
 import Radio from "../../src/Radio";
 import types from "../../src/types";
 
-const radioProps = () => ({
+const getKnobs = () => ({
   size: select("size", [types.size.SMALL, types.size.MEDIUM, types.size.LARGE], "medium"),
   isDisabled: boolean("Is Group Disabled", false),
   canDeselect: boolean("canDeselect", false),
@@ -38,4 +38,4 @@ const ExampleStory = props => {
   );
 };
 
-export default () => <ExampleStory {...radioProps()} />;
+export default () => <ExampleStory {...getKnobs()} />;

--- a/packages/Radio/stories/examples/Uncontrolled.js
+++ b/packages/Radio/stories/examples/Uncontrolled.js
@@ -1,0 +1,29 @@
+import React from "react";
+import { action } from "@storybook/addon-actions";
+import StoryHeading from "storybook/components/StoryHeading";
+import { Gap } from "storybook/assets/styles/common.styles";
+import Radio from "../../src/Radio";
+
+const ExampleStory = () => {
+  function handleChange(activeIndex) {
+    action("Radio selection changed to index ")(activeIndex);
+  }
+
+  return (
+    <>
+      <StoryHeading level={3}>
+        <span>
+          Setting initial selection with <code>defaultIsChecked</code>
+        </span>
+      </StoryHeading>
+      <Gap.Small />
+      <Radio.Group onChange={handleChange}>
+        <Radio>Radio 1</Radio>
+        <Radio defaultIsChecked>Radio 2</Radio>
+        <Radio>Radio 3</Radio>
+      </Radio.Group>
+    </>
+  );
+};
+
+export default ExampleStory;


### PR DESCRIPTION
### Purpose 🚀
The `<Radio.Group>` has a `size` prop that should be passed along to its `<Radio>` `children`.


### Notes ✏️
- `<Radio.Group>` was not including `size` when it did `React.cloneElement()`.
- `A11yText` prop was removed from `<Radio.Group>` – it was being implemented incorrectly as `aria-labelledby`, and had no effect.  The radio group needs to get a label from a parent `<FormElement hasFieldSet>`. 
- This _would_ be a `MAJOR` breaking change normally, but because it was already "broken", this can remain a `PATCH` update.
- Fixed the `Showcase` story, converted all stories to CSF, and split the examples in  the `Controlled` story into `Controlled` and `Uncontrolled` example stories.


### Updates 📦
- [x] PATCH (bug fix) change to `Radio`


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/RAPRM-926--fix-radio-button/?path=/story/forms-radio--showcase


### References 🔗
https://aclgrc.atlassian.net/browse/RAPRM-926


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
