### PR TITLE
chore(Semaphore): UXD-1150 Update node version for semaphore

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM node:10-alpine
+FROM node:12-alpine
 
 ENV DIR /src
 


### PR DESCRIPTION
### Purpose 🚀
Paprika storybook isnt deploying. Checked with Samson and build pipeline has this error:

```
[1/5] Validating package.json...
error @paprika/paprika@: The engine "node" is incompatible with this module. Expected version ">=12.13.0". Got "10.24.1"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
time="2021-06-06T03:11:11.861576915Z" level=info msg="shim reaped" id=23f7a7e6706bbcace889dcb995c5430074757685ea86979053ed85513380fe04 
time="2021-06-06T03:11:11.871614657Z" level=info msg="ignoring event" module=libcontainerd namespace=moby topic=/tasks/delete type="*events.TaskDelete"
The command '/bin/sh -c yarn' returned a non-zero code: 1
```

Probably caused by updating node version in package.json 4 weeks ago: https://github.com/acl-services/paprika/pull/1042/files?w=1#diff-2c8effdf840690ccb88c7e21e56148978c6adb2c6926530c58ff0e47a9588b44R1