### PR TITLE
RAPRM-2168 variables takeover copy input

### DIFF
--- a/.changeset/pink-pots-cough.md
+++ b/.changeset/pink-pots-cough.md
@@ -1,0 +1,5 @@
+---
+"@paprika/copy-input": minor
+---
+
+Addding popover shell and use of clipboard API

--- a/packages/CopyInput/src/CopyInput.js
+++ b/packages/CopyInput/src/CopyInput.js
@@ -38,17 +38,17 @@ function CopyInput(props) {
     const textToCopy = inputRef.current.value;
     if (navigator.clipboard) {
       navigator.clipboard.writeText(textToCopy);
+    } else {
+      // Fall back browser support
+      const textbox = document.createElement("textarea");
+      const activator = document.activeElement;
+      document.body.appendChild(textbox);
+      textbox.value = textToCopy;
+      textbox.select();
+      activator.focus();
+      document.execCommand("copy");
+      document.body.removeChild(textbox);
     }
-    // Fall back browser support
-    const textbox = document.createElement("textarea");
-    const activator = document.activeElement;
-    document.body.appendChild(textbox);
-    textbox.value = textToCopy;
-    textbox.select();
-    activator.focus();
-    document.execCommand("copy");
-    document.body.removeChild(textbox);
-
     setIsClickedTooltipOpen(true);
     setIsHoverTooltipOpen(false);
   }

--- a/packages/CopyInput/src/CopyInput.js
+++ b/packages/CopyInput/src/CopyInput.js
@@ -9,12 +9,14 @@ import { extractChildrenProps } from "@paprika/helpers";
 import CopyIcon from "@paprika/icon/lib/Clipboard";
 import CopyInputInputPropsCollector from "./components/Input/Input";
 import CopyInputButtonPropsCollector from "./components/Button/Button";
+import CopyInputPopoverPropsCollector from "./components/Popover/Popover";
 import * as sc from "./CopyInput.styles";
 
 function CopyInput(props) {
   const { children, isReadOnly, hasInputContainer, hasValueContainer, value, ...moreProps } = props;
   const extendedInputProps = extractChildrenProps(children, CopyInputInputPropsCollector);
   const extendedButtonProps = extractChildrenProps(children, CopyInputButtonPropsCollector);
+  const extendedPopoverProps = extractChildrenProps(children, CopyInputPopoverPropsCollector);
   const I18n = useI18n();
   const inputRef = React.createRef();
   const buttonRef = React.createRef();
@@ -34,6 +36,10 @@ function CopyInput(props) {
 
   function handleButtonClick() {
     const textToCopy = inputRef.current.value;
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(textToCopy);
+    }
+    // Fall back browser support
     const textbox = document.createElement("textarea");
     const activator = document.activeElement;
     document.body.appendChild(textbox);
@@ -75,6 +81,7 @@ function CopyInput(props) {
         isDark
         isEager
         isOpen={isHoverTooltipOpen && !isClickedTooltipOpen}
+        {...extendedPopoverProps}
       >
         <Popover.Content>
           <Popover.Card>{I18n.t("copyInput.hover_tooltip")}</Popover.Card>
@@ -86,6 +93,7 @@ function CopyInput(props) {
         getPositioningElement={() => buttonRef.current}
         isOpen={isClickedTooltipOpen}
         shouldKeepFocus
+        {...extendedPopoverProps}
       >
         <Popover.Content>
           <Popover.Card>{I18n.t("copyInput.clicked_tooltip")}</Popover.Card>
@@ -128,5 +136,6 @@ CopyInput.defaultProps = defaultProps;
 
 CopyInput.Input = CopyInputInputPropsCollector;
 CopyInput.Button = CopyInputButtonPropsCollector;
+CopyInput.Popover = CopyInputPopoverPropsCollector;
 
 export default CopyInput;

--- a/packages/CopyInput/src/components/Popover/Popover.js
+++ b/packages/CopyInput/src/components/Popover/Popover.js
@@ -1,0 +1,8 @@
+import React from "react";
+
+// Shell component for enhancing DX (developer experience)
+export default function Popover() {
+  return <></>;
+}
+
+Popover.displayName = "CopyInput.Popover";

--- a/packages/CopyInput/src/components/Popover/index.js
+++ b/packages/CopyInput/src/components/Popover/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Popover";

--- a/packages/CopyInput/stories/variations/Variations.js
+++ b/packages/CopyInput/stories/variations/Variations.js
@@ -16,6 +16,10 @@ const CopyInputVariations = () => {
         <CopyInput.Input hasError />
       </CopyInput>
       <Gap.Small />
+      <CopyInput value="Popover shell used">
+        <CopyInput.Popover offset={50} minWidth={300} align="right" />
+      </CopyInput>
+      <Gap.Small />
       <CopyInput hasValueContainer hasInputContainer={false} value="hasInputContainer and hasValueContainer prop used">
         <CopyInput.Button kind="minor" />
       </CopyInput>


### PR DESCRIPTION
### Purpose 🚀
https://aclgrc.atlassian.net/browse/RAPRM-2168-variables-takeover-copy-input

Adding support for Popover shell, as needed in variablesTakeover, specifically need for `Zindex` and `scrollContainer` props. Also, given reports of issues with the copy input, we have decided to opt into using the `Clipboard` API, as it is async, it has better performance when copying larger inputs, and also allows copying of variables (which would be preferred in our case) (and possibly copy of images may be easier in future)

https://web.dev/async-clipboard/
https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API

### Notes ✏️

Since `Clipboard` is not supported in IE, we are using the old logic as a safety net if the Clipboard is not supported.

Note: Permission must be requested for read events (**we use write**) e.g.
`navigator.clipboard.readText().then(
  clipText => document.querySelector(".editor").innerText += clipText);`


### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/RAPRM-2168-variables-takeover-copy-input

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
