### PR TITLE
chore(ActionBar): UXD-684 remove obsolete translation keys

### DIFF
--- a/packages/L10n/src/locales/en.yml
+++ b/packages/L10n/src/locales/en.yml
@@ -128,34 +128,6 @@ en:
         plural_label: "{{numberOfHiddenColumn}} columns hidden"
         search_placeholder: Search...
       no_results: No results
-      filter:
-        no_filters_applied: No filters applied to this view
-        label: Filter
-        singular_label: 1 filter applied
-        plural_label: "{{numberOfFilters}} filters applied"
-        add_filter: Add a field to filter by
-        and: and
-        or: or
-        where: Where
-        rules:
-          is: is
-          is_not: is not
-          contains: contains
-          does_not_contain: does not contain
-          is_blank: is blank
-          is_not_blank: is not blank
-          equals: equals
-          not_equal_to: not equal to
-          greater_than: ">"
-          less_than: "<"
-          greater_than_or_equal_to: "≥"
-          less_than_or_equal_to: "≤"
-          is_empty: is empty
-          is_not_empty: is not empty
-          is_before: is before
-          is_after: is after
-          true: "true"
-          false: "false"
       search_placeholder: Search...
       search_a11y_text: Search the data
       sort:


### PR DESCRIPTION
### Purpose 🚀
Remove obsolete translation keys. This was just an earlier oversight.


### Updates 📦
- [x] PATCH (bug fix) change to ActionBar
