### PR TITLE
UXD-972 move refLabel out from render content param…

### DIFF
--- a/.changeset/wicked-flowers-visit.md
+++ b/.changeset/wicked-flowers-visit.md
@@ -1,0 +1,5 @@
+---
+"@paprika/form-element": patch
+---
+
+Move `refLabel` out from `a11yProps` parameter when rendering content

--- a/packages/FormElement/README.md
+++ b/packages/FormElement/README.md
@@ -34,10 +34,12 @@ npm install @paprika/form-element
 
 ### FormElement.Content
 
-| Prop                                                                                                     | Type        | required | default | Description                                                                                     |
-| -------------------------------------------------------------------------------------------------------- | ----------- | -------- | ------- | ----------------------------------------------------------------------------------------------- |
-| children                                                                                                 | [func,node] | true     | -       | Input field and layout elements. May be a render function with a11yProps object as an argument. |
-| a11yProps includes: { id, refLabel, disabled?, "aria-disabled"?, "aria-describedby"?, "aria-required"? } |
+| Prop     | Type        | required | default | Description                                                                                   |
+| -------- | ----------- | -------- | ------- | --------------------------------------------------------------------------------------------- |
+| children | [func,node] | true     | -       | Input field and layout elements. May be a render function with a11yProps object and refLabel. |
+
+a11yProps includes: { id, disabled?, "aria-disabled"?, "aria-describedby"?, "aria-required"? }
+refLabel is a React ref for the `<FormElement.Label />`|
 
 ### FormElement.Description
 

--- a/packages/FormElement/src/components/Content/Content.js
+++ b/packages/FormElement/src/components/Content/Content.js
@@ -29,11 +29,10 @@ function Content(props) {
     "aria-required": isRequired || null,
     disabled: isDisabled || null,
     id: labelId,
-    refLabel,
   };
 
   const renderChildren = () => {
-    return typeof children === "function" ? children(a11yProps) : children;
+    return typeof children === "function" ? children(a11yProps, refLabel) : children;
   };
 
   const contextValue = { fieldsetAriaDescribedBy: ariaDescribedByIdsString };
@@ -50,8 +49,9 @@ function Content(props) {
 }
 
 const propTypes = {
-  /** Input field and layout elements. May be a render function with a11yProps object as an argument.
-   * a11yProps includes: { id, refLabel, disabled?, "aria-disabled"?, "aria-describedby"?, "aria-required"? }
+  /** Input field and layout elements. May be a render function with a11yProps object and refLabel.
+   * a11yProps includes: { id, disabled?, "aria-disabled"?, "aria-describedby"?, "aria-required"? }
+   * refLabel is a React ref for the `<FormElement.Label />`
    */
   children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]).isRequired,
 };

--- a/packages/FormElement/src/index.d.ts
+++ b/packages/FormElement/src/index.d.ts
@@ -23,8 +23,9 @@ declare namespace FormElement {
   function Content(props: ContentProps): JSX.Element;
   interface ContentProps {
     [x: string]: any;
-    /** Input field and layout elements. May be a render function with a11yProps object as an argument.
-a11yProps includes: { id, refLabel, disabled?, "aria-disabled"?, "aria-describedby"?, "aria-required"? } */
+    /** Input field and layout elements. May be a render function with a11yProps object and refLabel.
+a11yProps includes: { id, disabled?, "aria-disabled"?, "aria-describedby"?, "aria-required"? }
+refLabel is a React ref for the `<FormElement.Label />` */
     children: func | node;
   }
 }

--- a/packages/FormElement/stories/FormElement.stories.mdx
+++ b/packages/FormElement/stories/FormElement.stories.mdx
@@ -100,8 +100,8 @@ This works because the properties included in the `a11yProps` argument of the re
 <FormElement>
   <FormElement.Label>Field label</FormElement.Label>
   <FormElement.Content>
-    {a11yProps => <>
-      <ListBox {...a11yProps}>
+    {(a11yProps, refLabel) => <>
+      <ListBox {...a11yProps} refLabel={refLabel}>
         <ListBox.Option>Option #1</ListBox.Option>
         <ListBox.Option>Option #2</ListBox.Option>
         <ListBox.Option>Option #3</ListBox.Option>

--- a/packages/FormElement/stories/examples/ListBox.js
+++ b/packages/FormElement/stories/examples/ListBox.js
@@ -13,8 +13,9 @@ export default function ListBoxExample() {
       <FormElement>
         <Label>Form Label</Label>
         <Content>
-          {a11yProps => (
-            <ListBox {...a11yProps}>
+          {(a11yProps, refLabel) => (
+            <ListBox>
+              <ListBox.A11y {...a11yProps} refLabel={refLabel} />
               {optionsArray.map(item => (
                 <ListBox.Option key={item}>{item}</ListBox.Option>
               ))}


### PR DESCRIPTION
…ater object

### Purpose 🚀

Resolve the errors coming from `FormElement`, the `refLabel` is only required by `ListBox` but it has been passed down to all type of field, e.g. input or a textarea, so there's react warning about invalid DOM attribute

The PR changes the parameter of the render `Content` function, but I think since only `ListBox` needs to update the way of using `refLabel` we can treat it as a patch (bug fix) bump for the form element. Also I believe even if I didn't change to this way, the refLabel doesn't work on the current (master branch) form element + listbox example

master branch: http://storybooks.highbond-s3.com/paprika/master/?path=/story/forms-formelement-examples--list-box-story not working 
this branch: http://storybooks.highbond-s3.com/paprika/UXD-972-move-refLabel-out/?path=/story/forms-formelement-examples--list-box-story works

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
