### PR TITLE
fix(Breadcrumbs): ASM-1154 show expand button when rerender

### DIFF
--- a/.changeset/young-tools-wink.md
+++ b/.changeset/young-tools-wink.md
@@ -1,0 +1,5 @@
+---
+"@paprika/breadcrumbs": patch
+---
+
+Fix internal state

--- a/packages/Breadcrumbs/src/Breadcrumbs.js
+++ b/packages/Breadcrumbs/src/Breadcrumbs.js
@@ -15,6 +15,10 @@ function Breadcrumbs(props) {
   const hasOnlyOneChild = React.Children.count(children) === 1;
   const [isCollapsed, setIsCollapsed] = React.useState(shouldShowExpandButton);
 
+  React.useLayoutEffect(() => {
+    setIsCollapsed(shouldShowExpandButton);
+  }, [children, shouldShowExpandButton]);
+
   function handleExpand() {
     setIsCollapsed(false);
   }

--- a/packages/Breadcrumbs/src/Breadcrumbs.js
+++ b/packages/Breadcrumbs/src/Breadcrumbs.js
@@ -11,13 +11,14 @@ import * as sc from "./Breadcrumbs.styles";
 function Breadcrumbs(props) {
   const { children, isDark, isAutoCollapsed, ...moreProps } = props;
   const I18n = useI18n();
+  const childrenCount = React.Children.count(children);
   const shouldShowExpandButton = isAutoCollapsed && React.Children.count(children) > MAXIMUM_NUM_OF_LEVEL;
-  const hasOnlyOneChild = React.Children.count(children) === 1;
+  const hasOnlyOneChild = childrenCount === 1;
   const [isCollapsed, setIsCollapsed] = React.useState(shouldShowExpandButton);
 
   React.useLayoutEffect(() => {
     setIsCollapsed(shouldShowExpandButton);
-  }, [children, shouldShowExpandButton]);
+  }, [childrenCount, shouldShowExpandButton]);
 
   function handleExpand() {
     setIsCollapsed(false);

--- a/packages/Breadcrumbs/stories/Breadcrumbs.tests.stories.js
+++ b/packages/Breadcrumbs/stories/Breadcrumbs.tests.stories.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { getStoryName } from "storybook/storyTree";
 import Screener from "./examples/Screener";
+import RerenderBreadcrumbs from "./examples/RerenderBreadcrumbs";
 
 const storyName = getStoryName("Breadcrumbs");
 
@@ -10,6 +11,17 @@ export default {
 };
 
 export const screener = () => <Screener />;
+screener.story = {
+  parameters: {
+    docs: { page: null },
+    options: {
+      isToolshown: true,
+      showPanel: false,
+    },
+  },
+};
+
+export const rerenderBreadcrumbs = () => <RerenderBreadcrumbs />;
 screener.story = {
   parameters: {
     docs: { page: null },

--- a/packages/Breadcrumbs/stories/Breadcrumbs.tests.stories.js
+++ b/packages/Breadcrumbs/stories/Breadcrumbs.tests.stories.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { getStoryName } from "storybook/storyTree";
+import { testStoryParameters } from "storybook/assets/storyParameters";
 import Screener from "./examples/Screener";
 import RerenderBreadcrumbs from "./examples/RerenderBreadcrumbs";
 
@@ -12,22 +13,10 @@ export default {
 
 export const screener = () => <Screener />;
 screener.story = {
-  parameters: {
-    docs: { page: null },
-    options: {
-      isToolshown: true,
-      showPanel: false,
-    },
-  },
+  parameters: testStoryParameters,
 };
 
 export const rerenderBreadcrumbs = () => <RerenderBreadcrumbs />;
 screener.story = {
-  parameters: {
-    docs: { page: null },
-    options: {
-      isToolshown: true,
-      showPanel: false,
-    },
-  },
+  parameters: testStoryParameters,
 };

--- a/packages/Breadcrumbs/stories/examples/RerenderBreadcrumbs.js
+++ b/packages/Breadcrumbs/stories/examples/RerenderBreadcrumbs.js
@@ -1,0 +1,24 @@
+import React from "react";
+import Button from "@paprika/button";
+import L10n from "@paprika/l10n";
+import Breadcrumbs from "../../src";
+
+const URL = "https://www.wegalvanize.com/";
+
+export default function RerenderBreadcrumbs() {
+  const [clicked, setClicked] = React.useState(false);
+  const children = [2, 3, 4].map(num => (
+    <Breadcrumbs.Link key={num} href={URL}>{`Breadcrumb ${num}`}</Breadcrumbs.Link>
+  ));
+
+  return (
+    <L10n locale="en">
+      <Button onClick={() => setClicked(true)}>Click me</Button>
+      <Breadcrumbs>
+        <Breadcrumbs.Link href={URL}>Breadcrumb 1</Breadcrumbs.Link>
+
+        {clicked ? children : null}
+      </Breadcrumbs>
+    </L10n>
+  );
+}

--- a/packages/Breadcrumbs/tests/Breadcrumbs.cypress.js
+++ b/packages/Breadcrumbs/tests/Breadcrumbs.cypress.js
@@ -1,0 +1,19 @@
+describe("<Breadcrumbs />", () => {
+  it("Should rerender expand button", () => {
+    cy.visitStorybook(`breadcrumbs-tests--rerender-breadcrumbs`);
+
+    cy.findByText("Breadcrumb 1");
+    cy.findByText("Breadcrumb 2").should("not.exist");
+    cy.findByText("Breadcrumb 3").should("not.exist");
+    cy.findByText("Breadcrumb 4").should("not.exist");
+
+    cy.findByText("Click me").click();
+
+    cy.findByText("Breadcrumb 2").should("not.be.visible");
+    cy.findByText("Breadcrumb 3").should("be.visible");
+    cy.findByText("Breadcrumb 4").should("be.visible");
+
+    cy.findByLabelText("Show all breadcrumb items.").click();
+    cy.findByText("Breadcrumb 2").should("be.visible");
+  });
+});


### PR DESCRIPTION
### Purpose 🚀
_clear, one sentence description of primary purpose of this PR_

### Notes ✏️

Forgot to update the internal state based on component changes/re-render

test here: http://storybooks.highbond-s3.com/paprika/ASM-1154-fix-breadcrumb-rerender?path=/story/breadcrumbs-tests--rerender-breadcrumbs

### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
