### PR TITLE
Uxd 1007 fix popover tooltip accessibility

### DIFF
--- a/.changeset/four-bears-dream.md
+++ b/.changeset/four-bears-dream.md
@@ -1,0 +1,5 @@
+---
+"@paprika/popover": minor
+---
+
+Fixed aria tags on popover

--- a/packages/Popover/src/components/Content/Content.js
+++ b/packages/Popover/src/components/Content/Content.js
@@ -96,7 +96,7 @@ const Content = React.forwardRef((props, ref) => {
       data-component-name="PopoverContent"
       data-pka-anchor="popover.content"
       ref={handleRef}
-      id={isEager ? content.ariaId : null}
+      id={content.ariaId}
       isOpen={isOpen}
       onBlur={handleBlur}
       onMouseOut={handleMouseEvent}

--- a/packages/Popover/src/components/Trigger/Trigger.js
+++ b/packages/Popover/src/components/Trigger/Trigger.js
@@ -50,7 +50,7 @@ function Trigger(props) {
   const { children, a11yText, ...moreProps } = props;
 
   const tooltipA11yProps = { "aria-describedby": content.ariaId };
-  const popoverA11yProps = { ...tooltipA11yProps, "aria-haspopup": true };
+  const popoverA11yProps = { "aria-haspopup": true, "aria-controls": true, "aria-expanded": true };
   const a11yAttributes = isEager ? tooltipA11yProps : popoverA11yProps;
 
   if (typeof children === "function") {

--- a/packages/Popover/src/components/Trigger/Trigger.js
+++ b/packages/Popover/src/components/Trigger/Trigger.js
@@ -50,7 +50,7 @@ function Trigger(props) {
   const { children, a11yText, ...moreProps } = props;
 
   const tooltipA11yProps = { "aria-describedby": content.ariaId };
-  const popoverA11yProps = { "aria-haspopup": true, "aria-controls": true, "aria-expanded": true };
+  const popoverA11yProps = { "aria-haspopup": true, "aria-controls": content.ariaId, "aria-expanded": true };
   const a11yAttributes = isEager ? tooltipA11yProps : popoverA11yProps;
 
   if (typeof children === "function") {

--- a/packages/Popover/src/components/Trigger/Trigger.js
+++ b/packages/Popover/src/components/Trigger/Trigger.js
@@ -50,7 +50,7 @@ function Trigger(props) {
   const { children, a11yText, ...moreProps } = props;
 
   const tooltipA11yProps = { "aria-describedby": content.ariaId };
-  const popoverA11yProps = { "aria-haspopup": true, "aria-controls": content.ariaId, "aria-expanded": true };
+  const popoverA11yProps = { "aria-haspopup": true, "aria-controls": content.ariaId, "aria-expanded": isOpen };
   const a11yAttributes = isEager ? tooltipA11yProps : popoverA11yProps;
 
   if (typeof children === "function") {

--- a/packages/Popover/stories/examples/StateValue.js
+++ b/packages/Popover/stories/examples/StateValue.js
@@ -18,7 +18,9 @@ export default function StateValue() {
       <Popover defaultIsOpen>
         <Popover.Trigger>
           {(handler, a11yAttributes, isOpen) => (
-            <Button onClick={handler}>{isOpen ? "Click to close" : "Click to open"}</Button>
+            <Button onClick={handler} {...a11yAttributes}>
+              {isOpen ? "Click to close" : "Click to open"}
+            </Button>
           )}
         </Popover.Trigger>
         <Popover.Content>


### PR DESCRIPTION
### Purpose 🚀
Follow on pr from https://github.com/acl-services/paprika/pull/975

This PR addresses some incorrect and missing aria attributes on the Popover Trigger when used as a tooltip or just as a popover

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/uxd-1007-fix-popover-tooltip-accessibility

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
