### PR TITLE
Pdtvt 685  multi line

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: Paprika Semaphore 2.0 CI
 agent:
   machine:
-    type: e1-standard-2
+    type: e1-standard-4
     os_image: ubuntu1804
 auto_cancel:
   running:

--- a/packages/DynamicHyperlink/src/DynamicHyperlink.scss
+++ b/packages/DynamicHyperlink/src/DynamicHyperlink.scss
@@ -6,21 +6,25 @@ a[data-dynamic-hyperlink] {
   border-radius: $button--border-radius;
   box-shadow: 0 0 2px $color--black;
   color: $color--blue-darken-10;
-  display: inline-block;
   font-size: font-scale(-1);
   padding: 2px $space-sm;
-  text-decoration: underline;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
 
   span {
-    margin-left: $space-sm;
     border-radius: $button--border-radius;
-    display: inline-block;
-    text-decoration: none;
+    font-size: font-scale(-2);
+    font-weight: bold;
+    margin-left: $space-sm;
 
     &.valid {
       background-color: $color--blue-lighten-40;
       color: $color--blue-darken-10;
       padding: 1px $space;
+      text-transform: capitalize;
     }
 
     &.invalid {


### PR DESCRIPTION
### Purpose 🚀
Links should break onto a second line as needed
Also change a semaphore setting that is supposed to increase our RAM (https://docs.semaphoreci.com/ci-cd-environment/machine-types/#linux-machine-types), so tests stop failing for reasons beyond our control.

![Screen Shot 2021-01-13 at 3 26 54 PM](https://user-images.githubusercontent.com/23224777/104525251-95c32300-55b4-11eb-9c03-9af19e735026.png)

### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_
- [x] PATCH (bug fix) change to DynamicHyperlink

