### PR TITLE
fix(DataHeader): UXD-1068 fix css issues with long text

### DIFF
--- a/.changeset/bright-readers-reflect.md
+++ b/.changeset/bright-readers-reflect.md
@@ -1,0 +1,5 @@
+---
+"@paprika/data-header": patch
+---
+
+Fix css issues for longer header text

--- a/packages/DataHeader/package.json
+++ b/packages/DataHeader/package.json
@@ -24,6 +24,7 @@
     "@paprika/overflow-menu": "^1.0.15",
     "@paprika/popover": "^1.2.0",
     "@paprika/raw-button": "^1.0.3",
+    "@paprika/stylers": "1.0.0",
     "@paprika/toast": "^1.1.0",
     "@paprika/tokens": "^1.0.0",
     "prop-types": "^15.7.2"

--- a/packages/DataHeader/src/DataHeader.styles.js
+++ b/packages/DataHeader/src/DataHeader.styles.js
@@ -1,5 +1,6 @@
 import styled, { css } from "styled-components";
 import tokens from "@paprika/tokens";
+import stylers from "@paprika/stylers";
 
 export const Header = styled.div(({ $color, $backgroundColor, refHeader }) => {
   function resetHeaderParentContainer() {
@@ -27,6 +28,7 @@ export const Header = styled.div(({ $color, $backgroundColor, refHeader }) => {
   return css`
     align-items: center;
     display: flex;
+    overflow: hidden;
     width: 100%;
     /**
       * Css lacks of parent selector, we can use javascript to replace that :P
@@ -37,9 +39,9 @@ export const Header = styled.div(({ $color, $backgroundColor, refHeader }) => {
 
 export const Label = styled.div(() => {
   return css`
+    ${stylers.truncateText}
     flex-basis: 100%;
     flex-grow: 1;
-    min-height: 24px;
   `;
 });
 
@@ -53,10 +55,16 @@ export const Info = styled.div(() => {
   return css`
     align-items: center;
     display: flex;
+    flex-grow: 1;
     justify-content: flex-start;
-    width: 100%;
+    min-width: 0;
+
     svg {
       font-size: 1.2rem;
+    }
+
+    & + [data-pka-anchor="popover"] {
+      display: block;
     }
   `;
 });

--- a/packages/DataHeader/stories/DataHeaderWithLongTitle.datagrid.stories.js
+++ b/packages/DataHeader/stories/DataHeaderWithLongTitle.datagrid.stories.js
@@ -1,0 +1,93 @@
+import React from "react";
+import DataGrid from "@paprika/data-grid";
+import OverflowMenu from "@paprika/overflow-menu";
+import EllipsisVertical from "@paprika/icon/lib/EllipsisVertical";
+
+import { getStoryName } from "storybook/storyTree";
+import DataHeader from "../src";
+
+export default {
+  title: getStoryName("DataHeader"),
+};
+
+const data = [
+  { name: "Abbeline Doe", income: 153234.87, taxes: 32300.34 },
+  { name: "Alivia Smith", income: 85720.92, taxes: 17300.43 },
+  { name: "Aniya Johanson", income: 45328.54, taxes: 14302.23 },
+];
+
+function Menu(props) {
+  const { type } = props;
+  const handleClick = item => () => {
+    console.log(`${type} / ${item}`);
+  };
+
+  return (
+    <OverflowMenu>
+      <OverflowMenu.Trigger buttonType="raw">
+        <EllipsisVertical />
+      </OverflowMenu.Trigger>
+      <OverflowMenu.Item onClick={handleClick("one")}>One</OverflowMenu.Item>
+      <OverflowMenu.Item onClick={handleClick("two")}>Two</OverflowMenu.Item>
+      <OverflowMenu.Item onClick={handleClick("three")}>Three</OverflowMenu.Item>
+    </OverflowMenu>
+  );
+}
+
+export const DataGridWithLongTitleExample = () => {
+  return (
+    <div style={{ padding: "32px" }}>
+      <DataGrid data={data} width={600}>
+        <DataGrid.ColumnDefinition
+          header={() => (
+            <DataHeader
+              title="Name"
+              icons={DataHeader.icons}
+              label="name"
+              type="numeric"
+              renderActions={() => <Menu type="some" />}
+            />
+          )}
+          cell="name"
+        />
+        <DataGrid.ColumnDefinition
+          header={() => (
+            <DataHeader
+              title="Revenue with some background info"
+              icons={DataHeader.icons}
+              label="Revenue with some background info"
+              type="numeric"
+              renderActions={() => <Menu type="some" />}
+            />
+          )}
+          cell={({ row }) => Number(row.income - row.taxes)}
+          width={100}
+        />
+        <DataGrid.ColumnDefinition
+          header={() => (
+            <DataHeader
+              title="Income"
+              icons={DataHeader.icons}
+              label="Income"
+              type="numeric"
+              renderActions={() => <Menu type="some" />}
+            />
+          )}
+          cell={({ row }) => row.income}
+        />
+        <DataGrid.ColumnDefinition
+          header={() => (
+            <DataHeader
+              title="Taxes"
+              icons={DataHeader.icons}
+              label="Taxes"
+              type="numeric"
+              renderActions={() => <Menu type="some" />}
+            />
+          )}
+          cell={({ row }) => row.taxes}
+        />
+      </DataGrid>
+    </div>
+  );
+};


### PR DESCRIPTION
### Purpose 🚀
fix css issues with long text in data header

### Notes ✏️
test here:  http://storybooks.highbond-s3.com/paprika/UXD-1068-data-header-csss/?path=/story/table-dataheader--data-grid-with-long-title-example
Before:
![Screen Shot 2021-04-13 at 10 14 02 PM](https://user-images.githubusercontent.com/38733362/114743690-c45eb000-9d01-11eb-8e50-6450b1889703.png)

After:
![Screen Shot 2021-04-13 at 10 30 24 PM](https://user-images.githubusercontent.com/38733362/114743706-c759a080-9d01-11eb-9088-81b0979d4c2f.png)

### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/UXD-1068-data-header-csss

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
