### PR TITLE
fix(ListBoxWithTags): ADM-1775 Fix ListBoxWithTags focus after selecting an option

### DIFF
--- a/.changeset/kind-forks-begin.md
+++ b/.changeset/kind-forks-begin.md
@@ -1,0 +1,6 @@
+---
+"@paprika/list-box-with-tags": patch
+---
+
+- Fixed issue where the Popover is not dismissable by clicking outside after selecting an option 
+- It will now refocus on the next element available, or the Filter input (if no options available) when selecting an option

--- a/.changeset/stupid-gifts-bathe.md
+++ b/.changeset/stupid-gifts-bathe.md
@@ -1,0 +1,7 @@
+---
+"@paprika/list-box": minor
+---
+
+Added additional imperative functions for focusing:
+- Focus by option index in ListBox
+- Focus on ListBox.Filter input

--- a/packages/ListBox/src/components/Filter/Filter.js
+++ b/packages/ListBox/src/components/Filter/Filter.js
@@ -28,6 +28,10 @@ const Filter = React.forwardRef((props, ref) => {
       applyFilter(dispatch, applyFilterType)([], false);
       setTextSearch("");
     },
+    focus: () => {
+      refFilterInput.current.focus();
+    },
+    textSearch,
   }));
 
   const handleChangeFilter = event => {

--- a/packages/ListBox/src/imperative/imperative.js
+++ b/packages/ListBox/src/imperative/imperative.js
@@ -22,6 +22,16 @@ const handleImperative = ({ state, dispatch, onChangeContext }) => () => {
     focus: () => {
       state.refTrigger.current.focus();
     },
+    setFocusOptionByIndex: index => {
+      const optionElement = state.refListBox.current.childNodes[index];
+      optionElement.focus();
+      dispatch({
+        type: useListBox.types.setActiveOption,
+        payload: {
+          activeOptionIndex: index,
+        },
+      });
+    },
     toggleSelectedOption: index => {
       toggleOption({
         index,

--- a/packages/ListBoxWithTags/src/ListBoxWithTags.js
+++ b/packages/ListBoxWithTags/src/ListBoxWithTags.js
@@ -39,7 +39,7 @@ export default function ListBoxWithTags(props) {
 
   const validSize = Object.values(ListBox.types.size).includes(size) ? size : ListBox.types.size.MEDIUM;
 
-  function handleLastSelectedOption(options, selectedOption) {
+  function handleLastSelectedOption(selectedOption, options) {
     const lastIndex = Object.keys(options).length - 1;
     if (lastIndex === 0 || refFilter.current.textSearch) {
       setLastSelectedOption(null);
@@ -68,8 +68,9 @@ export default function ListBoxWithTags(props) {
   }
 
   function handleChange(...args) {
+    const [newSelectedOptions, options] = args;
     if (selectedOptions !== null && "length" in selectedOptions) {
-      handleLastSelectedOption(args[1], args[2]);
+      handleLastSelectedOption(newSelectedOptions[0], options);
       if (refFilter.current) {
         refFilter.current.reset();
         refFilter.current.focus();

--- a/packages/ListBoxWithTags/src/ListBoxWithTags.js
+++ b/packages/ListBoxWithTags/src/ListBoxWithTags.js
@@ -33,9 +33,22 @@ export default function ListBoxWithTags(props) {
   const { t } = useI18n();
   const refDivRoot = React.useRef(null);
   const refFilter = React.useRef(null);
+  const refListBox = React.useRef(null);
   const [idListBoxContent] = React.useState(() => `list-box_${uuidv4()}__content`);
+  const [lastSelectedOption, setLastSelectedOption] = React.useState(null);
 
   const validSize = Object.values(ListBox.types.size).includes(size) ? size : ListBox.types.size.MEDIUM;
+
+  function handleLastSelectedOption(options, selectedOption) {
+    const lastIndex = Object.keys(options).length - 1;
+    if (lastIndex === 0 || refFilter.current.textSearch) {
+      setLastSelectedOption(null);
+    } else if (selectedOption === lastIndex) {
+      setLastSelectedOption(lastIndex - 1);
+    } else {
+      setLastSelectedOption(selectedOption);
+    }
+  }
 
   function handleKeyDown(event) {
     const label = event.target.value;
@@ -47,13 +60,20 @@ export default function ListBoxWithTags(props) {
     ) {
       event.stopPropagation();
       onAddCustomOption(label);
-      refFilter.current.reset();
+      if (refFilter.current) {
+        refFilter.current.reset();
+        refFilter.current.focus();
+      }
     }
   }
 
   function handleChange(...args) {
     if (selectedOptions !== null && "length" in selectedOptions) {
-      refFilter.current.reset();
+      handleLastSelectedOption(args[1], args[2]);
+      if (refFilter.current) {
+        refFilter.current.reset();
+        refFilter.current.focus();
+      }
     }
 
     onChange(...args);
@@ -92,9 +112,17 @@ export default function ListBoxWithTags(props) {
     });
   }, [children, extendedProps]);
 
+  React.useEffect(() => {
+    if (refListBox.current && refFilter.current) {
+      if (lastSelectedOption !== null && !refFilter.current.textSearch) {
+        refListBox.current.setFocusOptionByIndex(lastSelectedOption);
+      }
+    }
+  });
+
   return (
     <div ref={refDivRoot}>
-      <ListBox isMulti size={validSize} onChange={handleChange} {...moreProps}>
+      <ListBox ref={refListBox} isMulti size={validSize} onChange={handleChange} {...moreProps}>
         <ListBox.Trigger {...extendedProps["ListBox.Trigger"]}>
           {(...[, , , attributes]) => <TriggerWithTags {...triggerProps} {...attributes} />}
         </ListBox.Trigger>


### PR DESCRIPTION
### Purpose 🚀
After selecting an option in  `<ListBoxWithTags>`, the option is removed from the list and the 'focus' is lost from the ListBox.
As a result, if the user tries to dismiss the popover list by clicking outside of it, it will not be dismissed, until the user refocuses the ListBox (i.e. click on the filter input). 

### Notes ✏️
- Add new imperative functions for focusing in ListBox and ListBox.Filter. This allows to focus a listbox option by its index in the option list.
- ListBoxWithTags will now remember the last selected option, and try to update the focus upon render (since the component rerenders every time you select an option). If no options are left, then it will default to focusing on the filter input.
- If the user uses the filter and selects an option, it will be defaulted to focus on the filter. 
- Resolving this focus issue also fixes and allows for keyboard accessibility support now, since it was previously broken as well.

These changes will also need to be ported over to sriracha's `<UserLookup>`

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/ADM-1775-fix-listbox-focus-on-rerender

### Screenshots 📸
![listboxwithtags_refocus_fix](https://user-images.githubusercontent.com/83314590/121609833-91871e80-ca09-11eb-8df5-564e8a511231.gif)


### References 🔗
https://aclgrc.atlassian.net/browse/ADM-1775
