### PR TITLE
feat(ListBox): ADM-1844 Expose ListBox.Content to spread props.

### DIFF
--- a/.changeset/twenty-rats-hug.md
+++ b/.changeset/twenty-rats-hug.md
@@ -1,0 +1,5 @@
+---
+"@paprika/list-box": minor
+---
+
+- Exposed and added ListBox.Content allowing to spread props on the content container

--- a/packages/ListBox/src/ListBox.js
+++ b/packages/ListBox/src/ListBox.js
@@ -41,6 +41,7 @@ export function ListBox(props) {
     filter,
     footer,
     trigger: _trigger,
+    content,
     /* eslint-enable react/prop-types */
 
     ...moreProps
@@ -55,6 +56,7 @@ export function ListBox(props) {
   const onCancelFooter = footer ? footer.props.onClickCancel : null;
   const noResultsMessage = filter ? filter.props.noResultsMessage || I18n.t("listBox.filter.no_results_message") : null;
   const boxProps = box ? box.props : null;
+  const contentProps = content ? { ...content.props, onCancelFooter } : { onCancelFooter };
   /* eslint-enable react/prop-types */
 
   const propsForTrigger = {
@@ -62,10 +64,6 @@ export function ListBox(props) {
     hasImplicitAll,
     onClickClear: null,
     onClickFooterAccept,
-  };
-
-  const contentProps = {
-    onCancelFooter,
   };
 
   const listProps = {
@@ -127,6 +125,7 @@ const ListBoxContainer = React.forwardRef((props, ref) => {
     footer,
     popover,
     trigger,
+    content,
     /* eslint-enable react/prop-types */
 
     ...moreProps
@@ -165,6 +164,7 @@ const ListBoxContainer = React.forwardRef((props, ref) => {
     filter,
     footer,
     trigger,
+    content,
 
     ...(providedProps.isInline ? moreProps : {}),
   };

--- a/packages/ListBox/src/components/Content/Content.js
+++ b/packages/ListBox/src/components/Content/Content.js
@@ -64,6 +64,7 @@ export default function Content(props) {
   return (
     <sc.PopoverContent
       {...getDOMAttributesForListBox({ idListBox, refLabel, ...state })}
+      {...moreProps}
       contentOffsetX={contentOffsetX}
       contentOffsetY={contentOffsetY}
       onBlur={handleBlur(state, dispatch, onCancelFooter)}
@@ -75,6 +76,8 @@ export default function Content(props) {
     </sc.PopoverContent>
   );
 }
+
+Content.displayName = "ListBox.Content";
 
 Content.propTypes = {
   children: PropTypes.node.isRequired,

--- a/packages/ListBox/src/components/Content/Content.js
+++ b/packages/ListBox/src/components/Content/Content.js
@@ -63,8 +63,8 @@ export default function Content(props) {
 
   return (
     <sc.PopoverContent
-      {...getDOMAttributesForListBox({ idListBox, refLabel, ...state })}
       {...moreProps}
+      {...getDOMAttributesForListBox({ idListBox, refLabel, ...state })}
       contentOffsetX={contentOffsetX}
       contentOffsetY={contentOffsetY}
       onBlur={handleBlur(state, dispatch, onCancelFooter)}

--- a/packages/ListBox/src/index.js
+++ b/packages/ListBox/src/index.js
@@ -5,6 +5,7 @@ import { extractChildrenProps, extractChildren } from "@paprika/helpers";
 import ListBox, { propTypes, defaultProps } from "./ListBox";
 import Divider from "./components/Divider";
 import Box from "./components/Box/BoxShell";
+import Content from "./components/Content";
 import Filter from "./components/Filter";
 import Footer from "./components/Footer";
 import Option from "./components/Option";
@@ -62,6 +63,7 @@ const ListBoxWithProvider = React.forwardRef((props, ref) => {
     "ListBox.Footer": footer,
     "ListBox.Popover": popover,
     "ListBox.Trigger": trigger,
+    "ListBox.Content": content,
     children: options,
   } = extractChildren(_children, [
     "ListBox.Box",
@@ -69,6 +71,7 @@ const ListBoxWithProvider = React.forwardRef((props, ref) => {
     "ListBox.Footer",
     "ListBox.Popover",
     "ListBox.Trigger",
+    "ListBox.Content",
   ]);
 
   const a11yProps = extractChildrenProps(_children, A11y);
@@ -98,6 +101,7 @@ const ListBoxWithProvider = React.forwardRef((props, ref) => {
             footer={footer}
             popover={popover}
             trigger={trigger}
+            content={content}
             ref={ref}
           >
             {options}
@@ -119,6 +123,7 @@ ListBoxWithProvider.Option = Option;
 ListBoxWithProvider.Popover = Popover;
 ListBoxWithProvider.RawItem = RawItem;
 ListBoxWithProvider.Trigger = Trigger;
+ListBoxWithProvider.Content = Content;
 
 ListBoxWithProvider.displayName = "ListBox";
 ListBoxWithProvider.propTypes = propTypes;

--- a/packages/ListBox/test/specs/single/ListBox.single.spec.js
+++ b/packages/ListBox/test/specs/single/ListBox.single.spec.js
@@ -121,4 +121,18 @@ describe("ListBox single select", () => {
     const { container } = renderComponent();
     expect(await axe(container)).toHaveNoViolations();
   });
+
+  it("should spread props to ListBox subcomponents", () => {
+    const { openSelect, getByTestId } = renderComponent({}, [
+      <ListBox.Content key="content" data-testid="test-content" />,
+      <ListBox.Filter key="filter" data-testid="test-filter" />,
+      <ListBox.Box key="box" data-testid="test-box" />,
+      [...childrenContent],
+    ]);
+
+    openSelect();
+    expect(getByTestId("popover.content").getAttribute("data-testid")).toEqual("test-content");
+    expect(getByTestId("list-filter-input").getAttribute("data-testid")).toEqual("test-filter");
+    expect(getByTestId("list-box-box").getAttribute("data-testid")).toEqual("test-box");
+  });
 });


### PR DESCRIPTION
### Purpose 🚀
There are times where consumers (such as `UserLookup`) would need to adjust or customize the styling of the listbox popover content. This CL addresses to expose the `<ListBox.Content>` subcomponent to spread props down.

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/ADM-1844-expose-listbox-content-api

### References 🔗
_relevant Jira ticket / GitHub issues_
https://aclgrc.atlassian.net/browse/ADM-1844