### PR TITLE
fix(OverflowMenu): FS-564 pass dynamic props to Confirmation on update

### DIFF
--- a/packages/OverflowMenu/CHANGELOG.md
+++ b/packages/OverflowMenu/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed passing updated props to Confirmation
+
 ## [1.0.0] - 2020-11-04
 
 ### Added


### PR DESCRIPTION
### Purpose 🚀
Fix passing dynamic props to Confirmation on update

### Notes ✏️
`renderConfirmation` state gets updated only when you click on the Item: https://github.com/acl-services/paprika/blob/4d84b80efcf86d70066fe4dd113a1f6f2a5b5dc0/packages/OverflowMenu/src/OverflowMenu.js#L183 This makes it impossible to use dynamic props in `Confirmation` component (e.g. `isPending`), since they never get updated in state until the next click.

This PR replaces `renderConfirmation` state with reference and adds explicit updates when required.
See discussion in https://wegalvanize.slack.com/archives/CB3QRPDJ4/p1607629290311200

### Updates 📦
- [x] PATCH (bug fix) change to `OverflowMenu` component

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/FS-564-fix-OverflowMenu-rerendering

### References 🔗
https://aclgrc.atlassian.net/browse/FS-564