### PR TITLE
Pdtvt 1034  progress accordion nav tweaks

### DIFF
--- a/.changeset/thin-windows-arrive.md
+++ b/.changeset/thin-windows-arrive.md
@@ -1,0 +1,5 @@
+---
+"@paprika/progress-accordion": patch
+---
+
+Refactored so more logical to use as a nav. Style changes.

--- a/packages/ProgressAccordion/src/ProgressAccordion.js
+++ b/packages/ProgressAccordion/src/ProgressAccordion.js
@@ -2,10 +2,10 @@ import React from "react";
 import PropTypes from "prop-types";
 import useI18n from "@paprika/l10n/lib/useI18n";
 import Item from "./components/Item";
+import NavItem from "./components/NavItem";
 import Indicator from "./components/Indicator";
 import Responses from "./components/Responses";
 import * as sc from "./ProgressAccordion.styles";
-import * as kinds from "./kinds";
 
 const propTypes = {
   /** A11y text for assistive technologies to descibe the semantic list. */
@@ -22,9 +22,6 @@ const propTypes = {
 
   /** List items (must be of type <ProgressAccordion.Item>. */
   children: PropTypes.node,
-
-  /** When kind is "navigation", all the children are expanded and cannot be collapsed */
-  kind: PropTypes.oneOf(["", kinds.NAVIGATION]),
 };
 
 const defaultProps = {
@@ -32,15 +29,17 @@ const defaultProps = {
   activeIndex: 0,
   activeStatus: null,
   children: null,
-  kind: "",
 };
 
 function filterChildren(children) {
-  return React.Children.toArray(children).filter(child => child.type && child.type.displayName === Item.displayName);
+  return React.Children.toArray(children).filter(
+    child =>
+      child.type && (child.type.displayName === Item.displayName || child.type.displayName === NavItem.displayName)
+  );
 }
 
 const ProgressAccordion = props => {
-  const { a11yText, activeIndex, activeStatus, children, kind, ...moreProps } = props;
+  const { a11yText, activeIndex, activeStatus, children, ...moreProps } = props;
 
   const I18n = useI18n();
 
@@ -60,10 +59,8 @@ const ProgressAccordion = props => {
     );
   };
 
-  const role = kind === kinds.NAVIGATION ? "navigation" : "list";
-
   return (
-    <sc.Accordion {...moreProps} role={role} aria-label={a11yText} data-pka-anchor="progress-accordion">
+    <sc.Accordion {...moreProps} role="list" aria-label={a11yText} data-pka-anchor="progress-accordion">
       {validChildren.length > 0 &&
         validChildren.map((child, index) => {
           const isComplete = activeIndex > index;
@@ -80,7 +77,6 @@ const ProgressAccordion = props => {
               {React.cloneElement(child, {
                 label: getLabel(child.props.label, index),
                 isComplete,
-                kind,
               })}
             </sc.Item>
           );
@@ -94,8 +90,8 @@ ProgressAccordion.propTypes = propTypes;
 ProgressAccordion.defaultProps = defaultProps;
 
 ProgressAccordion.Item = Item;
+ProgressAccordion.NavItem = NavItem;
 ProgressAccordion.Indicator = Indicator;
 ProgressAccordion.Responses = Responses;
 
-ProgressAccordion.kinds = kinds;
 export default ProgressAccordion;

--- a/packages/ProgressAccordion/src/ProgressAccordion.js
+++ b/packages/ProgressAccordion/src/ProgressAccordion.js
@@ -32,9 +32,8 @@ const defaultProps = {
 };
 
 function filterChildren(children) {
-  return React.Children.toArray(children).filter(
-    child =>
-      child.type && (child.type.displayName === Item.displayName || child.type.displayName === NavItem.displayName)
+  return React.Children.toArray(children).filter(child =>
+    [Item.displayName, NavItem.displayName].includes(child.type?.displayName)
   );
 }
 

--- a/packages/ProgressAccordion/src/components/Item/Item.js
+++ b/packages/ProgressAccordion/src/components/Item/Item.js
@@ -3,7 +3,6 @@ import PropTypes from "prop-types";
 import UpIcon from "@paprika/icon/lib/ArrowUp";
 import DownIcon from "@paprika/icon/lib/ArrowDown";
 import * as sc from "./Item.styles";
-import * as kinds from "../../kinds";
 
 const propTypes = {
   /** Content to be revealed with the Collapsible for this item is open. */
@@ -15,46 +14,24 @@ const propTypes = {
   /** If the item is complete (and should therefore include content that can be revealed). */
   isComplete: PropTypes.bool,
 
-  /** When kind is "navigation", all the children are expanded and cannot be collapsed */
-  kind: PropTypes.oneOf(["", kinds.NAVIGATION]),
-
-  /** Function to call when click on an item (only used when kind=navigation). */
+  /** Function to call when click on an item. */
   onClick: PropTypes.func,
 };
 
 const defaultProps = {
   children: null,
   isComplete: false,
-  kind: "",
   onClick: () => {},
 };
 
 const Item = props => {
-  const { children, label, isComplete, kind, onClick, ...moreProps } = props;
+  const { children, label, isComplete, onClick, ...moreProps } = props;
 
   const [isOpen, setIsOpen] = React.useState(false);
 
   const handleToggle = () => {
     setIsOpen(prevIsOpen => !prevIsOpen);
   };
-
-  if (kind === kinds.NAVIGATION) {
-    // it is always expanded and cant be collapsed
-    return (
-      <sc.Item
-        hasBorder={false}
-        iconAlign={null}
-        iconCollapse={null}
-        iconExpand={null}
-        isCollapsed={false}
-        label={<sc.ItemLabel>{label}</sc.ItemLabel>}
-        onClick={onClick}
-        {...moreProps}
-      >
-        {children}
-      </sc.Item>
-    );
-  }
 
   if (isComplete) {
     return (

--- a/packages/ProgressAccordion/src/components/Item/Item.styles.js
+++ b/packages/ProgressAccordion/src/components/Item/Item.styles.js
@@ -6,7 +6,7 @@ import stylers from "@paprika/stylers";
 const incompleteHeight = `${Number.parseInt(tokens.space, 10) * 5 + 1}px`;
 
 export const Item = styled(Collapsible)`
-  border-bottom: ${({ hasBorder = true }) => (hasBorder ? `1px solid ${tokens.border.color}` : "none")};
+  border-bottom: 1px solid ${tokens.border.color};
   color: ${tokens.textColor.subtle};
   max-width: calc(100% - 36px); /* 36px = indicatorSize + margin-right */
 

--- a/packages/ProgressAccordion/src/components/NavItem/NavItem.js
+++ b/packages/ProgressAccordion/src/components/NavItem/NavItem.js
@@ -9,7 +9,7 @@ const propTypes = {
   /** The title of the nav item. */
   label: PropTypes.node.isRequired,
 
-  /** If the step is complete (and should have checkbox and be clickable). */
+  /** If the step is complete. */
   isComplete: PropTypes.bool,
 
   /** Function to call when click on an item. */
@@ -30,6 +30,7 @@ const NavItem = props => {
       iconAlign={null}
       iconCollapse={null}
       iconExpand={null}
+      isClickable={onClick === null}
       isCollapsed={false}
       isComplete={isComplete}
       label={<sc.ItemLabel isClickable={onClick === null}>{label}</sc.ItemLabel>}

--- a/packages/ProgressAccordion/src/components/NavItem/NavItem.js
+++ b/packages/ProgressAccordion/src/components/NavItem/NavItem.js
@@ -1,0 +1,48 @@
+import React from "react";
+import PropTypes from "prop-types";
+import * as sc from "./NavItem.styles";
+
+const propTypes = {
+  /** Body of the nav item. */
+  children: PropTypes.node,
+
+  /** The title of the nav item. */
+  label: PropTypes.node.isRequired,
+
+  /** If the step is complete (and should have checkbox and be clickable). */
+  isComplete: PropTypes.bool,
+
+  /** Function to call when click on an item. */
+  onClick: PropTypes.func,
+};
+
+const defaultProps = {
+  children: null,
+  isComplete: false,
+  onClick: null,
+};
+
+const NavItem = props => {
+  const { children, label, isComplete, onClick, ...moreProps } = props;
+
+  return (
+    <sc.NavItem
+      iconAlign={null}
+      iconCollapse={null}
+      iconExpand={null}
+      isCollapsed={false}
+      isComplete={isComplete}
+      label={<sc.ItemLabel isClickable={onClick === null}>{label}</sc.ItemLabel>}
+      onClick={onClick}
+      {...moreProps}
+    >
+      {children}
+    </sc.NavItem>
+  );
+};
+
+NavItem.displayName = "ProgressAccordion.NavItem";
+NavItem.propTypes = propTypes;
+NavItem.defaultProps = defaultProps;
+
+export default NavItem;

--- a/packages/ProgressAccordion/src/components/NavItem/NavItem.styles.js
+++ b/packages/ProgressAccordion/src/components/NavItem/NavItem.styles.js
@@ -1,0 +1,36 @@
+import styled from "styled-components";
+import Collapsible from "@paprika/collapsible";
+import tokens from "@paprika/tokens";
+import stylers from "@paprika/stylers";
+// import Item from "../Item";
+
+export const NavItem = styled(Collapsible)`
+  color: ${({ isComplete }) => (isComplete ? tokens.color.black : tokens.textColor.subtle)};
+  max-width: calc(100% - 36px); /* 36px = indicatorSize + margin-right */
+
+  [role="button"] {
+    font-weight: bold;
+    margin-left: -${tokens.spaceSm};
+    padding: ${tokens.space} ${tokens.spaceSm};
+    width: calc(100% + ${tokens.spaceSm});
+  }
+
+  p {
+    margin-top: 0;
+  }
+`;
+
+// works
+// export const NavItem = styled(Item)`
+//   border-bottom: none;
+//   color: ${({ isComplete }) => (isComplete ? tokens.color.black : tokens.textColor.subtle)};
+
+//   p {
+//     margin-top: 0;
+//   }
+// `;
+
+export const ItemLabel = styled.div`
+  ${stylers.truncateText}
+  cursor: ${({ isClickable }) => (isClickable ? "default" : "pointer")};
+`;

--- a/packages/ProgressAccordion/src/components/NavItem/NavItem.styles.js
+++ b/packages/ProgressAccordion/src/components/NavItem/NavItem.styles.js
@@ -2,7 +2,6 @@ import styled from "styled-components";
 import Collapsible from "@paprika/collapsible";
 import tokens from "@paprika/tokens";
 import stylers from "@paprika/stylers";
-// import Item from "../Item";
 
 export const NavItem = styled(Collapsible)`
   color: ${({ isComplete }) => (isComplete ? tokens.color.black : tokens.textColor.subtle)};
@@ -18,17 +17,11 @@ export const NavItem = styled(Collapsible)`
   p {
     margin-top: 0;
   }
+
+  [data-pka-anchor="collapsible.trigger"] {
+    cursor: ${({ isClickable }) => (isClickable ? "default" : "pointer")};
+  }
 `;
-
-// works
-// export const NavItem = styled(Item)`
-//   border-bottom: none;
-//   color: ${({ isComplete }) => (isComplete ? tokens.color.black : tokens.textColor.subtle)};
-
-//   p {
-//     margin-top: 0;
-//   }
-// `;
 
 export const ItemLabel = styled.div`
   ${stylers.truncateText}

--- a/packages/ProgressAccordion/src/components/NavItem/NavItem.styles.js
+++ b/packages/ProgressAccordion/src/components/NavItem/NavItem.styles.js
@@ -20,6 +20,10 @@ export const NavItem = styled(Collapsible)`
 
   [data-pka-anchor="collapsible.trigger"] {
     cursor: ${({ isClickable }) => (isClickable ? "default" : "pointer")};
+
+    :hover {
+      text-decoration: ${({ isClickable }) => (isClickable ? "none" : "underline")};
+    }
   }
 `;
 

--- a/packages/ProgressAccordion/src/components/NavItem/index.js
+++ b/packages/ProgressAccordion/src/components/NavItem/index.js
@@ -1,0 +1,1 @@
+export { default } from "./NavItem";

--- a/packages/ProgressAccordion/src/kinds.js
+++ b/packages/ProgressAccordion/src/kinds.js
@@ -1,1 +1,0 @@
-export const NAVIGATION = "navigation";

--- a/packages/ProgressAccordion/stories/examples/Nav.js
+++ b/packages/ProgressAccordion/stories/examples/Nav.js
@@ -3,22 +3,26 @@ import ProgressAccordion from "../../src";
 
 const NavStory = () => {
   return (
-    <ProgressAccordion activeIndex={2} activeStatus="" a11yText="" kind={ProgressAccordion.kinds.NAVIGATION}>
-      {[1, 2, 3, 4].map(index => (
-        <ProgressAccordion.Item
-          key={index}
-          label={`Step ${index}`}
-          onClick={() => {
-            console.log(`clicked step ${index}`);
-          }}
-        >
-          <ProgressAccordion.Responses>
-            <ProgressAccordion.Responses.Item>
-              <p>This is a description of step {index}. Try clicking the label and check the console.</p>
-            </ProgressAccordion.Responses.Item>
-          </ProgressAccordion.Responses>
-        </ProgressAccordion.Item>
-      ))}
+    <ProgressAccordion activeIndex={1} activeStatus="" a11yText="">
+      <ProgressAccordion.NavItem
+        label="Step 1"
+        onClick={() => {
+          console.log("You clicked step 1");
+        }}
+      >
+        <p>This is a description of step 1. Try clicking the label and check the console.</p>
+      </ProgressAccordion.NavItem>
+      <ProgressAccordion.NavItem
+        label="Step 2"
+        onClick={() => {
+          console.log("You clicked step 2");
+        }}
+      >
+        <p>This is a description of step 2. Try clicking the label and check the console.</p>
+      </ProgressAccordion.NavItem>
+      <ProgressAccordion.NavItem label="Step 3" onClick={null}>
+        <p>This is a description of step 3. It cannot be clicked.</p>
+      </ProgressAccordion.NavItem>
     </ProgressAccordion>
   );
 };


### PR DESCRIPTION
### Purpose 🚀
I made a different sub-component so the ProgressAccordion is easier to use as a nav.

Made some style tweaks to it (black when complete and grey when incomplete, changed hover cursor if theres no click action).

No one is using this component as a nav, so just did it as a patch.

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
