### PR TITLE
feat(Popover): UXD-622 Pass the event object down when clicking on th…

### DIFF
--- a/packages/Popover/CHANGELOG.md
+++ b/packages/Popover/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+- Pass the `Event` object down for `<Popover.Trigger />` `onClick`.
+
 ## [0.3.11] - 2020-01-21
 
 ### Added

--- a/packages/Popover/src/components/Trigger/Trigger.js
+++ b/packages/Popover/src/components/Trigger/Trigger.js
@@ -43,7 +43,7 @@ function Trigger(props) {
         if (!isActiveElementPopover()) onClose();
       });
     } else if (event.type === "click" || event.key === " " || event.key === "Enter") {
-      onClick();
+      onClick(event);
     }
   }
 


### PR DESCRIPTION
…e trigger

### Purpose 🚀

The global navbar need the Event object to determine if it's a keyboard event

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_
- [x] PATCH (bug fix) change to `@paprika/popover`

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
