### PR TITLE
Uxd 1086 Bug fix for saving show/hide columns in localStorage

### DIFF
--- a/.changeset/silent-islands-fold.md
+++ b/.changeset/silent-islands-fold.md
@@ -1,0 +1,5 @@
+---
+"@paprika/action-bar": patch
+---
+
+Bug fix for saving show/hide columns in localStorage

--- a/packages/ActionBar/src/hooks/useColumnsArrangement/useColumnsArrangement.js
+++ b/packages/ActionBar/src/hooks/useColumnsArrangement/useColumnsArrangement.js
@@ -10,11 +10,12 @@ function getLocalStorageKey(localStoragePrefix, typeOfSavedItem) {
   return `${localStoragePrefix}--${typeOfSavedItem}`;
 }
 
-function getColumnIdsfromLocalStorage(localStorageKey) {
+function getColumnIdsfromLocalStorage(localStorageKey, fallbackArray = []) {
   const prevDataInString = window.localStorage.getItem(localStorageKey);
 
   if (prevDataInString) return JSON.parse(prevDataInString);
-  return [];
+  window.localStorage.setItem(localStorageKey, JSON.stringify(fallbackArray));
+  return fallbackArray;
 }
 
 function updateHiddenColumnIdFromLocalStorage(localStoragePrefix, columnId, isVisible) {
@@ -40,7 +41,12 @@ export default function useColumnsArrangement({
   const [order, setOrder] = React.useState(defaultOrder);
   const [hiddenColumnIds, setHiddenColumnIds] = React.useState(() =>
     isLocalStorageEnabled
-      ? new Set(getColumnIdsfromLocalStorage(getLocalStorageKey(localStoragePrefix, savedItem.VISIBILITY)))
+      ? new Set(
+          getColumnIdsfromLocalStorage(
+            getLocalStorageKey(localStoragePrefix, savedItem.VISIBILITY),
+            defaultHiddenColumnIds
+          )
+        )
       : new Set(defaultHiddenColumnIds)
   );
 


### PR DESCRIPTION
### Purpose 🚀

forgot to fallback to the passed in hidden columns value if the cache is not there

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
