### PR TITLE
UXD-1348 fix(Sortable): add isSemantic false to sortable.item delete button

### DIFF
--- a/.changeset/strange-mails-tie.md
+++ b/.changeset/strange-mails-tie.md
@@ -1,0 +1,5 @@
+---
+"@paprika/sortable": minor
+---
+
+Added isSemantic false to Sortable.Item delete button

--- a/packages/Sortable/CHANGELOG.md
+++ b/packages/Sortable/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Added isSemantic false to Sortable.Item delete button
+
 ## 1.1.13
 
 ### Patch Changes

--- a/packages/Sortable/CHANGELOG.md
+++ b/packages/Sortable/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog
 
-- Added isSemantic false to Sortable.Item delete button
-
 ## 1.1.13
 
 ### Patch Changes

--- a/packages/Sortable/src/components/SortableItem/SortableItem.js
+++ b/packages/Sortable/src/components/SortableItem/SortableItem.js
@@ -62,10 +62,11 @@ const SortableItem = ({ children, index, handleElement, hasNumbers, isDragDisabl
           {onRemove && (
             <div css={itemCloseStyles} data-pka-anchor="sortable.item.remove">
               <Button.Icon
-                onClick={handleRemove}
-                kind={Button.Icon.types.kind.MINOR}
-                size={Button.Icon.types.size.MEDIUM}
                 a11yText={I18n.t("sortable.aria_remove")}
+                isSemantic={false}
+                kind={Button.Icon.types.kind.MINOR}
+                onClick={handleRemove}
+                size={Button.Icon.types.size.MEDIUM}
               >
                 <TrashbinIcon color={tokens.color.blackLighten20} />
               </Button.Icon>


### PR DESCRIPTION
### Purpose 🚀
Render remove button as a `<span>` instead of a `<button>` to make it more resilient to global CSS.

### Notes ✏️
Ticket : https://aclgrc.atlassian.net/browse/UXD-1348

### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
