### PR TITLE
fix(Breadcrumbs): UXD-1356 Support using any custom component/element…

### DIFF
--- a/.changeset/sweet-steaks-do.md
+++ b/.changeset/sweet-steaks-do.md
@@ -1,0 +1,5 @@
+---
+"@paprika/breadcrumbs": patch
+---
+
+Support using any custom component/element as Breadcrumbs.Link

--- a/.changeset/sweet-steaks-do.md
+++ b/.changeset/sweet-steaks-do.md
@@ -1,5 +1,6 @@
 ---
-"@paprika/breadcrumbs": patch
+"@paprika/breadcrumbs": minor
 ---
 
-Support using any custom component/element as Breadcrumbs.Link
+- Support using any custom component/element as Breadcrumbs.Link
+- Remove the arrow icon

--- a/packages/Breadcrumbs/src/components/Link/Link.js
+++ b/packages/Breadcrumbs/src/components/Link/Link.js
@@ -20,17 +20,18 @@ function Link(props) {
   const isDark = React.useContext(IsDarkContext);
   const I18n = useI18n();
   const shouldTruncate = isString(children) && children.length > MAXIMUM_NUM_OF_CHARACTER;
+  const isLinkAlike = !!href;
   const isUsingDefaultLinkComponent = !as;
   const commonComponentProps = {
     "data-pka-anchor": "breadcrumbs.link",
     as: isUsingDefaultLinkComponent ? Button.Link : as,
+    href: isLinkAlike ? href : undefined,
     isDark,
   };
   const defaultLinkComponentProps = isUsingDefaultLinkComponent
     ? {
         ...commonComponentProps,
         kind: Button.types.kind.MINOR,
-        href,
       }
     : commonComponentProps;
   const arrowIcon = hasOnlyOneChild ? <sc.ArrowIcon aria-label={I18n.t("breadcrumbs.aria_back_to")} /> : null;
@@ -88,7 +89,7 @@ const defaultProps = {
   children: null,
   as: null,
   hasOnlyOneChild: false,
-  href: "",
+  href: null,
 };
 
 Link.displayName = "Breadcrumbs.Link";

--- a/packages/Breadcrumbs/src/components/Link/Link.js
+++ b/packages/Breadcrumbs/src/components/Link/Link.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import Button from "@paprika/button";
 import Popover from "@paprika/popover";
 import useI18n from "@paprika/l10n/lib/useI18n";
 import IsDarkContext from "../../context";
@@ -19,26 +20,53 @@ function Link(props) {
   const isDark = React.useContext(IsDarkContext);
   const I18n = useI18n();
   const shouldTruncate = isString(children) && children.length > MAXIMUM_NUM_OF_CHARACTER;
-
-  const link = (
-    <sc.Link data-pka-anchor="breadcrumbs.link" as={as} kind="minor" href={href} isDark={isDark} {...moreProps}>
-      {hasOnlyOneChild ? <sc.ArrowIcon aria-label={I18n.t("breadcrumbs.aria_back_to")} /> : null}
-      {shouldTruncate ? truncate(children) : children}
-    </sc.Link>
-  );
+  const isUsingDefaultLinkComponent = !as;
+  const commonComponentProps = {
+    "data-pka-anchor": "breadcrumbs.link",
+    as: isUsingDefaultLinkComponent ? Button.Link : as,
+    isDark,
+  };
+  const defaultLinkComponentProps = isUsingDefaultLinkComponent
+    ? {
+        ...commonComponentProps,
+        kind: Button.types.kind.MINOR,
+        href,
+      }
+    : commonComponentProps;
+  const arrowIcon = hasOnlyOneChild ? <sc.ArrowIcon aria-label={I18n.t("breadcrumbs.aria_back_to")} /> : null;
 
   return (
     <sc.ListItem data-pka-anchor="breadcrumbs.list-item">
       {shouldTruncate ? (
         <Popover isDark isEager>
-          <Popover.Trigger>{link}</Popover.Trigger>
+          <Popover.Trigger>
+            {(handler, a11yAttributes) => (
+              <sc.Link
+                {...defaultLinkComponentProps}
+                onMouseOver={handler}
+                onMouseOut={handler}
+                onFocus={handler}
+                onBlur={handler}
+                tabIndex={isUsingDefaultLinkComponent ? undefined : 0}
+                {...a11yAttributes}
+                {...moreProps}
+              >
+                {arrowIcon}
+                {truncate(children)}
+              </sc.Link>
+            )}
+          </Popover.Trigger>
+
           <Popover.Content>
             <Popover.Card>{children}</Popover.Card>
           </Popover.Content>
           <Popover.Tip />
         </Popover>
       ) : (
-        link
+        <sc.Link {...defaultLinkComponentProps} {...moreProps}>
+          {arrowIcon}
+          {children}
+        </sc.Link>
       )}
     </sc.ListItem>
   );

--- a/packages/Breadcrumbs/src/components/Link/Link.js
+++ b/packages/Breadcrumbs/src/components/Link/Link.js
@@ -2,7 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import Button from "@paprika/button";
 import Popover from "@paprika/popover";
-import useI18n from "@paprika/l10n/lib/useI18n";
 import IsDarkContext from "../../context";
 import { MAXIMUM_NUM_OF_CHARACTER } from "../../constants";
 
@@ -18,7 +17,6 @@ function isString(item) {
 function Link(props) {
   const { children, hasOnlyOneChild, href, as, ...moreProps } = props;
   const isDark = React.useContext(IsDarkContext);
-  const I18n = useI18n();
   const shouldTruncate = isString(children) && children.length > MAXIMUM_NUM_OF_CHARACTER;
   const isUsingDefaultLinkComponent = !as;
   const commonComponentProps = {
@@ -33,7 +31,6 @@ function Link(props) {
         kind: Button.types.kind.MINOR,
       }
     : commonComponentProps;
-  const arrowIcon = hasOnlyOneChild ? <sc.ArrowIcon aria-label={I18n.t("breadcrumbs.aria_back_to")} /> : null;
 
   return (
     <sc.ListItem data-pka-anchor="breadcrumbs.list-item">
@@ -51,7 +48,6 @@ function Link(props) {
                 {...a11yAttributes}
                 {...moreProps}
               >
-                {arrowIcon}
                 {truncate(children)}
               </sc.Link>
             )}
@@ -64,7 +60,6 @@ function Link(props) {
         </Popover>
       ) : (
         <sc.Link {...defaultLinkComponentProps} {...moreProps}>
-          {arrowIcon}
           {children}
         </sc.Link>
       )}

--- a/packages/Breadcrumbs/src/components/Link/Link.js
+++ b/packages/Breadcrumbs/src/components/Link/Link.js
@@ -20,12 +20,11 @@ function Link(props) {
   const isDark = React.useContext(IsDarkContext);
   const I18n = useI18n();
   const shouldTruncate = isString(children) && children.length > MAXIMUM_NUM_OF_CHARACTER;
-  const isLinkAlike = !!href;
   const isUsingDefaultLinkComponent = !as;
   const commonComponentProps = {
     "data-pka-anchor": "breadcrumbs.link",
     as: isUsingDefaultLinkComponent ? Button.Link : as,
-    href: isLinkAlike ? href : undefined,
+    href: href || undefined,
     isDark,
   };
   const defaultLinkComponentProps = isUsingDefaultLinkComponent

--- a/packages/Breadcrumbs/src/components/Link/Link.js
+++ b/packages/Breadcrumbs/src/components/Link/Link.js
@@ -25,12 +25,10 @@ function Link(props) {
     href: href || undefined,
     isDark,
   };
-  const defaultLinkComponentProps = isUsingDefaultLinkComponent
-    ? {
-        ...commonComponentProps,
-        kind: Button.types.kind.MINOR,
-      }
-    : commonComponentProps;
+
+  if (isUsingDefaultLinkComponent) {
+    commonComponentProps.kind = Button.types.kind.MINOR;
+  }
 
   return (
     <sc.ListItem data-pka-anchor="breadcrumbs.list-item">
@@ -39,7 +37,7 @@ function Link(props) {
           <Popover.Trigger>
             {(handler, a11yAttributes) => (
               <sc.Link
-                {...defaultLinkComponentProps}
+                {...commonComponentProps}
                 onMouseOver={handler}
                 onMouseOut={handler}
                 onFocus={handler}
@@ -59,7 +57,7 @@ function Link(props) {
           <Popover.Tip />
         </Popover>
       ) : (
-        <sc.Link {...defaultLinkComponentProps} {...moreProps}>
+        <sc.Link {...commonComponentProps} {...moreProps}>
           {children}
         </sc.Link>
       )}

--- a/packages/Breadcrumbs/src/components/Link/Link.styles.js
+++ b/packages/Breadcrumbs/src/components/Link/Link.styles.js
@@ -1,7 +1,6 @@
 import styled from "styled-components";
 import tokens from "@paprika/tokens";
-import { lineHeight, fontSize } from "@paprika/stylers/lib/helpers";
-import ArrowLeftIcon from "@paprika/icon/lib/ArrowLeft";
+import { lineHeight } from "@paprika/stylers/lib/helpers";
 
 export const Link = styled.a`
   color: ${({ isDark }) => (isDark ? tokens.color.white : tokens.textColor.subtle)};
@@ -32,10 +31,4 @@ export const ListItem = styled.li`
   &:first-child::before {
     display: none;
   }
-`;
-
-export const ArrowIcon = styled(ArrowLeftIcon)`
-  ${fontSize(-3)};
-  margin-right: ${tokens.spaceSm};
-  padding: 2px 0;
 `;

--- a/packages/Breadcrumbs/src/components/Link/Link.styles.js
+++ b/packages/Breadcrumbs/src/components/Link/Link.styles.js
@@ -1,10 +1,9 @@
 import styled from "styled-components";
 import tokens from "@paprika/tokens";
 import { lineHeight, fontSize } from "@paprika/stylers/lib/helpers";
-import Button from "@paprika/button";
 import ArrowLeftIcon from "@paprika/icon/lib/ArrowLeft";
 
-export const Link = styled(Button.Link)`
+export const Link = styled.a`
   color: ${({ isDark }) => (isDark ? tokens.color.white : tokens.textColor.subtle)};
   display: inline;
   font-weight: normal;

--- a/packages/Breadcrumbs/stories/examples/AllVariations.js
+++ b/packages/Breadcrumbs/stories/examples/AllVariations.js
@@ -91,15 +91,7 @@ const AllVariations = () => {
       </Heading>
 
       <Breadcrumbs>
-        <Breadcrumbs.Link
-          as="span"
-          style={{
-            fontWeight: "bold",
-            color: "#3f3d3c",
-          }}
-        >
-          Breadcrumb 1 with long content, Breadcrumb 1 with long content.
-        </Breadcrumbs.Link>
+        <Breadcrumbs.Link as="span">Breadcrumb 1</Breadcrumbs.Link>
         <Breadcrumbs.Link href={URL}>Breadcrumb 2</Breadcrumbs.Link>
         <Breadcrumbs.Link href={URL}>Breadcrumb 3</Breadcrumbs.Link>
         <Breadcrumbs.Link href={URL}>Breadcrumb 4 with long content, Breadcrumb 4 with long content.</Breadcrumbs.Link>
@@ -112,8 +104,8 @@ const AllVariations = () => {
       </Heading>
 
       <Breadcrumbs>
-        <Breadcrumbs.Link as="a" href="www.google.com">
-          Breadcrumb 1 with long content, Breadcrumb 1 with long content.
+        <Breadcrumbs.Link as="a" href={URL}>
+          Breadcrumb 1
         </Breadcrumbs.Link>
         <Breadcrumbs.Link href={URL}>Breadcrumb 2</Breadcrumbs.Link>
         <Breadcrumbs.Link href={URL}>Breadcrumb 3</Breadcrumbs.Link>

--- a/packages/Breadcrumbs/stories/examples/AllVariations.js
+++ b/packages/Breadcrumbs/stories/examples/AllVariations.js
@@ -104,6 +104,21 @@ const AllVariations = () => {
         <Breadcrumbs.Link href={URL}>Breadcrumb 3</Breadcrumbs.Link>
         <Breadcrumbs.Link href={URL}>Breadcrumb 4 with long content, Breadcrumb 4 with long content.</Breadcrumbs.Link>
       </Breadcrumbs>
+
+      <Gap />
+
+      <Heading level={3} displayLevel={5} isLight>
+        Customized breadcrumb link
+      </Heading>
+
+      <Breadcrumbs>
+        <Breadcrumbs.Link as="a" href="www.google.com">
+          Breadcrumb 1 with long content, Breadcrumb 1 with long content.
+        </Breadcrumbs.Link>
+        <Breadcrumbs.Link href={URL}>Breadcrumb 2</Breadcrumbs.Link>
+        <Breadcrumbs.Link href={URL}>Breadcrumb 3</Breadcrumbs.Link>
+        <Breadcrumbs.Link href={URL}>Breadcrumb 4 with long content, Breadcrumb 4 with long content.</Breadcrumbs.Link>
+      </Breadcrumbs>
     </>
   );
 };

--- a/packages/Breadcrumbs/stories/examples/AllVariations.js
+++ b/packages/Breadcrumbs/stories/examples/AllVariations.js
@@ -83,6 +83,27 @@ const AllVariations = () => {
       <Breadcrumbs>
         <Breadcrumbs.Link href={URL}>Breadcrumb 1</Breadcrumbs.Link>
       </Breadcrumbs>
+
+      <Gap />
+
+      <Heading level={3} displayLevel={5} isLight>
+        Not clickable breadcrumb item
+      </Heading>
+
+      <Breadcrumbs>
+        <Breadcrumbs.Link
+          as="span"
+          style={{
+            fontWeight: "bold",
+            color: "#3f3d3c",
+          }}
+        >
+          Breadcrumb 1 with long content, Breadcrumb 1 with long content.
+        </Breadcrumbs.Link>
+        <Breadcrumbs.Link href={URL}>Breadcrumb 2</Breadcrumbs.Link>
+        <Breadcrumbs.Link href={URL}>Breadcrumb 3</Breadcrumbs.Link>
+        <Breadcrumbs.Link href={URL}>Breadcrumb 4 with long content, Breadcrumb 4 with long content.</Breadcrumbs.Link>
+      </Breadcrumbs>
     </>
   );
 };


### PR DESCRIPTION
… as Breadcrumbs.Link

https://aclgrc.atlassian.net/browse/UXD-1356

### Purpose 🚀

Support using any custom component/element as Breadcrumbs.Link

- small refactoring on how the popover renders the trigger, to avoid double tab/focus
- only passes the `href` when it's valid 
- added some examples
Test it here http://storybooks.highbond-s3.com/paprika/UXD-1356-adjust-breadcrumbs/?path=/story/navigation-breadcrumbs--variations


### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message

Also noticed there's a design change https://aclgrc.atlassian.net/wiki/spaces/UX/pages/1288077545/Breadcrumbs+approved#Only-two-levels
Updated in this PR as well


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
