### PR TITLE
UXD-1417 breadcrumb link tooltip additional props

### DIFF
--- a/.changeset/fluffy-eels-hope.md
+++ b/.changeset/fluffy-eels-hope.md
@@ -1,0 +1,5 @@
+---
+"@paprika/breadcrumbs": minor
+---
+
+Allow additional props to be set on Breadcrumbs.Link tooltip

--- a/packages/Breadcrumbs/src/components/Link/Link.js
+++ b/packages/Breadcrumbs/src/components/Link/Link.js
@@ -2,6 +2,8 @@ import React from "react";
 import PropTypes from "prop-types";
 import Button from "@paprika/button";
 import Popover from "@paprika/popover";
+import { extractChildren, extractChildrenProps } from "@paprika/helpers";
+import LinkTooltipContentPropsCollector from "./LinkTooltipContentPropsCollector";
 import IsDarkContext from "../../context";
 import { MAXIMUM_NUM_OF_CHARACTER } from "../../constants";
 
@@ -17,7 +19,12 @@ function isString(item) {
 function Link(props) {
   const { children, hasOnlyOneChild, href, as, ...moreProps } = props;
   const isDark = React.useContext(IsDarkContext);
-  const shouldTruncate = isString(children) && children.length > MAXIMUM_NUM_OF_CHARACTER;
+  const {
+    children: [extractedChildren],
+  } = extractChildren(children, ["Breadcrumbs.Link.Tooltip"]);
+
+  const TooltipProps = extractChildrenProps(children, LinkTooltipContentPropsCollector);
+  const shouldTruncate = isString(extractedChildren) && extractedChildren.length > MAXIMUM_NUM_OF_CHARACTER;
   const isUsingDefaultLinkComponent = !as;
   const commonComponentProps = {
     "data-pka-anchor": "breadcrumbs.link",
@@ -46,19 +53,19 @@ function Link(props) {
                 {...a11yAttributes}
                 {...moreProps}
               >
-                {truncate(children)}
+                {truncate(extractedChildren)}
               </sc.Link>
             )}
           </Popover.Trigger>
 
-          <Popover.Content>
-            <Popover.Card>{children}</Popover.Card>
+          <Popover.Content {...TooltipProps}>
+            <Popover.Card>{extractedChildren}</Popover.Card>
           </Popover.Content>
           <Popover.Tip />
         </Popover>
       ) : (
         <sc.Link {...commonComponentProps} {...moreProps}>
-          {children}
+          {extractedChildren}
         </sc.Link>
       )}
     </sc.ListItem>
@@ -85,6 +92,7 @@ const defaultProps = {
 };
 
 Link.displayName = "Breadcrumbs.Link";
+Link.Tooltip = LinkTooltipContentPropsCollector;
 Link.propTypes = propTypes;
 Link.defaultProps = defaultProps;
 

--- a/packages/Breadcrumbs/src/components/Link/LinkTooltipContentPropsCollector.js
+++ b/packages/Breadcrumbs/src/components/Link/LinkTooltipContentPropsCollector.js
@@ -1,0 +1,5 @@
+export default function LinkTooltipContentPropsCollector() {
+  return null;
+}
+
+LinkTooltipContentPropsCollector.displayName = "Breadcrumbs.Link.Tooltip";

--- a/packages/Breadcrumbs/stories/examples/AllVariations.js
+++ b/packages/Breadcrumbs/stories/examples/AllVariations.js
@@ -111,6 +111,21 @@ const AllVariations = () => {
         <Breadcrumbs.Link href={URL}>Breadcrumb 3</Breadcrumbs.Link>
         <Breadcrumbs.Link href={URL}>Breadcrumb 4 with long content, Breadcrumb 4 with long content.</Breadcrumbs.Link>
       </Breadcrumbs>
+
+      <Gap />
+
+      <Heading level={3} displayLevel={5} isLight>
+        Breadcrumb link custom tooltip
+      </Heading>
+
+      <Breadcrumbs>
+        <Breadcrumbs.Link href={URL}>Breadcrumb 2</Breadcrumbs.Link>
+        <Breadcrumbs.Link href={URL}>Breadcrumb 3</Breadcrumbs.Link>
+        <Breadcrumbs.Link href={URL}>
+          Breadcrumb 4 with extra long content, Breadcrumb 4 with extra long content.
+          <Breadcrumbs.Link.Tooltip zIndex={4000} />
+        </Breadcrumbs.Link>
+      </Breadcrumbs>
     </>
   );
 };


### PR DESCRIPTION
### Purpose 🚀
Allow passing additional props to the Breadcrumb Link Tooltip (Popover.Content).
This is required to at least be able to change/set the zIndex on it as it is currently rendering behind some other UI in it's implementation in Visualizer

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/uxd-1417-breadcrumb-link-tooltip-additional-props

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
