### PR TITLE
feature(Table): UXD-1141 adding support for cssProps prop in Columnde…

### DIFF
--- a/.changeset/poor-carpets-doubt.md
+++ b/.changeset/poor-carpets-doubt.md
@@ -1,0 +1,7 @@
+---
+"@paprika/table": minor
+---
+
+### Added
+
+- Added support for cellProps prop on ColumnDefinition allowing to control props on top of each cell, styles, class, anchors, etc.

--- a/packages/Table/README.md
+++ b/packages/Table/README.md
@@ -39,6 +39,7 @@ npm install @paprika/table
 | Prop                                 | Type          | required | default   | Description                                                                                                                                         |
 | ------------------------------------ | ------------- | -------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | cell                                 | [string,func] | true     | -         | Each time a cell is renderer this prop will be call either to read a string value or to execute a cell function                                     |
+| cellProps                            | func          | false    | undefined | Give you access to return an object (styles, className, data-qa, etc) to render on top of each <td /> element                                       |
 | header                               | [string,func] | true     | -         | Represent the header for the column can either be a string or a function                                                                            |
 | sticky                               | number        | false    | undefined | Determine if a column should behave as a sticky column or not, received a number representing the space between the left side and the column pixels |
 | internally the default value is zero |

--- a/packages/Table/src/Table.js
+++ b/packages/Table/src/Table.js
@@ -66,7 +66,19 @@ const Table = React.forwardRef((props, ref) => {
               {ColumnDefinitions.map((columnDefinition, columnIndex) => {
                 const position = { "data-row-index": rowIndex, "data-column-index": columnIndex };
 
-                const { cell, header, width, sticky, ...moreColumnProps } = columnDefinition.props;
+                const {
+                  cell,
+                  header,
+                  width,
+                  sticky,
+                  cellProps: _cellProps,
+                  ...moreColumnProps
+                } = columnDefinition.props;
+
+                const cellProps =
+                  typeof _cellProps === "function"
+                    ? _cellProps({ ...columnDefinition.props, row, rowIndex, columnIndex })
+                    : {};
 
                 if (typeof cell === "function")
                   return (
@@ -76,6 +88,7 @@ const Table = React.forwardRef((props, ref) => {
                       key={columnIndex}
                       width={width}
                       sticky={sticky}
+                      {...cellProps}
                       {...moreColumnProps}
                       {...position}
                     >
@@ -88,6 +101,7 @@ const Table = React.forwardRef((props, ref) => {
                       cellPropsResetCSS={cellPropsResetCSS}
                       borderType={borderType}
                       key={columnIndex}
+                      {...cellProps}
                       {...moreColumnProps}
                       {...position}
                     >

--- a/packages/Table/src/components/ColumnDefinition/ColumnDefinition.js
+++ b/packages/Table/src/components/ColumnDefinition/ColumnDefinition.js
@@ -5,9 +5,9 @@ import PropTypes from "prop-types";
 const propTypes = {
   /** Each time a cell is renderer this prop will be call either to read a string value or to execute a cell function */
   cell: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).isRequired,
-  /** Represent the header for the column can either be a string or a function */
+  /** Give you access to return an object (styles, className, data-qa, etc) to render on top of each <td /> element */
   cellProps: PropTypes.func,
-  cellPropsResetCSS: PropTypes.bool,
+  /** Represent the header for the column can either be a string or a function */
   header: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).isRequired,
   /** Determine if a column should behave as a sticky column or not, received a number representing the space between the left side and the column pixels
    *  internally the default value is zero
@@ -18,7 +18,6 @@ const propTypes = {
 const defaultProps = {
   sticky: undefined,
   cellProps: undefined,
-  cellPropsResetCSS: undefined,
 };
 
 export default function ColumnDefinition() {

--- a/packages/Table/src/components/ColumnDefinition/ColumnDefinition.js
+++ b/packages/Table/src/components/ColumnDefinition/ColumnDefinition.js
@@ -6,6 +6,8 @@ const propTypes = {
   /** Each time a cell is renderer this prop will be call either to read a string value or to execute a cell function */
   cell: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).isRequired,
   /** Represent the header for the column can either be a string or a function */
+  cellProps: PropTypes.func,
+  cellPropsResetCSS: PropTypes.bool,
   header: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).isRequired,
   /** Determine if a column should behave as a sticky column or not, received a number representing the space between the left side and the column pixels
    *  internally the default value is zero
@@ -15,6 +17,8 @@ const propTypes = {
 
 const defaultProps = {
   sticky: undefined,
+  cellProps: undefined,
+  cellPropsResetCSS: undefined,
 };
 
 export default function ColumnDefinition() {

--- a/packages/Table/src/index.d.ts
+++ b/packages/Table/src/index.d.ts
@@ -33,6 +33,8 @@ declare namespace Table {
     [x: string]: any;
     /** Each time a cell is renderer this prop will be call either to read a string value or to execute a cell function */
     cell: string | func;
+    /** Give you access to return an object (styles, className, data-qa, etc) to render on top of each <td /> element */
+    cellProps?: (...args: any[]) => any;
     /** Represent the header for the column can either be a string or a function */
     header: string | func;
     /** Determine if a column should behave as a sticky column or not, received a number representing the space between the left side and the column pixels

--- a/packages/Table/stories/Table.screener.stories.js
+++ b/packages/Table/stories/Table.screener.stories.js
@@ -2,7 +2,8 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 import { getStoryName } from "storybook/storyTree";
 
-import { WithZebras, Borders } from "./Table.stories";
+import { WithZebras, Borders, WithCustomCellProps } from "./Table.stories";
+import { WithUsers } from "./Table.users.stories";
 
 const storyName = getStoryName("Table");
 
@@ -11,5 +12,13 @@ storiesOf(`${storyName}`, module).add("Screener", () => (
     <Borders />
     <br />
     <WithZebras />
+    <br />
+    <WithCustomCellProps />
+    <br />
+    <WithUsers />
   </>
 ));
+
+storiesOf(`${storyName}`, module).add("Screener CellProps", () => <WithCustomCellProps />);
+
+storiesOf(`${storyName}`, module).add("Screener With users", () => <WithUsers />);

--- a/packages/Table/stories/Table.stories.js
+++ b/packages/Table/stories/Table.stories.js
@@ -110,7 +110,28 @@ export function WithZebras() {
   );
 }
 
+export function WithCustomCellProps() {
+  return (
+    <bordersStyles.Container>
+      <bordersStyles.Gap>
+        <h4>Default value</h4>
+        <Table a11yText="" data={data} hasZebraStripes>
+          <Table.ColumnDefinition
+            cellProps={() => ({
+              style: { background: "purple", color: "white" },
+            })}
+            header="Name"
+            cell="name"
+          />
+          <Table.ColumnDefinition header="LastName" cell="lastName" />
+        </Table>
+      </bordersStyles.Gap>
+    </bordersStyles.Container>
+  );
+}
+
 storiesOf(`${storyName}`, module)
   .add("Basic", () => <Basic />)
   .add("Has Zebra stripes", () => <WithZebras />)
-  .add("Border types", () => <Borders />);
+  .add("Border types", () => <Borders />)
+  .add("Cell props", () => <WithCustomCellProps />);

--- a/packages/Table/stories/Table.users.stories.js
+++ b/packages/Table/stories/Table.users.stories.js
@@ -1,0 +1,115 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { getStoryName } from "storybook/storyTree";
+
+import Table from "../src";
+
+const storyName = getStoryName("Table");
+
+storiesOf(storyName, module);
+
+const data = [
+  { roleType: "Administrator" },
+  {
+    role: "user 1",
+    email: "1@1.com",
+    date: "Thu, October 1, 2020",
+    time: "7:13:42, Pacific DayLight time",
+  },
+  {
+    role: "user 1",
+    email: "1@1.com",
+    date: "Thu, October 1, 2020",
+    time: "7:13:42, Pacific DayLight time",
+  },
+  { roleType: "Reader" },
+  {
+    role: "user 1",
+    email: "1@1.com",
+    date: "Thu, October 1, 2020",
+    time: "7:13:42, Pacific DayLight time",
+  },
+];
+
+const Group = props => {
+  const { children, row, columnType } = props;
+
+  if ("roleType" in row && columnType === "role") {
+    return (
+      <>
+        <div style={{ position: "relative", left: "-36px" }}>
+          <input type="checkbox" />
+          <span style={{ display: "inline-block", position: "relative", left: "16px" }}>{row.roleType}</span>
+        </div>
+      </>
+    );
+  }
+
+  if ("roleType" in row) {
+    return "";
+  }
+
+  if (!("roleType" in row) && columnType === "checkbox") {
+    return "";
+  }
+
+  return children(props);
+};
+
+export function WithUsers() {
+  function handleCellProps({ row }) {
+    if ("roleType" in row) {
+      return { style: { background: "#F6F6F6" } };
+    }
+  }
+
+  return (
+    <Table data={data} forceTableWidthWithScrollBars>
+      <Table.ColumnDefinition
+        header={() => <input type="checkbox" />}
+        cell={props => (
+          <Group columnType="checkbox" {...props}>
+            {() => <input type="checkbox" />}
+          </Group>
+        )}
+        cellProps={handleCellProps}
+      />
+      <Table.ColumnDefinition
+        header="Role"
+        cell={props => (
+          <Group columnType="role" {...props}>
+            {props => (
+              <>
+                <input type="checkbox" />
+                <span>{props.row.role}</span>
+              </>
+            )}
+          </Group>
+        )}
+        cellProps={handleCellProps}
+      />
+      <Table.ColumnDefinition
+        header="Email or group members"
+        cell={props => <Group {...props}>{props => <span>{props.row.email}</span>}</Group>}
+        cellProps={handleCellProps}
+      />
+      <Table.ColumnDefinition
+        header="Previous sign-in data"
+        cell={props => <Group {...props}>{props => <span>{props.row.date}</span>}</Group>}
+        cellProps={handleCellProps}
+      />
+      <Table.ColumnDefinition
+        header="Previous sing-in time"
+        cell={props => <Group {...props}>{props => <span>{props.row.time}</span>}</Group>}
+        cellProps={handleCellProps}
+      />
+      <Table.ColumnDefinition
+        header=""
+        cell={props => <Group {...props}>{props => ("roleType" in props.row ? null : <span>x</span>)}</Group>}
+        cellProps={handleCellProps}
+      />
+    </Table>
+  );
+}
+
+storiesOf(`${storyName}`, module).add("WithUsers", () => <WithUsers />);


### PR DESCRIPTION
### Purpose 🚀

- Added support for `cellProps` prop on ColumnDefinition allowing to control props on top of each cell, styles, class, anchors, etc.
![Screen Shot 2021-05-11 at 4 04 39 PM](https://user-images.githubusercontent.com/19418590/117896090-a3dc3400-b274-11eb-88a8-30b26ee52e15.png)
![Screen Shot 2021-05-11 at 3 20 40 PM](https://user-images.githubusercontent.com/19418590/117896096-a63e8e00-b274-11eb-981b-aa35a2da8435.png)


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/UXD-1141-table-css-style-support

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
