### PR TITLE
fix(StatusTracker): UXD-613 fixed some minor styling and a11y issues

### DIFF
--- a/packages/StatusTracker/CHANGELOG.md
+++ b/packages/StatusTracker/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed some minor styling and a11y issue.
+
 ## [0.0.2-alpha.0] - 2020-12-01
 
 - Added `<StatusTracker />` component.

--- a/packages/StatusTracker/src/components/Point/Point.js
+++ b/packages/StatusTracker/src/components/Point/Point.js
@@ -61,7 +61,6 @@ const Point = React.forwardRef((props, ref) => {
           onBlur={handleTooltipClose}
           kind={kind}
           data-pka-anchor="status-tracker.point"
-          {...a11yAttributes}
         >
           {React.cloneElement(
             extractedOverflowMenu,
@@ -81,6 +80,7 @@ const Point = React.forwardRef((props, ref) => {
                     kind: Button.types.kind.PRIMARY,
                     onClick: handleOverflowMenuOpen,
                     "data-pka-anchor": "status-tracker.point.overflow-menu.trigger",
+                    "aria-describedby": a11yAttributes["aria-describedby"],
                   },
                   name
                 )
@@ -91,6 +91,7 @@ const Point = React.forwardRef((props, ref) => {
                   kind={Button.types.kind.PRIMARY}
                   onClick={handleOverflowMenuOpen}
                   data-pka-anchor="status-tracker.point.overflow-menu.trigger"
+                  aria-describedby={a11yAttributes["aria-describedby"]}
                 >
                   {name}
                 </OverflowMenu.Trigger>
@@ -107,6 +108,7 @@ const Point = React.forwardRef((props, ref) => {
 
     return (
       <sc.Point
+        aria-label={name}
         onMouseOver={handleTooltipOpen}
         onMouseOut={handleTooltipClose}
         onFocus={handleTooltipOpen}
@@ -126,7 +128,7 @@ const Point = React.forwardRef((props, ref) => {
       <sc.Popover isEager isDark isOpen={isTooltipOpen}>
         <Popover.Trigger>{getTrigger}</Popover.Trigger>
         <Popover.Content>
-          <sc.PopoverCard hasOnlyName={Boolean(name) && Boolean(description)}>
+          <sc.PopoverCard hasBoth={Boolean(name) && Boolean(description)}>
             {name ? <sc.NameInTooltip data-pka-anchor="status-tracker.point.name">{name}</sc.NameInTooltip> : null}
             {description ? (
               <sc.Description data-pka-anchor="status-tracker.point.description">{description}</sc.Description>

--- a/packages/StatusTracker/src/components/Point/Point.styles.js
+++ b/packages/StatusTracker/src/components/Point/Point.styles.js
@@ -62,9 +62,7 @@ export const Point = styled.div(({ kind }) => {
       `;
     case types.kinds.CURRENT:
       return css`
-        > [data-pka-anchor="popover"] > [data-pka-anchor="button"] {
-          margin-top: -${tokens.spaceSm};
-        }
+        margin-top: -${tokens.spaceSm};
       `;
     case types.kinds.FUTURE:
       return css`
@@ -89,8 +87,9 @@ export const PopoverCard = styled(Popover.Card)`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  min-height: ${({ hasBoth }) => (hasBoth ? "auto" : spacer(3))};
-  min-width: ${({ hasBoth }) => (hasBoth ? spacer(22) : spacer(8))};
+  min-height: ${({ hasBoth }) => (hasBoth ? "auto" : spacer(2))};
+  min-width: ${({ hasBoth }) => (hasBoth ? spacer(21) : spacer(8))};
+  padding: ${tokens.space};
 `;
 
 export const NameInTooltip = styled.div`


### PR DESCRIPTION
### Purpose 🚀

- Fixed min-width for popover
- Fixed aria-describedby
- Fixed button alignment

http://storybooks.highbond-s3.com/paprika/UXD-613-fix-status-tracker-ui/?path=/story/buttons-statustracker--showcase

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_
- [x] PATCH (bug fix) change to `@paprika/status-tracker`

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/UXD-613-fix-status-tracker-ui

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
