### PR TITLE
feature(ListBoxWithTags): UXD-1160 spreading props on listBoxWithTags

### DIFF
--- a/.changeset/ninety-berries-hide.md
+++ b/.changeset/ninety-berries-hide.md
@@ -1,0 +1,5 @@
+---
+"@paprika/list-box-with-tags": patch
+---
+
+Adding the ability to spread props at any component without affecting the Filter, Box and Trigger config

--- a/.changeset/wise-waves-look.md
+++ b/.changeset/wise-waves-look.md
@@ -1,0 +1,5 @@
+---
+"@paprika/list-box": patch
+---
+
+Removing data prop from spreding into the main div

--- a/packages/ListBox/src/ListBox.js
+++ b/packages/ListBox/src/ListBox.js
@@ -41,6 +41,7 @@ export function ListBox(props) {
     size,
 
     /* eslint-disable react/prop-types */
+    data,
     box,
     filter,
     footer,

--- a/packages/ListBoxWithTags/src/ListBoxWithTags.js
+++ b/packages/ListBoxWithTags/src/ListBoxWithTags.js
@@ -75,18 +75,41 @@ export default function ListBoxWithTags(props) {
     tagLabelKey,
   };
 
+  const extendedProps = {
+    "ListBox.Trigger": {},
+    "ListBox.Box": {},
+    "ListBox.Filter": {},
+  };
+
+  const filteredChildren = React.useMemo(() => {
+    return React.Children.map(children, child => {
+      if (child && ["ListBox.Trigger", "ListBox.Box", "ListBox.Filter"].includes(child.type.displayName)) {
+        const { children, ...moreProps } = child.props;
+        extendedProps[child.type.displayName] = moreProps;
+        return null;
+      }
+      return child;
+    });
+  }, [children, extendedProps]);
+
   return (
     <div ref={refDivRoot}>
       <ListBox isMulti size={validSize} onChange={handleChange} {...moreProps}>
-        <ListBox.Trigger>
+        <ListBox.Trigger {...extendedProps["ListBox.Trigger"]}>
           {(...[, , , attributes]) => <TriggerWithTags {...triggerProps} {...attributes} />}
         </ListBox.Trigger>
-        <ListBox.Box id={idListBoxContent} />
+        <ListBox.Box id={idListBoxContent} {...extendedProps["ListBox.Box"]} />
         {allOptionsAreSelected ? null : (
-          <ListBox.Filter filter={filter} ref={refFilter} onKeyDown={handleKeyDown} {...noResultMessageProp} />
+          <ListBox.Filter
+            filter={filter}
+            ref={refFilter}
+            onKeyDown={handleKeyDown}
+            {...noResultMessageProp}
+            {...extendedProps["ListBox.Filter"]}
+          />
         )}
         {allOptionsAreSelected ? null : React.Children.count(children) > 0 ? (
-          children
+          filteredChildren
         ) : (
           <ListBox.RawItem>{noResultsMessage}</ListBox.RawItem>
         )}
@@ -100,15 +123,12 @@ export default function ListBoxWithTags(props) {
   );
 }
 
+for (const subComponent in ListBox) {
+  if ({}.hasOwnProperty.call(ListBox, subComponent)) {
+    ListBoxWithTags[subComponent] = ListBox[subComponent];
+  }
+}
 ListBoxWithTags.displayName = "ListBoxWithTags";
-
-ListBoxWithTags.A11y = ListBox.A11y;
-ListBoxWithTags.Box = ListBox.Box;
-ListBoxWithTags.Divider = ListBox.Divider;
-ListBoxWithTags.Footer = ListBox.Footer;
-ListBoxWithTags.Option = ListBox.Option;
-ListBoxWithTags.Popover = ListBox.Popover;
-ListBoxWithTags.RawItem = ListBox.RawItem;
 ListBoxWithTags.filter = filter;
 
 ListBoxWithTags.types = {

--- a/packages/ListBoxWithTags/stories/ListBoxWithTags.examples.stories.js
+++ b/packages/ListBoxWithTags/stories/ListBoxWithTags.examples.stories.js
@@ -12,6 +12,7 @@ import UncontrolledUser from "./examples/UncontrolledUser";
 import UncontrolledFooter from "./examples/UncontrolledFooter";
 import FormElement from "./examples/FormElement";
 import UIStates from "./examples/UIStates";
+import SpreadingSubComponents from "./examples/SpreadingSubComponents";
 
 const storyName = getStoryName("ListBoxWithTags");
 
@@ -96,4 +97,11 @@ export const UIStatesStory = () => (
     <UIStates />
   </ExampleStory>
 );
+
+export const SpreadingSubComponentsStory = () => (
+  <ExampleStory storyName="UI States" component="ListBoxWithTags" fileName="examples/SpreadingSubComponents.js">
+    <SpreadingSubComponents />
+  </ExampleStory>
+);
+
 UIStatesStory.story = { name: "UI States", parameters: exampleStoryParameters };

--- a/packages/ListBoxWithTags/stories/examples/SpreadingSubComponents.js
+++ b/packages/ListBoxWithTags/stories/examples/SpreadingSubComponents.js
@@ -1,0 +1,29 @@
+import React from "react";
+import ListBoxWithTags, { useListBoxWithTags } from "../../src";
+import animals from "../mocks";
+
+const defaultFilteredData = animals.slice(0, 20);
+const defaultData = animals;
+
+export default function App() {
+  const { isSelected, filteredData, getSelectedOptions, ...moreUseListBoxWithTagsProps } = useListBoxWithTags({
+    key: "label",
+    defaultData,
+    defaultFilteredData,
+  });
+
+  return (
+    <ListBoxWithTags selectedOptions={getSelectedOptions()} {...moreUseListBoxWithTagsProps}>
+      <ListBoxWithTags.Box data-test-anchor="ListBoxWithTags.Box-test" />
+      <ListBoxWithTags.Filter data-test-anchor="ListBoxWithTags.Filter-test" />
+      <ListBoxWithTags.Trigger data-test-anchor="ListBoxWithTags.Trigger-test" />
+      {filteredData.map(option => {
+        return !isSelected(option.label) ? (
+          <ListBoxWithTags.Option value={option.label} key={option.label} label={option.label}>
+            {option.label}
+          </ListBoxWithTags.Option>
+        ) : null;
+      })}
+    </ListBoxWithTags>
+  );
+}


### PR DESCRIPTION
### Purpose 🚀
Simply allowed to spread down properties to different subcomponent from ListBoxWithTags to ListBox

![Screen Shot 2021-05-21 at 11 56 02 AM](https://user-images.githubusercontent.com/19418590/119188412-7b4ff900-ba2f-11eb-8d44-3b18ed4a0f97.png)
![Screen Shot 2021-05-21 at 11 56 11 AM](https://user-images.githubusercontent.com/19418590/119188416-7be88f80-ba2f-11eb-9a27-b0b093647924.png)
![Screen Shot 2021-05-21 at 11 57 12 AM](https://user-images.githubusercontent.com/19418590/119188418-7c812600-ba2f-11eb-8abb-ad875c76234a.png)


### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
