### PR TITLE
fix(BuildTranslations): UXD-1170 fix missing dependency issue

### DIFF
--- a/.changeset/chilly-spoons-march.md
+++ b/.changeset/chilly-spoons-march.md
@@ -1,0 +1,5 @@
+---
+"@paprika/build-translations": patch
+---
+
+Fix missing dependency issue.

--- a/packages/BuildTranslations/package.json
+++ b/packages/BuildTranslations/package.json
@@ -16,6 +16,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@babel/runtime-corejs2": "^7.3.1",
     "arg": "^5.0.0",
     "esm": "^3.2.25",
     "js-yaml": "^3.13.1"


### PR DESCRIPTION
### Purpose 🚀
_clear, one sentence description of primary purpose of this PR_

### Notes ✏️

Used `"@babel/runtime-corejs2"` to build, but missing it in the dependency list

### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
