### PR TITLE
ADM-1775 Fix ListBoxWithTags refocus on an undefined option after selecting last option

### DIFF
--- a/.changeset/smooth-pigs-promise.md
+++ b/.changeset/smooth-pigs-promise.md
@@ -1,0 +1,5 @@
+---
+"@paprika/list-box-with-tags": patch
+---
+
+- Fixed option refocus being undefined when selecting the last option with a null second last option. 

--- a/packages/ListBoxWithTags/src/ListBoxWithTags.js
+++ b/packages/ListBoxWithTags/src/ListBoxWithTags.js
@@ -41,7 +41,7 @@ export default function ListBoxWithTags(props) {
 
   function handleLastSelectedOption(selectedOption, options) {
     const lastIndex = Object.keys(options).length - 1;
-    if (lastIndex === 0 || refFilter.current.textSearch) {
+    if (lastIndex === 0 || refFilter.current.textSearch || options[lastIndex - 1].hasLabel === undefined) {
       setLastSelectedOption(null);
     } else if (selectedOption === lastIndex) {
       setLastSelectedOption(lastIndex - 1);


### PR DESCRIPTION
### Purpose 🚀
In `<UserLookup>`, the underlying `<ListBoxWithTags>` could include options that are 'group dividers'. As a result, if you selected the last option in the list as well as its 'group', it will throw an error since it tries to refocus on the second to last item (which is the 'group divider', and since that disappears as well and the index becomes undefined)

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/ADM-1775-patch-fix-listboxwithtags-focus

### Screenshots 📸
**Issue seen in `<UserLookup>`:**
![broken_listbox](https://user-images.githubusercontent.com/83314590/122129333-cbca3480-cdea-11eb-8f33-cc9dbf0cd299.gif)

**Expected behaviour (it is fixed in UserLookup already when it uses the underlying ListBox instead of ListBoxWithTags):**
![expected_listbox](https://user-images.githubusercontent.com/83314590/122129320-c836ad80-cdea-11eb-900b-9623a36bcd1e.gif)



### References 🔗
Followup fix to https://github.com/acl-services/paprika/pull/1080