### PR TITLE
UXD-1086 support local storage in useColumnsArrangement

### DIFF
--- a/.changeset/late-seas-guess.md
+++ b/.changeset/late-seas-guess.md
@@ -1,0 +1,5 @@
+---
+"@paprika/action-bar": major
+---
+
+The parameters of `useColumnsArrangement` has been changed. Check [here](https://github.com/acl-services/paprika/pull/1014) for the details.

--- a/packages/ActionBar/README.md
+++ b/packages/ActionBar/README.md
@@ -136,7 +136,7 @@ const {
   onHideAll,
   onChangeOrder,
   isColumnHidden,
-} = useColumnsArrangement(defaultColumnsForArrangement);
+} = useColumnsArrangement({ defaultOrderedColumnIds });
 
 return (
   <ColumnsArrangement

--- a/packages/ActionBar/src/components/ColumnsArrangement/ColumnsArrangement.js
+++ b/packages/ActionBar/src/components/ColumnsArrangement/ColumnsArrangement.js
@@ -80,7 +80,7 @@ export default function ColumnsArrangement(props) {
   };
 
   function handleSearch(e) {
-    setSearchTerm(e.target.value);
+    setSearchTerm(e === null ? "" : e.target.value);
   }
 
   return (
@@ -120,23 +120,32 @@ export default function ColumnsArrangement(props) {
             I18n.t("actionBar.no_results")
           ) : (
             <sc.Sortable onChange={handleChangeOrder} hasNumbers={false}>
-              {filteredColumnIds.map(id => (
-                <Sortable.Item
-                  key={id}
-                  sortId={id}
-                  isDragDisabled={columns[id].isDisabled}
-                  handleElement={columns[id].isDisabled ? <sc.LockIcon /> : undefined}
-                >
-                  <ColumnManagingItem
+              {filteredColumnIds.map(id => {
+                if (!columns[id]) {
+                  console.error(
+                    `Failed from rendering the ${id} column. Have you passed the <ColumnsArrangement.ColumnDefinition /> for that column?`
+                  );
+                  return null;
+                }
+
+                return (
+                  <Sortable.Item
                     key={id}
-                    id={id}
-                    label={columns[id].label}
-                    isDisabled={columns[id].isDisabled}
-                    isHidden={columns[id].isHidden}
-                    onChangeVisibility={onChangeVisibility}
-                  />
-                </Sortable.Item>
-              ))}
+                    sortId={id}
+                    isDragDisabled={columns[id].isDisabled}
+                    handleElement={columns[id].isDisabled ? <sc.LockIcon /> : undefined}
+                  >
+                    <ColumnManagingItem
+                      key={id}
+                      id={id}
+                      label={columns[id].label}
+                      isDisabled={columns[id].isDisabled}
+                      isHidden={columns[id].isHidden}
+                      onChangeVisibility={onChangeVisibility}
+                    />
+                  </Sortable.Item>
+                );
+              })}
             </sc.Sortable>
           )}
           {searchTerm.length ? null : (

--- a/packages/ActionBar/src/hooks/useColumnsArrangement/useColumnsArrangement.js
+++ b/packages/ActionBar/src/hooks/useColumnsArrangement/useColumnsArrangement.js
@@ -56,9 +56,12 @@ export default function useColumnsArrangement({
     );
   }
 
-  function isColumnHidden(columnId) {
-    return hiddenColumnIds.has(columnId);
-  }
+  const isColumnHidden = React.useCallback(
+    columnId => {
+      return hiddenColumnIds.has(columnId);
+    },
+    [hiddenColumnIds]
+  );
 
   function handleChangeOrder({ source, destination }) {
     if (!canMove({ source, destination })) return;

--- a/packages/ActionBar/stories/Actionbar.stories.js
+++ b/packages/ActionBar/stories/Actionbar.stories.js
@@ -3,9 +3,12 @@ import { storiesOf } from "@storybook/react";
 import { getStoryName } from "storybook/storyTree";
 import ButtonTrigger from "./examples/ButtonTrigger";
 import CustomButton from "./examples/CustomButton";
+import WithLocalStorageEnabled from "./examples/WithLocalStorageEnabled";
 
 const storyName = getStoryName("ActionBar");
 
 storiesOf(`${storyName}/Examples`, module).add("Button Trigger", () => <ButtonTrigger />);
 
 storiesOf(`${storyName}/Examples`, module).add("Custom Button", () => <CustomButton />);
+
+storiesOf(`${storyName}/Examples`, module).add("With LocalStorage Enabled", () => <WithLocalStorageEnabled />);

--- a/packages/ActionBar/stories/examples/ButtonTrigger.js
+++ b/packages/ActionBar/stories/examples/ButtonTrigger.js
@@ -48,16 +48,9 @@ const columnsSettings = [
 ];
 
 export default function ButtonTrigger() {
-  const { orderedColumnIds, isColumnHidden, ...handlers } = useColumnsArrangement([
-    "goals",
-    "name",
-    "status",
-    "country",
-    "joined",
-    "shareable",
-    "level",
-    "position",
-  ]);
+  const { orderedColumnIds, isColumnHidden, ...handlers } = useColumnsArrangement({
+    defaultOrderedColumnIds: ["goals", "name", "status", "country", "joined", "shareable", "level", "position"],
+  });
   return (
     <Story>
       <Heading level={2}>Columns Arrangement - Button Trigger</Heading>

--- a/packages/ActionBar/stories/examples/CustomButton.js
+++ b/packages/ActionBar/stories/examples/CustomButton.js
@@ -51,16 +51,9 @@ export default function CustomButton() {
     columns: columnsSettings,
     data,
   });
-  const { orderedColumnIds, isColumnHidden, ...handlers } = useColumnsArrangement([
-    "goals",
-    "name",
-    "status",
-    "country",
-    "joined",
-    "shareable",
-    "level",
-    "position",
-  ]);
+  const { orderedColumnIds, isColumnHidden, ...handlers } = useColumnsArrangement({
+    defaultOrderedColumnIds: ["goals", "name", "status", "country", "joined", "shareable", "level", "position"],
+  });
 
   const [rowColor, setRowColor] = React.useState("");
 

--- a/packages/ActionBar/stories/examples/WithLocalStorageEnabled.js
+++ b/packages/ActionBar/stories/examples/WithLocalStorageEnabled.js
@@ -77,7 +77,9 @@ export default function WithLocalStorageEnabled() {
         <thead>
           <tr>
             <th>id</th>
-            {orderedColumnIds.map(id => (isColumnHidden(id) ? null : <th key={id}>{id}</th>))}
+            {orderedColumnIds.map(id =>
+              isColumnHidden(id) ? null : <th key={id}>{columnsSettings.find(column => column.id === id).label}</th>
+            )}
           </tr>
         </thead>
         <tbody>

--- a/packages/ActionBar/stories/examples/WithLocalStorageEnabled.js
+++ b/packages/ActionBar/stories/examples/WithLocalStorageEnabled.js
@@ -47,7 +47,7 @@ const columnsSettings = [
 export default function WithLocalStorageEnabled() {
   const { orderedColumnIds, isColumnHidden, ...handlers } = useColumnsArrangement({
     defaultOrderedColumnIds: ["name", "goals", "status", "country", "joined", "shareable", "level", "position"],
-    localStorageKey: "paprika-storybook-example",
+    localStoragePrefix: "paprika-storybook-example",
     disabledColumnIds: ["name"],
   });
 
@@ -55,8 +55,8 @@ export default function WithLocalStorageEnabled() {
     <Story>
       <Heading level={2}>ActionBar with Custom Button</Heading>
       <Tagline>
-        If you want to save user show/hide preferences in localStorage, you can pass <code>localStorageKey</code> while
-        using <code>useColumnsArrangement</code>
+        If you want to save user show/hide preferences in localStorage, you can pass <code>localStoragePrefix</code>{" "}
+        while using <code>useColumnsArrangement</code>
       </Tagline>
       <br />
       <ActionBar>

--- a/packages/ActionBar/stories/examples/WithLocalStorageEnabled.js
+++ b/packages/ActionBar/stories/examples/WithLocalStorageEnabled.js
@@ -1,7 +1,8 @@
 import React from "react";
+import { Story, Tagline } from "storybook/assets/styles/common.styles";
 import Heading from "@paprika/heading";
-import ActionBar, { ColumnsArrangement, SearchInput, Sort, useColumnsArrangement, useSort } from "../../src";
-import data from "./data";
+import ActionBar, { ColumnsArrangement, useColumnsArrangement } from "../../src";
+import data from "../ShowcaseApp/data";
 
 const columnsSettings = [
   {
@@ -43,63 +44,30 @@ const columnsSettings = [
   },
 ];
 
-export default function App() {
-  const [searchTerm, setSearchTerm] = React.useState("");
-  const { sortedFields, sortedData, onDeleteSort, onChangeSort, ...sortProps } = useSort({
-    columns: columnsSettings,
-    data,
-    maxSortFields: 3,
-  });
+export default function WithLocalStorageEnabled() {
   const { orderedColumnIds, isColumnHidden, ...handlers } = useColumnsArrangement({
-    defaultOrderedColumnIds: ["goals", "name", "status", "country", "joined", "shareable", "level", "position"],
+    defaultOrderedColumnIds: ["name", "goals", "status", "country", "joined", "shareable", "level", "position"],
+    localStorageKey: "paprika-storybook-example",
     disabledColumnIds: ["name"],
   });
 
-  const subset = React.useMemo(() => {
-    return sortedData.filter(item =>
-      searchTerm
-        ? !!Object.values(item).find(value => {
-            return new RegExp(`${searchTerm}`, "i").test(`${value}`);
-          })
-        : true
-    );
-  }, [searchTerm, sortedData]);
-
   return (
-    <React.Fragment>
-      <Heading level={2}>ActionBar showcase</Heading>
-
+    <Story>
+      <Heading level={2}>ActionBar with Custom Button</Heading>
+      <Tagline>
+        If you want to save user show/hide preferences in localStorage, you can pass <code>localStorageKey</code> while
+        using <code>useColumnsArrangement</code>
+      </Tagline>
+      <br />
       <ActionBar>
-        <SearchInput
-          onChange={term => {
-            setSearchTerm(term);
-          }}
-        />
-
-        <Sort {...sortProps} columns={columnsSettings}>
-          {sortedFields.map((field, index) => {
-            return (
-              <Sort.Field
-                columnId={field.columnId}
-                direction={field.direction}
-                id={field.id}
-                isFirst={index === 0}
-                key={field.id}
-                onChange={onChangeSort}
-                onDelete={onDeleteSort}
-              />
-            );
-          })}
-        </Sort>
-
         <ColumnsArrangement orderedColumnIds={orderedColumnIds} {...handlers}>
           {columnsSettings.map(column => (
             <ColumnsArrangement.ColumnDefinition
               key={column.id}
               id={column.id}
               label={column.label}
-              isDisabled={column.id === "name"}
               isHidden={isColumnHidden(column.id)}
+              isDisabled={column.id === "name"}
             />
           ))}
         </ColumnsArrangement>
@@ -113,7 +81,7 @@ export default function App() {
           </tr>
         </thead>
         <tbody>
-          {subset.map(item => (
+          {data.map(item => (
             <tr key={item.id}>
               <td>{item.id}</td>
               {orderedColumnIds.map(id => (isColumnHidden(id) ? null : <td key={id}>{`${item[id]}`}</td>))}
@@ -121,6 +89,6 @@ export default function App() {
           ))}
         </tbody>
       </table>
-    </React.Fragment>
+    </Story>
   );
 }

--- a/packages/ActionBar/tests/cypress/ActionBar.cypress.js
+++ b/packages/ActionBar/tests/cypress/ActionBar.cypress.js
@@ -1,7 +1,21 @@
 import { getStoryUrlPrefix } from "../../../../.storybook/storyTree";
 
+function toggleSwitchFor(columnName) {
+  cy.findByTestId("sortable").within(() => {
+    cy.findByText(columnName)
+      .parent()
+      .within(() => {
+        cy.findByRole("switch").click();
+      });
+  });
+}
+
 beforeEach(() => {
   cy.visitStorybook(`${getStoryUrlPrefix("ActionBar")}--showcase`);
+});
+
+afterEach(() => {
+  window.localStorage.setItem("paprika-storybook-example--VISIBILITY", "[]");
 });
 
 describe("ActionBar", () => {
@@ -194,5 +208,45 @@ describe("ActionBar Arrange Columns", () => {
       .eq(0)
       .contains("Goals")
       .should("be.visible");
+  });
+
+  it.only("Should save user preferences for columns arrangement in localStorage", () => {
+    cy.visitStorybook(`${getStoryUrlPrefix("ActionBar")}-examples--with-localstorage-enabled`);
+    cy.findByText("Arrange").click();
+
+    toggleSwitchFor("Status");
+    toggleSwitchFor("Level");
+
+    cy.reload();
+
+    cy.findByRole("table").within(() => {
+      cy.findByText("Status").should("not.exist");
+      cy.findByText("Level").should("not.exist");
+    });
+
+    cy.findByText("2 columns hidden").click();
+    toggleSwitchFor("Status");
+
+    cy.reload();
+
+    cy.findByRole("table").within(() => {
+      cy.findByText("Status").should("be.visible");
+      cy.findByText("Level").should("not.exist");
+    });
+
+    cy.findByText("1 column hidden").click();
+    cy.findByText("Hide all").click();
+
+    cy.reload();
+
+    cy.findAllByRole("columnheader").should("have.length", 2);
+
+    cy.findByText("7 columns hidden").click();
+    cy.findByText("Show all").click();
+
+    cy.reload();
+
+    cy.findAllByRole("columnheader").should("have.length", 9);
+    cy.findByText("Arrange");
   });
 });

--- a/packages/DataGrid/stories/DataGrid.resize.stories.js
+++ b/packages/DataGrid/stories/DataGrid.resize.stories.js
@@ -52,13 +52,9 @@ export function CanGrowStressing() {
 }
 
 function AppWithActionBar() {
-  const { orderedColumnIds, isColumnHidden, ...handlers } = useColumnsArrangement([
-    "goals",
-    "name",
-    "status",
-    "country",
-    "joined",
-  ]);
+  const { orderedColumnIds, isColumnHidden, ...handlers } = useColumnsArrangement({
+    defaultOrderedColumnIds: ["goals", "name", "status", "country", "joined"],
+  });
 
   const renderColumns = type => {
     const column = {


### PR DESCRIPTION
### Purpose 🚀

This PR is for using localStorage to save the show/hide states in `useColumnsArrangement` hook. There'll be a follow-up PR to save the orders of columns.
Saving in localStorage will be only activated, when you pass in the `localStoragePrefix` when you use the hook.
For developers who are not using the hook, you can implement that by yourself.

Try here: http://storybooks.highbond-s3.com/paprika/UXD-1086-support-using-localStorage/?path=/story/table-actionbar-examples--with-localstorage-enabled

**_[BREAKING CHANGES]_**

This PR also changes the way of passing parameters to `useColumnsArrangement` hook.
Before:
```jsx
const {orderedColumnIds, ...} = useColumnsArrangement(
  defaultOrderedColumnIds, // string[], required
  disabledColumnIds  // string[]
);
```
After:
```jsx
const {orderedColumnIds, ...} = useColumnsArrangement({
  defaultOrderedColumnIds, // string[], required
  disabledColumnIds,  // string[]
  defaultHiddenColumnIds,  // string[]
  localStoragePrefix // string
});
```

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/UXD-1086-support-using-localStorage

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
