### PR TITLE
fix(StatusTracker): ASM-1113 support onClick

### DIFF
--- a/.changeset/friendly-cups-heal.md
+++ b/.changeset/friendly-cups-heal.md
@@ -1,0 +1,5 @@
+---
+"@paprika/status-tracker": patch
+---
+
+Support onClick on the <OverflowMenu.Trigger> inside <StatusTracker.Point>

--- a/packages/StatusTracker/src/components/Point/Point.js
+++ b/packages/StatusTracker/src/components/Point/Point.js
@@ -80,7 +80,10 @@ const Point = React.forwardRef((props, ref) => {
                     buttonType: OverflowMenu.Trigger.types.button.SIMPLE,
                     isDropdown: true,
                     kind: Button.types.kind.PRIMARY,
-                    onClick: e => handleOverflowMenuOpen(extractedOverflowMenuTrigger.props.onClick, e),
+                    onClick: e => {
+                      handleOverflowMenuOpen(extractedOverflowMenuTrigger.props.onClick, e);
+                      extractedOverflowMenuTrigger.props.onClick(e);
+                    },
                     "data-pka-anchor": "status-tracker.point.overflow-menu.trigger",
                     "aria-describedby": a11yAttributes["aria-describedby"],
                   },
@@ -91,7 +94,10 @@ const Point = React.forwardRef((props, ref) => {
                   buttonType={OverflowMenu.Trigger.types.button.SIMPLE}
                   isDropdown
                   kind={Button.types.kind.PRIMARY}
-                  onClick={e => handleOverflowMenuOpen(extractedOverflowMenuTrigger.props.onClick, e)}
+                  onClick={e => {
+                    handleOverflowMenuOpen(extractedOverflowMenuTrigger.props.onClick, e);
+                    extractedOverflowMenuTrigger.props.onClick(e);
+                  }}
                   data-pka-anchor="status-tracker.point.overflow-menu.trigger"
                   aria-describedby={a11yAttributes["aria-describedby"]}
                 >


### PR DESCRIPTION
### Purpose 🚀

Support onClick on the <OverflowMenu.Trigger> inside <StatusTracker.Point>

### Notes ✏️

### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
