### PR TITLE
fix(OverflowMenu): ISSUE-452 prevent browser default behaviours when …

### DIFF
--- a/.changeset/cyan-lemons-walk.md
+++ b/.changeset/cyan-lemons-walk.md
@@ -1,0 +1,5 @@
+---
+"@paprika/overflow-menu": patch
+---
+
+Block default behaviour when press up/down/home/end key so page doesnt scroll when navigating through options.

--- a/packages/OverflowMenu/src/OverflowMenu.js
+++ b/packages/OverflowMenu/src/OverflowMenu.js
@@ -123,14 +123,18 @@ const OverflowMenu = React.forwardRef((props, ref) => {
 
   const onKeyDown = (event, currentIndex) => {
     if (event.key === "ArrowDown") {
+      event.preventDefault();
       const indexToFocus = currentIndex === overflowLastItemIndex ? 0 : currentIndex + 1;
       focusAndSetIndex(indexToFocus);
     } else if (event.key === "ArrowUp") {
+      event.preventDefault();
       const indexToFocus = currentIndex === 0 ? overflowLastItemIndex : currentIndex - 1;
       focusAndSetIndex(indexToFocus);
     } else if (event.key === "Home") {
+      event.preventDefault();
       focusAndSetIndex(0);
     } else if (event.key === "End") {
+      event.preventDefault();
       focusAndSetIndex(overflowLastItemIndex);
     } else if (event.key === "Enter" || event.key === " ") {
       // do nothing


### PR DESCRIPTION
…use up/down/home/end so page doesnt scroll

### Purpose 🚀
Fix this issue: https://github.com/acl-services/paprika/issues/452

### Notes ✏️
![scroll](https://user-images.githubusercontent.com/23224777/116588715-bcda0200-a8d0-11eb-83fe-ba40460123dd.gif)
