### PR TITLE
UXD-1122 chore(StatusTracker): new colours

### DIFF
--- a/.changeset/spicy-lizards-film.md
+++ b/.changeset/spicy-lizards-film.md
@@ -1,0 +1,5 @@
+---
+"@paprika/status-tracker": patch
+---
+
+update status tracker with new colours

--- a/packages/StatusTracker/src/StatusTracker.styles.js
+++ b/packages/StatusTracker/src/StatusTracker.styles.js
@@ -20,7 +20,7 @@ export const StatusTracker = styled.ol`
         vertical-align: middle;
         border-style: solid;
         border-width: 1px;
-        border-image: linear-gradient(45deg, ${tokens.color.white} 0%, ${tokens.color.black} 100%) 1;
+        border-image: linear-gradient(45deg, ${tokens.color.white} 0%, ${tokens.color.blackLighten10} 100%) 1;
         max-width: ${spacer(3)};        
       }
     `}

--- a/packages/StatusTracker/src/components/Point/Point.styles.js
+++ b/packages/StatusTracker/src/components/Point/Point.styles.js
@@ -6,7 +6,7 @@ import { fontSize, lineHeight, spacer } from "@paprika/stylers/lib/helpers";
 import * as types from "../../types";
 
 const passedPath = css`
-  border-bottom: 2px solid ${tokens.color.black};
+  border-bottom: 2px solid ${tokens.color.blackLighten10};
 `;
 
 const futurePath = css`
@@ -57,7 +57,8 @@ const basicPoint = css`
 `;
 
 const pastPoint = css`
-  background-color: ${tokens.color.black};
+  background-color: ${tokens.color.blackLighten20};
+  border: 2px solid ${tokens.color.blackLighten10};
 `;
 
 const futurePoint = css`


### PR DESCRIPTION
### Purpose 🚀
- update status tracker with new colours

### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/UXD-1122-update-status-tracker-colours

### Screenshots 📸
![Screen Shot 2021-05-04 at 3 22 54 PM](https://user-images.githubusercontent.com/19940076/117078026-f904cc80-aced-11eb-831a-094c7f8a7ccb.png)


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
