### PR TITLE
feat(CollapsibleCard): UXD-963 support position to be passed in

### DIFF
--- a/.changeset/nine-steaks-rescue.md
+++ b/.changeset/nine-steaks-rescue.md
@@ -1,0 +1,5 @@
+---
+"@paprika/collapsible-card": patch
+---
+
+Support position prop to be passed in

--- a/packages/CollapsibleCard/src/CollapsibleCard.js
+++ b/packages/CollapsibleCard/src/CollapsibleCard.js
@@ -76,3 +76,6 @@ CollapsibleCard.Body = Body;
 CollapsibleCard.Header = Header;
 CollapsibleCard.Segment = Segment;
 CollapsibleCard.Group = Group;
+CollapsibleCard.types = {
+  position: POSITIONS,
+};

--- a/packages/CollapsibleCard/src/components/Group/Group.js
+++ b/packages/CollapsibleCard/src/components/Group/Group.js
@@ -1,28 +1,32 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { v4 as uuidv4 } from "uuid";
 import Header from "./components/Header";
 import { POSITIONS } from "../../CollapsibleCard";
 import * as sc from "./Group.styles";
 
 export default function Group(props) {
   const { children } = props;
-  const newChildren = [];
 
-  React.Children.map(children, (child, index) => {
-    let position;
-    if (index === 0) {
-      position = POSITIONS.FIRST;
-    } else if (index === React.Children.toArray(children).length - 1) {
-      position = POSITIONS.LAST;
-    } else {
-      position = POSITIONS.MIDDLE;
-    }
+  return (
+    <sc.Group>
+      {React.Children.map(children, (child, index) => {
+        if (child.props.position) {
+          return child;
+        }
 
-    newChildren.push(React.cloneElement(child, { position, key: uuidv4() }));
-  });
+        let position;
+        if (index === 0) {
+          position = POSITIONS.FIRST;
+        } else if (index === React.Children.toArray(children).length - 1) {
+          position = POSITIONS.LAST;
+        } else {
+          position = POSITIONS.MIDDLE;
+        }
 
-  return <sc.Group>{newChildren}</sc.Group>;
+        return React.cloneElement(child, { position });
+      })}
+    </sc.Group>
+  );
 }
 
 const propTypes = {

--- a/packages/CollapsibleCard/src/components/Header/Header.styles.js
+++ b/packages/CollapsibleCard/src/components/Header/Header.styles.js
@@ -39,7 +39,8 @@ export const HeaderContent = styled.div(
   ({ isBroken }) => css`
     align-self: center;
     display: flex;
-    flex: 1 1 auto;
+    flex-grow: 1;
+    flex-wrap: nowrap;
     margin-right: ${spacer(2)};
 
     ${isBroken &&


### PR DESCRIPTION
### Purpose 🚀

We need to support custom `position` so even though the CollapsibleCard is in the `middle` between others in the DOM, but visually it's the `last`
![image](https://user-images.githubusercontent.com/38733362/111548334-c865d500-8737-11eb-8cfe-63915ea535fb.png)


### Notes ✏️


- Support `position` to be passed in 
- Export `position` values
- Remove `uuid()` keys on CollapsibleCard
- Small css adjustment

### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
