### PR TITLE
UXD-543 Avoid double escaped strings

### DIFF
--- a/packages/CopyInput/README.md
+++ b/packages/CopyInput/README.md
@@ -57,7 +57,6 @@ return (
 <!-- eoContent -->
 
 ## Links
-
 - [Storybook showcase](https://paprika.highbond.com/?path=/story/copy-input--showcase)
 - [Github source code](https://github.com/acl-services/paprika/tree/master/packages/CopyInput/src)
 - [Github create issue](https://github.com/acl-services/paprika/issues/new?label=[]&title=@paprika/copy-input%20[help]:%20your%20short%20description&body=%0A%23%20Help%20wanted%0A%0A%23%23%20Please%20write%20your%20question.%0A*A%20clear%20and%20concise%20description%20of%20what%20the%20question%20is*%0A%0A%23%23%20Additional%20context%0A*Add%20any%20other%20context%20or%20screenshots%20about%20your%20question%20here.*%0A)

--- a/packages/L10n/CHANGELOG.md
+++ b/packages/L10n/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Avoid double escaped strings.
+
 ## [0.4.1] - 2020-07-09
 
 ### Removed

--- a/packages/L10n/src/i18n.js
+++ b/packages/L10n/src/i18n.js
@@ -9,6 +9,9 @@ export const i18n = locales => {
     fallbackLng: defaultLocale,
     lowerCaseLng: true,
     resources: locales || paprikaLocales,
+    interpolation: {
+      escapeValue: false,
+    },
   };
 
   const newInstance = i18next.createInstance(i18nConfig, err => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3348,6 +3348,11 @@
   resolved "https://registry.yarnpkg.com/@paprika/helpers/-/helpers-0.2.14.tgz#42b4ef1ccdb7ddba699ee05a4988908f14936d37"
   integrity sha512-j+LaBc/tI/CeKwkX7mPOzjOpFmg2UzuTFov2Z+DWJbxf/dRZkQUyKxinEaY6ReJ6oXn2XREaqyq7fj+VO9gbug==
 
+"@paprika/helpers@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@paprika/helpers/-/helpers-1.0.0.tgz#e9fb09fb4b2605a46ce2be2a7b1bef3e8a1987f9"
+  integrity sha512-Rpxf0/xVuV9v6V6HE+eMx5AWECLTTscCWfJ73PHBHhA9aXDdgYAd/CrBk8HZX+egMLQJk5L2hzLTJIphSeJy0g==
+
 "@paprika/icon@^0.2.15":
   version "0.2.16"
   resolved "https://registry.yarnpkg.com/@paprika/icon/-/icon-0.2.16.tgz#689b394e9828dd624cd825897f20aa9dea82d42d"


### PR DESCRIPTION
### Purpose 🚀

In the consumer apps, there might be some string like ` Product/Service` `<Product><Service>` since React already escaped the characters when we render all the components/elements. i18next doesn't need to escape them again. 


### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
- [x] MAJOR (breaking) change to `@paprika/l10n`
- [ ] MINOR (backward compatible) change to _these packages_
- [ ] PATCH (bug fix) change to _these packages_

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
