### PR TITLE
chore(Icon): UXD-757 add declaration in icon package

### DIFF
--- a/packages/Icon/CHANGELOG.md
+++ b/packages/Icon/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Declaration files for each icon.
+
 ## [0.3.0] - 2020-04-29
 
 ### Removed

--- a/packages/Icon/package.json
+++ b/packages/Icon/package.json
@@ -15,7 +15,8 @@
   },
   "scripts": {
     "svgr": "svgr -d . ./src/svg --out-dir src/",
-    "pretranspile": "yarn rimraf src/*.js && yarn svgr"
+    "build-declaration": "npx typescript src/*.js --declaration --allowJs --emitDeclarationOnly --outDir src",
+    "pretranspile": "yarn rimraf src/*.js && yarn svgr && yarn build-declaration"
   },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.3.1",

--- a/packages/Icon/src/Add.d.ts
+++ b/packages/Icon/src/Add.d.ts
@@ -1,0 +1,5 @@
+export default SvgAdd;
+declare function SvgAdd({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/ArrowDown.d.ts
+++ b/packages/Icon/src/ArrowDown.d.ts
@@ -1,0 +1,5 @@
+export default SvgArrowDown;
+declare function SvgArrowDown({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/ArrowLeft.d.ts
+++ b/packages/Icon/src/ArrowLeft.d.ts
@@ -1,0 +1,5 @@
+export default SvgArrowLeft;
+declare function SvgArrowLeft({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/ArrowRight.d.ts
+++ b/packages/Icon/src/ArrowRight.d.ts
@@ -1,0 +1,5 @@
+export default SvgArrowRight;
+declare function SvgArrowRight({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/ArrowRightB.d.ts
+++ b/packages/Icon/src/ArrowRightB.d.ts
@@ -1,0 +1,5 @@
+export default SvgArrowRightB;
+declare function SvgArrowRightB({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/ArrowUp.d.ts
+++ b/packages/Icon/src/ArrowUp.d.ts
@@ -1,0 +1,5 @@
+export default SvgArrowUp;
+declare function SvgArrowUp({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/Calendar.d.ts
+++ b/packages/Icon/src/Calendar.d.ts
@@ -1,0 +1,5 @@
+export default SvgCalendar;
+declare function SvgCalendar({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/CaretDown.d.ts
+++ b/packages/Icon/src/CaretDown.d.ts
@@ -1,0 +1,5 @@
+export default SvgCaretDown;
+declare function SvgCaretDown({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/CaretUp.d.ts
+++ b/packages/Icon/src/CaretUp.d.ts
@@ -1,0 +1,5 @@
+export default SvgCaretUp;
+declare function SvgCaretUp({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/Caution.d.ts
+++ b/packages/Icon/src/Caution.d.ts
@@ -1,0 +1,5 @@
+export default SvgCaution;
+declare function SvgCaution({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/Character.d.ts
+++ b/packages/Icon/src/Character.d.ts
@@ -1,0 +1,5 @@
+export default SvgCharacter;
+declare function SvgCharacter({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/Check.d.ts
+++ b/packages/Icon/src/Check.d.ts
@@ -1,0 +1,5 @@
+export default SvgCheck;
+declare function SvgCheck({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/Clipboard.d.ts
+++ b/packages/Icon/src/Clipboard.d.ts
@@ -1,0 +1,5 @@
+export default SvgClipboard;
+declare function SvgClipboard({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/Clock.d.ts
+++ b/packages/Icon/src/Clock.d.ts
@@ -1,0 +1,5 @@
+export default SvgClock;
+declare function SvgClock({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/ColoredCaution.d.ts
+++ b/packages/Icon/src/ColoredCaution.d.ts
@@ -1,0 +1,5 @@
+export default SvgColoredCaution;
+declare function SvgColoredCaution({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/Dash.d.ts
+++ b/packages/Icon/src/Dash.d.ts
@@ -1,0 +1,5 @@
+export default SvgDash;
+declare function SvgDash({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/DragHandle.d.ts
+++ b/packages/Icon/src/DragHandle.d.ts
@@ -1,0 +1,5 @@
+export default SvgDragHandle;
+declare function SvgDragHandle({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/Ellipsis.d.ts
+++ b/packages/Icon/src/Ellipsis.d.ts
@@ -1,0 +1,5 @@
+export default SvgEllipsis;
+declare function SvgEllipsis({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/EllipsisVertical.d.ts
+++ b/packages/Icon/src/EllipsisVertical.d.ts
@@ -1,0 +1,5 @@
+export default SvgEllipsisVertical;
+declare function SvgEllipsisVertical({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/ExclamationCircle.d.ts
+++ b/packages/Icon/src/ExclamationCircle.d.ts
@@ -1,0 +1,5 @@
+export default SvgExclamationCircle;
+declare function SvgExclamationCircle({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/Filter.d.ts
+++ b/packages/Icon/src/Filter.d.ts
@@ -1,0 +1,5 @@
+export default SvgFilter;
+declare function SvgFilter({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/Hide.d.ts
+++ b/packages/Icon/src/Hide.d.ts
@@ -1,0 +1,5 @@
+export default SvgHide;
+declare function SvgHide({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/InfoCircle.d.ts
+++ b/packages/Icon/src/InfoCircle.d.ts
@@ -1,0 +1,5 @@
+export default SvgInfoCircle;
+declare function SvgInfoCircle({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/Lock.d.ts
+++ b/packages/Icon/src/Lock.d.ts
@@ -1,0 +1,5 @@
+export default SvgLock;
+declare function SvgLock({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/Maximize.d.ts
+++ b/packages/Icon/src/Maximize.d.ts
@@ -1,0 +1,5 @@
+export default SvgMaximize;
+declare function SvgMaximize({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/Menu.d.ts
+++ b/packages/Icon/src/Menu.d.ts
@@ -1,0 +1,5 @@
+export default SvgMenu;
+declare function SvgMenu({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/NewTab.d.ts
+++ b/packages/Icon/src/NewTab.d.ts
@@ -1,0 +1,5 @@
+export default SvgNewTab;
+declare function SvgNewTab({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/Number.d.ts
+++ b/packages/Icon/src/Number.d.ts
@@ -1,0 +1,5 @@
+export default SvgNumber;
+declare function SvgNumber({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/Refresh.d.ts
+++ b/packages/Icon/src/Refresh.d.ts
@@ -1,0 +1,5 @@
+export default SvgRefresh;
+declare function SvgRefresh({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/Search.d.ts
+++ b/packages/Icon/src/Search.d.ts
@@ -1,0 +1,5 @@
+export default SvgSearch;
+declare function SvgSearch({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/Sort.d.ts
+++ b/packages/Icon/src/Sort.d.ts
@@ -1,0 +1,5 @@
+export default SvgSort;
+declare function SvgSort({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/TimeAndDate.d.ts
+++ b/packages/Icon/src/TimeAndDate.d.ts
@@ -1,0 +1,5 @@
+export default SvgTimeAndDate;
+declare function SvgTimeAndDate({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/Times.d.ts
+++ b/packages/Icon/src/Times.d.ts
@@ -1,0 +1,5 @@
+export default SvgTimes;
+declare function SvgTimes({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/TimesCircle.d.ts
+++ b/packages/Icon/src/TimesCircle.d.ts
@@ -1,0 +1,5 @@
+export default SvgTimesCircle;
+declare function SvgTimesCircle({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/Trashbin.d.ts
+++ b/packages/Icon/src/Trashbin.d.ts
@@ -1,0 +1,5 @@
+export default SvgTrashbin;
+declare function SvgTrashbin({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/Unlink.d.ts
+++ b/packages/Icon/src/Unlink.d.ts
@@ -1,0 +1,5 @@
+export default SvgUnlink;
+declare function SvgUnlink({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;

--- a/packages/Icon/src/Upload.d.ts
+++ b/packages/Icon/src/Upload.d.ts
@@ -1,0 +1,5 @@
+export default SvgUpload;
+declare function SvgUpload({ title, ...props }: {
+    [x: string]: any;
+    title: any;
+}): JSX.Element;


### PR DESCRIPTION
### Purpose 🚀

This PR added `d.ts` for `@paprika/icon` package(this package was skipped before from `typeFiles.js` script). Also with this change, we can copy these declarations to interal wasabicons library easily, and ts apps can use them

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_
- [x] PATCH (bug fix) change to `@paprika/icon`

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
