### PR TITLE
feat(ActionBar): PDTVT-1584 Support adding a className to the ActionB…

### DIFF
--- a/.changeset/giant-jeans-watch.md
+++ b/.changeset/giant-jeans-watch.md
@@ -1,0 +1,5 @@
+---
+"@paprika/action-bar": patch
+---
+
+Support adding className to the Popover.Content within the ActionBar's ColumnArrangment subcomponent.

--- a/.changeset/giant-jeans-watch.md
+++ b/.changeset/giant-jeans-watch.md
@@ -2,4 +2,4 @@
 "@paprika/action-bar": patch
 ---
 
-Support adding className to the Popover.Content within the ActionBar's ColumnArrangment subcomponent.
+Support adding className to the Popover.Content within the ActionBar's ColumnArrangment and Sort subcomponents.

--- a/packages/ActionBar/src/components/ColumnsArrangement/ColumnsArrangement.js
+++ b/packages/ActionBar/src/components/ColumnsArrangement/ColumnsArrangement.js
@@ -5,9 +5,10 @@ import Input from "@paprika/input";
 import Popover from "@paprika/popover";
 import Sortable from "@paprika/sortable";
 import useI18n from "@paprika/l10n/lib/useI18n";
-import { extractChildren } from "@paprika/helpers";
+import { extractChildren, extractChildrenProps } from "@paprika/helpers";
 import tokens from "@paprika/tokens";
 import ColumnManagingItem from "./ColumnsArrangementItem";
+import PopoverContentPropsCollector from "./PopoverContentPropsCollector";
 import ColumnDefinition from "./ColumnDefinition";
 import * as sc from "./ColumnsArrangement.styles";
 
@@ -62,6 +63,7 @@ export default function ColumnsArrangement(props) {
       },
     };
   }, {});
+  const popoverContentProps = extractChildrenProps(children, PopoverContentPropsCollector);
 
   const hiddenColumns = Object.keys(columns).filter(columnId => columns[columnId].isHidden);
 
@@ -106,7 +108,7 @@ export default function ColumnsArrangement(props) {
           )}
         </Popover.Trigger>
       )}
-      <Popover.Content>
+      <Popover.Content {...popoverContentProps}>
         <Popover.Card>
           <Input
             data-pka-anchor="actionBar.columnsArrangement.filter"
@@ -167,3 +169,4 @@ ColumnsArrangement.propTypes = propTypes;
 ColumnsArrangement.defaultProps = defaultProps;
 ColumnsArrangement.displayName = "ActionBar.ColumnsArrangement";
 ColumnsArrangement.ColumnDefinition = ColumnDefinition;
+ColumnsArrangement.PopoverContent = PopoverContentPropsCollector;

--- a/packages/ActionBar/src/components/ColumnsArrangement/PopoverContentPropsCollector.js
+++ b/packages/ActionBar/src/components/ColumnsArrangement/PopoverContentPropsCollector.js
@@ -1,0 +1,5 @@
+export default function ColumnsArrangementPopoverContentPropsCollector() {
+  return null;
+}
+
+ColumnsArrangementPopoverContentPropsCollector.displayName = "ActionBar.ColumnsArrangement.PopoverContents";

--- a/packages/ActionBar/src/components/Sort/PopoverContentPropsCollector.js
+++ b/packages/ActionBar/src/components/Sort/PopoverContentPropsCollector.js
@@ -1,0 +1,5 @@
+export default function SortPopoverContentPropsCollector() {
+  return null;
+}
+
+SortPopoverContentPropsCollector.displayName = "ActionBar.Sort.PopoverContents";

--- a/packages/ActionBar/src/components/Sort/Sort.js
+++ b/packages/ActionBar/src/components/Sort/Sort.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Button from "@paprika/button";
+import { extractChildrenProps } from "@paprika/helpers";
 import Popover from "@paprika/popover";
 import useI18n from "@paprika/l10n/lib/useI18n";
 import CheckIcon from "@paprika/icon/lib/Check";
@@ -9,6 +10,7 @@ import tokens from "@paprika/tokens";
 import SortField from "./SortField";
 import SortContext from "./context";
 import columnShape from "../../columnShape";
+import PopoverContentPropsCollector from "./PopoverContentPropsCollector";
 
 import * as sc from "./Sort.styles";
 import { GenericNoAppliedPlaceholder } from "../../ActionBar.styles";
@@ -50,6 +52,8 @@ export default function Sort(props) {
   const I18n = useI18n();
   const fieldsRef = React.useRef(null);
   const [isOpen, setIsOpen] = React.useState(false);
+
+  const popoverContentProps = extractChildrenProps(children, PopoverContentPropsCollector);
 
   function handleClickTrigger() {
     setIsOpen(prevIsOpen => {
@@ -103,7 +107,7 @@ export default function Sort(props) {
           <sc.Icon />
           {getLabelText(appliedNumber, I18n)}
         </sc.Trigger>
-        <Popover.Content>
+        <Popover.Content {...popoverContentProps}>
           <Popover.Card>
             <sc.FieldsPanel ref={fieldsRef} tabIndex={-1}>
               {React.Children.count(children) === 0 ? (
@@ -139,3 +143,4 @@ Sort.propTypes = propTypes;
 Sort.defaultProps = defaultProps;
 Sort.displayName = "ActionBar.Sort";
 Sort.Field = SortField;
+Sort.PopoverContent = PopoverContentPropsCollector;

--- a/packages/ActionBar/stories/ShowcaseApp/ShowcaseApp.js
+++ b/packages/ActionBar/stories/ShowcaseApp/ShowcaseApp.js
@@ -77,6 +77,8 @@ export default function App() {
         />
 
         <Sort {...sortProps} columns={columnsSettings}>
+          <Sort.PopoverContent className="add-a-class-to-the-sort-popover-content-wrapper-like-this" />
+
           {sortedFields.map((field, index) => {
             return (
               <Sort.Field
@@ -93,6 +95,8 @@ export default function App() {
         </Sort>
 
         <ColumnsArrangement orderedColumnIds={orderedColumnIds} {...handlers}>
+          <ColumnsArrangement.PopoverContent className="add-a-class-to-the-columnsarrangement-popover-content-wrapper-like-this" />
+
           {columnsSettings.map(column => (
             <ColumnsArrangement.ColumnDefinition
               key={column.id}


### PR DESCRIPTION
…ar's ColumnsArrangment and Sort popovers (since the popovers are added in portals)

### Purpose 🚀
I need to set the z-index of the popover in my app; I can do that by adding a classname to the popover content.



### Storybook 📕
http://storybooks.highbond-s3.com/paprika/pdtvt-1584--sort

### Screenshots 📸
![Screen Shot 2021-09-01 at 3 23 57 PM](https://user-images.githubusercontent.com/23224777/131754013-a98ff1df-4ad6-4e57-8628-3bf5cbdab8b8.png)
