### PR TITLE
fix(ProgressBar): Fix 'serious' axe issue even though have provided a…

### DIFF
--- a/.changeset/twelve-nails-sort.md
+++ b/.changeset/twelve-nails-sort.md
@@ -1,0 +1,5 @@
+---
+"@paprika/progress-bar": patch
+---
+
+Fix "serious" axe issue even though have provided a11yText

--- a/packages/ProgressBar/package.json
+++ b/packages/ProgressBar/package.json
@@ -23,7 +23,8 @@
     "@paprika/heading": "^1.0.6",
     "@paprika/stylers": "^1.0.0",
     "@paprika/tokens": "^1.0.0",
-    "prop-types": "^15.7.2"
+    "prop-types": "^15.7.2",
+    "uuid": "^8.3.2"
   },
   "gitHead": "8bff2e8a6f01708ba60d9178f867dba378806370"
 }

--- a/packages/ProgressBar/src/ProgressBar.js
+++ b/packages/ProgressBar/src/ProgressBar.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-
+import { v4 as uuidv4 } from "uuid";
 import Heading from "@paprika/heading";
 import * as sc from "./ProgressBar.styles";
 
@@ -35,6 +35,7 @@ const defaultProps = {
 
 function ProgressBar(props) {
   const { a11yText, bodyText, completed, header, headerLevel, isCompact, ...moreProps } = props;
+  const randomId = a11yText ? uuidv4() : null;
 
   return (
     <sc.ProgressBar {...moreProps}>
@@ -51,10 +52,15 @@ function ProgressBar(props) {
           completed={completed}
           data-pka-anchor="progress-bar"
           role="progressbar"
+          aria-labelledby={randomId}
         />
       </sc.Bar>
       {bodyText ? <sc.Body>{bodyText}</sc.Body> : null}
-      {a11yText ? <sc.A11yText aria-live="polite">{a11yText}</sc.A11yText> : null}
+      {a11yText ? (
+        <sc.A11yText aria-live="polite" id={randomId}>
+          {a11yText}
+        </sc.A11yText>
+      ) : null}
     </sc.ProgressBar>
   );
 }


### PR DESCRIPTION
 I made a codesandbox to test this ProgressBar:

```
<ProgressBar
  completed={33}
  header="header"
  bodyText="body"
  headerLevel={2}
  a11yText="my a11y text"
/>
```
which generated this HTML (classes shortened):
```
<div class="ProgressBarstyles">
  <h2 data-pka-anchor="heading" class="Headingstyles">header</h2>
  <div class="ProgressBarstyles__Bar">
    <div aria-valuemin="0" aria-valuemax="100" aria-valuenow="33" data-pka-anchor="progress-bar" role="progressbar" class="ProgressBarstyles__BarFiller"></div>
  </div>
  <p class="ProgressBarstyles__Body">body</p>
  <div aria-live="polite" class="ProgressBarstyles__A11yText">
    my a11y text
  </div>
</div>
```

Running axe, it reported this “Serious” issue: https://dequeuniversity.com/rules/axe/4.1/aria-progressbar-name?application=AxeChrome


This PR fixes that.