### PR TITLE
chore(Filter): UXD-1203 Update docs, highlighting that 'operator' can be forced

### DIFF
--- a/packages/Filter/README.md
+++ b/packages/Filter/README.md
@@ -119,6 +119,10 @@ return (
 );
 ```
 
+### Variations
+
+- You can prevent the user from having to choose between <code>AND</code> and <code>OR</code> by setting the <code>onChangeOperator</code> prop to <code>null</code> and including the <code>operator</code> to use.
+
 <!-- eoContent -->
 
 ## Links

--- a/packages/Filter/stories/Hooks/Hooks.js
+++ b/packages/Filter/stories/Hooks/Hooks.js
@@ -31,7 +31,7 @@ const columnsSettings = [
   },
 ];
 
-export default function FilterWithServer() {
+export default function Hooks() {
   const {
     filters,
     // filteredData,
@@ -60,7 +60,6 @@ export default function FilterWithServer() {
       <Filter
         {...filterProps}
         columns={columnsSettings}
-        rulesByType={Filter.defaultRulesByType}
         onCancel={() => {
           console.log("onCancel");
         }}

--- a/packages/Filter/stories/MockServer/MockServer.js
+++ b/packages/Filter/stories/MockServer/MockServer.js
@@ -40,7 +40,7 @@ const customRulesByType = {
   CUSTOM_SELECT: [Filter.rules.IS, Filter.rules.IS_NOT, Filter.rules.IS_EMPTY, Filter.rules.IS_NOT_EMPTY],
 };
 
-export default function FilterWithServer() {
+export default function MockServer() {
   const [serverSideData, setServerSideData] = React.useState(null);
   const [isPending, setIsPending] = React.useState(true);
   const { filters, getFilterProps, getFilterItemProps } = useFilter({


### PR DESCRIPTION
I was going to add the ability to force `AND` or `OR` and prevent the user from being able to switch... but turns out that functionality is already in there.  So instead I updated the docs to make it more clear.