### PR TITLE
UXD-982 Fix initial focus index for Tabs 🐐

### DIFF
--- a/.changeset/tender-flies-pretend.md
+++ b/.changeset/tender-flies-pretend.md
@@ -1,0 +1,9 @@
+---
+"@paprika/tabs": patch
+---
+
+### Fixed
+
+- Set initial `focusIndex` to selected tab index, or first tab index if no tab is selected.
+
+[@mikrotron](https://github.com/mikrotron)

--- a/packages/Tabs/src/Tabs.js
+++ b/packages/Tabs/src/Tabs.js
@@ -31,7 +31,7 @@ export default function Tabs(props) {
   const isControlled = index !== undefined;
   const initIndex = defaultIndex === undefined ? 0 : defaultIndex;
   const [internalIndex, setInternalIndex] = React.useState(initIndex);
-  const [focusIndex, setFocusIndex] = React.useState(isControlled ? index || 0 : initIndex);
+  const [focusIndex, setFocusIndex] = React.useState(isControlled ? index || 0 : initIndex || 0);
   const activeIndex = isControlled ? index : internalIndex;
 
   if (isControlled && !onClickTab) {
@@ -50,6 +50,7 @@ export default function Tabs(props) {
       const itemIndexes = getItemIndexes(refList, { hasDisabledItems: false });
       if (itemIndexes.length > 0) {
         setInternalIndex(itemIndexes[0]);
+        setFocusIndex(itemIndexes[0]);
       }
     }
   }, []);


### PR DESCRIPTION
### Purpose 🚀
Set initial `focusIndex` to selected tab index, or first tab index if no tab is selected.


### Notes ✏️
- Currently if no tab is initially selected (active) then all tabs have `tabindex="-1"` and the `<Tabs>` component is inoperable by keyboard. 


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/UXD-982--fix-initial-focus/?path=/story/navigation-tabs-backyard-tests--keyboard

Compare with current behaviour:
https://paprika.highbond.com/?path=/story/navigation-tabs-backyard-tests--keyboard


### References 🔗
https://aclgrc.atlassian.net/browse/UXD-982


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
