### PR TITLE
chore(DynamicHyperlinkTranslator): PDTVT-784 Tweak link styles.

### DIFF
--- a/packages/DynamicHyperlinkTransformer/src/DynamicHyperlinkTransformer.js
+++ b/packages/DynamicHyperlinkTransformer/src/DynamicHyperlinkTransformer.js
@@ -36,15 +36,24 @@ export default function DynamicHyperlinkTransformer({ onFetch }) {
               .then(response => {
                 const { error, name, term } = response;
 
-                const className = error ? "dynamic-hyperlink--invalid" : "dynamic-hyperlink--valid";
-                const linkText = error ? originalLinkUrl : name;
-                const errorText = error ? I18n.t(`dynamicHyperlinkTransformer.${error}`) : "";
+                dynamicHyperlink.innerHTML = ""; // eslint-disable-line no-param-reassign
 
-                dynamicHyperlink.innerHTML = linkText; // eslint-disable-line no-param-reassign
-                const typeOrErrorSpan = document.createElement("span");
-                typeOrErrorSpan.innerHTML = error ? `- ${errorText}` : term;
-                typeOrErrorSpan.className = className;
-                dynamicHyperlink.appendChild(typeOrErrorSpan);
+                const labelSpan = document.createElement("span");
+                labelSpan.className = "dynamic-hyperlink--label";
+                labelSpan.innerHTML = error ? originalLinkUrl : name;
+                dynamicHyperlink.appendChild(labelSpan);
+
+                if (error) {
+                  const errorSpan = document.createElement("span");
+                  errorSpan.className = "dynamic-hyperlink--invalid";
+                  errorSpan.innerHTML = `- ${I18n.t(`dynamicHyperlinkTransformer.${error}`)}`;
+                  dynamicHyperlink.appendChild(errorSpan);
+                } else {
+                  const termSpan = document.createElement("span");
+                  termSpan.className = "dynamic-hyperlink--valid";
+                  termSpan.innerHTML = term;
+                  dynamicHyperlink.appendChild(termSpan);
+                }
               });
           } else {
             throw new Error("In DynamicHyperlinkTransformer component, the onFetch prop must return a Promise");

--- a/packages/DynamicHyperlinkTransformer/src/DynamicHyperlinkTransformer.scss
+++ b/packages/DynamicHyperlinkTransformer/src/DynamicHyperlinkTransformer.scss
@@ -10,30 +10,32 @@ a[data-dynamic-hyperlink] {
   border-radius: $button--border-radius;
   box-shadow: 0 0 2px $color--black;
   color: $color--blue-darken-10;
+  cursor: default;
   font-size: font-scale(-1);
   padding: 2px 2px 2px $space-sm;
   text-decoration: none;
 
-  &:hover {
-    text-decoration: underline;
+  .dynamic-hyperlink--label {
+    cursor: pointer;
+    margin-right: $space-sm;
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
 
-  span {
+  .dynamic-hyperlink--valid {
+    background-color: $color--blue-lighten-40;
     border-radius: $button--border-radius;
+    color: $color--blue-darken-10;
     font-size: font-scale(-2);
     font-weight: bold;
-    margin-left: $space-sm;
+    padding: 1px $space 0;
+    text-transform: uppercase;
+  }
 
-    &.dynamic-hyperlink--valid {
-      background-color: $color--blue-lighten-40;
-      color: $color--blue-darken-10;
-      padding: 1px $space 0;
-      text-transform: uppercase;
-    }
-
-    &.dynamic-hyperlink--invalid {
-      color: $color--black-lighten-20;
-      padding-right: $space-sm;
-    }
+  .dynamic-hyperlink--invalid {
+    color: $color--black-lighten-20;
+    padding-right: $space-sm;
   }
 }

--- a/packages/DynamicHyperlinkTransformer/stories/tests/Screener.js
+++ b/packages/DynamicHyperlinkTransformer/stories/tests/Screener.js
@@ -6,23 +6,26 @@ const Screener = () => (
     Hard-coded styles:
     <br />
     <br />
-    <a href="https://www.wegalvanize.com/" data-dynamic-hyperlink="link1">
+    <a href="https://www.wegalvanize.com/" data-dynamic-hyperlink="control" data-dynamic-hyperlink--processed="true">
       Loading...
     </a>
     <br />
     <br />
-    <a href="https://www.wegalvanize.com/" data-dynamic-hyperlink="link2">
-      Link 2<span className="dynamic-hyperlink--valid">CONTROL</span>
+    <a href="https://www.wegalvanize.com/" data-dynamic-hyperlink="control" data-dynamic-hyperlink--processed="true">
+      <span className="dynamic-hyperlink--label">My really long control name</span>
+      <span className="dynamic-hyperlink--valid">Control</span>
     </a>
     <br />
     <br />
-    <a href="https://www.wegalvanize.com/" data-dynamic-hyperlink="link3">
-      Link 3<span className="dynamic-hyperlink--invalid">- Access denied</span>
+    <a href="https://www.wegalvanize.com/" data-dynamic-hyperlink="narrative" data-dynamic-hyperlink--processed="true">
+      <span className="dynamic-hyperlink--label">https://www.wegalvanize.com/</span>
+      <span className="dynamic-hyperlink--invalid">- Invalid URL</span>
     </a>
     <br />
     <br />
-    <a href="https://www.wegalvanize.com/" data-dynamic-hyperlink="link4">
-      Link 4<span className="dynamic-hyperlink--invalid">- Invalid URL</span>
+    <a href="https://www.wegalvanize.com/" data-dynamic-hyperlink="risk" data-dynamic-hyperlink--processed="true">
+      <span className="dynamic-hyperlink--label">https://www.wegalvanize.com/</span>
+      <span className="dynamic-hyperlink--invalid">- Access denied</span>
     </a>
   </React.Fragment>
 );


### PR DESCRIPTION
### Purpose 🚀
Don't underline the right-hand-side of the cards on hover. Note: they are still clickable links, as everything is under a link..
![hover](https://user-images.githubusercontent.com/23224777/105762428-3a285c00-5f09-11eb-9b46-69412d0c5357.gif)

### Updates 📦
- [ ] MAJOR (breaking) change to _these packages_
- [ ] MINOR (backward compatible) change to _these packages_
- [x] PATCH (bug fix) change to _these packages_

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/pdtvt-784--no-underline
