### PR TITLE
UXD-1128  Squash two Popover bugs 🐐

### DIFF
--- a/.changeset/moody-snails-live.md
+++ b/.changeset/moody-snails-live.md
@@ -1,0 +1,10 @@
+---
+"@paprika/popover": patch
+---
+
+### Fixed
+
+- Ensure `<Popover.Content>` receives focus after opening so its `onBlur` event will cause it to close.
+- Ensure proper `tab` focus order when `<Popover.Content>` has no focussable elements.
+
+Author: [@mikrotron](https://github.com/mikrotron)

--- a/packages/Popover/README.md
+++ b/packages/Popover/README.md
@@ -98,6 +98,8 @@ To include an arrow that points to the trigger element, the `<Popover.Tip>` can 
 ```jsx
 import Popover from "@paprika/popover";
 
+...
+
 <Popover>
   <Popover.Trigger>
     <Icon />
@@ -106,7 +108,29 @@ import Popover from "@paprika/popover";
     <Popover.Card>Lorem hipsum kombucha leggings vinyl.</Popover.Card>
   </Popover.Content>
   <Popover.Tip />
-</Popover>;
+</Popover>
+```
+
+### Uncontrolled example with button trigger
+
+```jsx
+import Popover from "@paprika/popover";
+
+...
+
+<Popover>
+  <Popover.Trigger>
+    {(onClickHandler, a11yAttributes) => (
+      <Button onClick={onClickHandler} {...a11yAttributes}>
+        Open Popover
+      </Button>
+    )}
+  </Popover.Trigger>
+  <Popover.Content>
+    <Popover.Card>Lorem hipsum kombucha leggings vinyl.</Popover.Card>
+  </Popover.Content>
+  <Popover.Tip />
+</Popover>
 ```
 
 ### Basic controlled example
@@ -114,10 +138,14 @@ import Popover from "@paprika/popover";
 ```jsx
 import Popover from "@paprika/popover";
 
+...
+
 const [isOpen, setOpen] = React.useState(false);
 
-<Popover isOpen={isOpen} onClose={() => { setOpen(false) }>
-  <Button onClick={() => { setOpen(prevOpen => !prevOpen) }}>
+...
+
+<Popover isOpen={isOpen} onClose={() => { setOpen(false) }}>
+  <Button onClick={() => { setOpen(true) }}>
     Open Popover
   </Button>
   <Popover.Content>

--- a/packages/Popover/src/Popover.js
+++ b/packages/Popover/src/Popover.js
@@ -284,7 +284,7 @@ class Popover extends React.Component {
     return false;
   };
 
-  getPopoverTriggerFocusIndex = () => {
+  setPopoverTriggerFocusIndex = () => {
     this.focusableElements.forEach((focusableElement, index) => {
       if (focusableElement === this.$trigger) {
         this.triggerFocusIndex = index;
@@ -293,11 +293,8 @@ class Popover extends React.Component {
   };
 
   handleTransitionEnd = event => {
-    // NOTE: do this should make more that only focus the content div? should as well
-    //       find the first focusable element like button, input, etc?
-    //       can focus automatically
-    if (!this.props.shouldKeepFocus && !this.props.isEager && this.isOpen() && event.propertyName === "visibility") {
-      this.getPopoverTriggerFocusIndex();
+    if (!this.props.shouldKeepFocus && !this.props.isEager && this.isOpen() && event.propertyName === "opacity") {
+      this.setPopoverTriggerFocusIndex();
       event.target.focus();
     }
   };
@@ -384,7 +381,6 @@ class Popover extends React.Component {
       }
 
       this.$content.addEventListener("transitionend", this.handleTransitionEnd, false);
-
       this.hasListeners = true;
     }
   }

--- a/packages/Popover/src/Popover.js
+++ b/packages/Popover/src/Popover.js
@@ -251,15 +251,18 @@ class Popover extends React.Component {
     if (event.key === "Escape" && this.isOpen() && this.$trigger) {
       event.stopPropagation();
       this.close();
-      if (this.$trigger) this.$trigger.focus();
+      this.$trigger.focus();
     } else if (event.key === "Tab" && this.isOpen() && this.$trigger) {
       const isFocusOnFirst = this.focusIsOnCertainElementInPopover("first") || document.activeElement === this.$content;
       const isFocusOnLast = this.focusIsOnCertainElementInPopover("last");
+      const isFocusOnOnly =
+        (document.activeElement === this.$content &&
+          this.$content.querySelectorAll(focusableElementSelector).length) === 0;
 
       if (event.shiftKey && isFocusOnFirst) {
         event.preventDefault();
         this.focusableElements[this.triggerFocusIndex].focus();
-      } else if (!event.shiftKey && isFocusOnLast) {
+      } else if (!event.shiftKey && (isFocusOnLast || isFocusOnOnly)) {
         event.preventDefault();
         this.focusableElements[this.triggerFocusIndex + 1].focus();
       }

--- a/packages/Popover/src/components/Content/Content.js
+++ b/packages/Popover/src/components/Content/Content.js
@@ -61,7 +61,6 @@ const Content = React.forwardRef((props, ref) => {
     setTimeout(() => {
       if (!isElementContainsFocus(currentTarget)) {
         onClose();
-        if (moreProps.onBlur) moreProps.onBlur();
       }
     }, parseInt(PopoverConstants.transition, 10));
   }
@@ -87,7 +86,6 @@ const Content = React.forwardRef((props, ref) => {
   if (content.width && content.width !== "auto") {
     contentStyles.width = content.width;
   }
-
   /* eslint-disable jsx-a11y/mouse-events-have-key-events */
   const ContentStyledComponent = (
     <ContentStyled
@@ -101,7 +99,7 @@ const Content = React.forwardRef((props, ref) => {
       tabIndex="-1"
       zIndex={content.zIndex}
       {...moreProps}
-      onBlur={handleBlur}
+      onBlur={callAll(handleBlur, moreProps.onBlur)}
       onMouseOut={callAll(handleMouseEvent, moreProps.onMouseOut)}
       onMouseOver={callAll(handleMouseEvent, moreProps.onMouseOver)}
       onKeyDown={callAll(handleKeyDown, moreProps.onKeyDown)}

--- a/packages/Popover/stories/Popover.examples.stories.js
+++ b/packages/Popover/stories/Popover.examples.stories.js
@@ -4,6 +4,7 @@ import ExampleStory from "storybook/components/ExampleStory";
 import { exampleStoryParameters } from "storybook/assets/storyParameters";
 import ButtonTriggerExample from "./examples/ButtonTrigger";
 import TooltipExample from "./examples/Tooltip";
+import MultipleExample from "./examples/Multiple";
 import ShouldKeepFocusExample from "./examples/ShouldKeepFocus";
 import StateValueExample from "./examples/StateValue";
 import PositioningElementExample from "./examples/PositioningElement";
@@ -33,6 +34,16 @@ export const TooltipStory = () => (
 );
 TooltipStory.story = {
   name: "Tooltip",
+  parameters: exampleStoryParameters,
+};
+
+export const MultipleStory = () => (
+  <ExampleStory storyName="Multiple Popovers" component="Popover" fileName="sandbox/Multiple.js">
+    <MultipleExample />
+  </ExampleStory>
+);
+MultipleStory.story = {
+  name: "Multiple Popovers",
   parameters: exampleStoryParameters,
 };
 

--- a/packages/Popover/stories/examples/Multiple.js
+++ b/packages/Popover/stories/examples/Multiple.js
@@ -1,0 +1,56 @@
+import React from "react";
+import { Gap } from "storybook/assets/styles/common.styles";
+import Button from "@paprika/button";
+import Popover from "../../src";
+
+export default function FocusTest() {
+  return (
+    <>
+      <Popover>
+        <Popover.Trigger>
+          {(onClickHandler, a11yAttributes) => (
+            <Button onClick={onClickHandler} {...a11yAttributes}>
+              Vinyl
+            </Button>
+          )}
+        </Popover.Trigger>
+        <Popover.Content>
+          <Popover.Card>
+            <Button size="small" kind="link">
+              Vaporware hexagon prism
+            </Button>
+          </Popover.Card>
+        </Popover.Content>
+        <Popover.Tip />
+      </Popover>
+      <Gap.Large />
+      <Popover>
+        <Popover.Trigger>
+          {(onClickHandler, a11yAttributes) => (
+            <Button onClick={onClickHandler} {...a11yAttributes}>
+              Locavore
+            </Button>
+          )}
+        </Popover.Trigger>
+        <Popover.Content>
+          <Popover.Card>Ethical typewriter asymmetrical distillery.</Popover.Card>
+        </Popover.Content>
+        <Popover.Tip />
+      </Popover>
+      <Gap.Large />
+      <Popover>
+        <Popover.Trigger>
+          {(onClickHandler, a11yAttributes) => (
+            <Button onClick={onClickHandler} {...a11yAttributes}>
+              Quinoa
+            </Button>
+          )}
+        </Popover.Trigger>
+        <Popover.Content>
+          <Popover.Card>Retro kale chips cold-pressed hammock.</Popover.Card>
+        </Popover.Content>
+        <Popover.Tip />
+      </Popover>
+    </>
+  );
+}

--- a/packages/Popover/stories/sandbox/FocusTest.js
+++ b/packages/Popover/stories/sandbox/FocusTest.js
@@ -5,57 +5,62 @@ import Popover from "../../src";
 
 export default function FocusTest() {
   const [isOpen, setOpen] = React.useState(false);
-  const handleClick = () => {
-    setOpen(prevOpen => !prevOpen);
+  const handleOpen = () => {
+    setOpen(true);
+  };
+  const handleClose = () => {
+    setOpen(false);
   };
 
   return (
     <>
       <Button>Vinyl</Button>
       <Gap />
-      <p>
-        <Popover>
-          <Popover.Trigger>Open Popover</Popover.Trigger>
-          <Popover.Content>
-            <Popover.Card>
-              <Button>Aesthetic</Button>
-              <Button>Gastropub</Button>
-              <Button>Snackwave</Button>
-            </Popover.Card>
-          </Popover.Content>
-          <Popover.Tip />
-        </Popover>
-      </p>
+      <Popover>
+        <Popover.Trigger>Open Popover</Popover.Trigger>
+        <Popover.Content>
+          <Popover.Card>Snackwave literally gastropub biodiesel master cleanse.</Popover.Card>
+        </Popover.Content>
+        <Popover.Tip />
+      </Popover>
       <Gap />
-      <p>
-        <Popover isOpen={isOpen}>
-          <Button onClick={handleClick}>Open Controlled Popover</Button>
-          <Popover.Content>
-            <Popover.Card>
-              <Button>Aesthetic</Button>
-              <Button>Gastropub</Button>
-              <Button>Snackwave</Button>
-            </Popover.Card>
-          </Popover.Content>
-          <Popover.Tip />
-        </Popover>
-      </p>
+      <Popover>
+        <Popover.Trigger>
+          {onClickHandler => <Button onClick={onClickHandler}>Open Uncontrolled Popover</Button>}
+        </Popover.Trigger>
+        <Popover.Content>
+          <Popover.Card>
+            <Button>Aesthetic</Button>
+            <Button>Gastropub</Button>
+            <Button>Snackwave</Button>
+          </Popover.Card>
+        </Popover.Content>
+        <Popover.Tip />
+      </Popover>
       <Gap />
-      <p>
-        <Popover isDark isEager>
-          <Popover.Trigger>Open Tooltip</Popover.Trigger>
-          <Popover.Content>
-            <Popover.Card>Lorem hipsum snackwave</Popover.Card>
-          </Popover.Content>
-          <Popover.Tip />
-        </Popover>
-      </p>
+      <Popover isOpen={isOpen} onClose={handleClose}>
+        <Button onClick={handleOpen}>Open Controlled Popover</Button>
+        <Popover.Content>
+          <Popover.Card>
+            <Button>Aesthetic</Button>
+            <Button>Gastropub</Button>
+            <Button>Snackwave</Button>
+          </Popover.Card>
+        </Popover.Content>
+        <Popover.Tip />
+      </Popover>
       <Gap />
-      <p>
-        <a href="https://www.youtube.com/watch?v=woSuxsthmSg" target="_blank" rel="noopener noreferrer">
-          Link
-        </a>
-      </p>
+      <Popover isDark isEager>
+        <Popover.Trigger>Open Tooltip</Popover.Trigger>
+        <Popover.Content>
+          <Popover.Card>Lorem hipsum snackwave</Popover.Card>
+        </Popover.Content>
+        <Popover.Tip />
+      </Popover>
+      <Gap />
+      <a href="https://www.youtube.com/watch?v=woSuxsthmSg" target="_blank" rel="noopener noreferrer">
+        Link
+      </a>
     </>
   );
 }


### PR DESCRIPTION
### Purpose 🚀
Don't allow multiple `<Popovers>` to be open at the same time.


### Notes ✍️
- Ensure `<Popover.Content>` receives focus after opening so its `onBlur` event will cause it to close.
- **BONUS:** Ensure proper `tab` focus order when `<Popover.Content>` has no focussable elements.


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/UXD-1128--popover-bugs/?path=/story/messaging-popover-examples--multiple-story


### Screenshots 📸
![multipopovers](https://user-images.githubusercontent.com/14944896/117509622-69565c80-af3f-11eb-8662-388b45326516.gif)


### References 🔗
https://aclgrc.atlassian.net/browse/UXD-1128


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
