### PR TITLE
UXD-1501 Removed extra focused border of the switch component

### DIFF
--- a/packages/Switch/src/Switch.styles.js
+++ b/packages/Switch/src/Switch.styles.js
@@ -129,7 +129,7 @@ export const Switch = styled(RawButton)(
       ${KnobSizeStyles[size]}
     }
 
-    &:focus {
+    &[data-pka-anchor="switch"]&:focus {
       box-shadow: none;
 
       ${Underlay} {


### PR DESCRIPTION
https://aclgrc.atlassian.net/browse/UXD-1501

### Purpose 🚀
Removed the square border around the switch when navigated through tab

### Notes ✏️
Adjusted the selector to be more specific when focused.

### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
After:
<img width="350" alt="Screen Shot 2021-09-07 at 1 48 29 PM" src="https://user-images.githubusercontent.com/89101720/132408926-a377fa1d-285d-434e-9000-4b8e41ac5ab1.png">


Before:
<img width="350" alt="Screen Shot 2021-09-07 at 11 24 52 AM" src="https://user-images.githubusercontent.com/89101720/132408803-61b07318-4b69-4028-9627-55d7546654e0.png">

### References 🔗
https://aclgrc.atlassian.net/browse/UXD-1500


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
