### PR TITLE
Uxd 1091 data header small fix

### DIFF
--- a/.changeset/nasty-ads-rest.md
+++ b/.changeset/nasty-ads-rest.md
@@ -1,0 +1,5 @@
+---
+"@paprika/data-header": patch
+---
+
+Fixed some small css issues.

--- a/packages/DataHeader/src/DataHeader.styles.js
+++ b/packages/DataHeader/src/DataHeader.styles.js
@@ -34,6 +34,19 @@ export const Header = styled.div(({ $color, $backgroundColor, refHeader }) => {
       * Css lacks of parent selector, we can use javascript to replace that :P
       */
     ${$backgroundColor || $color ? resetHeaderParentContainer() : ""}
+
+    [data-pka-anchor="raw-button"] {
+      padding: 0 2px;
+
+      &:focus {
+        box-shadow: none;
+
+        > svg {
+          box-shadow: ${tokens.highlight.active.withBorder.boxShadow};
+          outline: none;
+        }
+      }
+    }
   `;
 });
 
@@ -47,6 +60,7 @@ export const Label = styled.div(() => {
 
 export const Icon = styled.div(() => {
   return css`
+    color: ${tokens.color.blackLighten20};
     padding-right: ${tokens.spaceSm};
   `;
 });


### PR DESCRIPTION
### Purpose 🚀

- Icon color changed to #717171
- Focusing ring on the ... button 
http://storybooks.highbond-s3.com/paprika/UXD-1091-data-header-small-fix/?path=/story/table-dataheader--data-grid-with-long-title-example

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
