### PR TITLE
RAPRM-2465 Ensure CopyInput hides input when hasInputContainer is false 🐐

### DIFF
--- a/.changeset/selfish-olives-share.md
+++ b/.changeset/selfish-olives-share.md
@@ -1,0 +1,5 @@
+---
+"@paprika/copy-input": patch
+---
+
+Ensure input container is hidden when hasInputContainer is false.

--- a/packages/CopyInput/src/CopyInput.styles.js
+++ b/packages/CopyInput/src/CopyInput.styles.js
@@ -20,5 +20,7 @@ export const Value = styled.div`
 `;
 
 export const HiddenInput = styled(Input)`
-  display: none;
+  &[data-pka-anchor="input"] {
+    display: none;
+  }
 `;

--- a/packages/CopyInput/stories/variations/Variations.js
+++ b/packages/CopyInput/stories/variations/Variations.js
@@ -1,38 +1,44 @@
 import React from "react";
-import { Gap } from "storybook/assets/styles/common.styles";
+import { Gap, CodeHeading } from "storybook/assets/styles/common.styles";
 import Input from "@paprika/input";
 import CopyInput from "../../src/CopyInput";
 
 const CopyInputVariations = () => {
-  const customInputValue = "this is my custom Input component";
+  const customInputValue = "Custom input component";
 
   return (
     <>
       <CopyInput value="read only" />
-      <Gap.Small />
+      <Gap />
+      <CodeHeading>{"isReadOnly={false}"}</CodeHeading>
       <CopyInput isReadOnly={false} value="edit input" />
-      <Gap.Small />
-      <CopyInput isReadOnly={false} value="an error occurred">
-        <CopyInput.Input hasError />
-      </CopyInput>
-      <Gap.Small />
-      <CopyInput value="Popover shell used">
-        <CopyInput.Popover offset={50} minWidth={300} align="right" />
-      </CopyInput>
-      <Gap.Small />
+      <Gap />
+      <CodeHeading>{"hasValueContainer hasInputContainer={false}"}</CodeHeading>
       <CopyInput hasValueContainer hasInputContainer={false} value="hasInputContainer and hasValueContainer prop used">
         <CopyInput.Button kind="minor" />
       </CopyInput>
-      <Gap.Small />
+      <Gap />
+      <CodeHeading>{"<CopyInput.Input /> a and <CopyInput.Button />"}</CodeHeading>
       <CopyInput isReadOnly={false} value="button kind=default">
         <CopyInput.Input hasClearButton />
         <CopyInput.Button kind="default" />
       </CopyInput>
-      <Gap.Small />
-      <>
-        <Input hasClearButton size={Input.types.size.LARGE} value={customInputValue} />
+      <Gap />
+      <CodeHeading>{"<CopyInput.Input hasError />"}</CodeHeading>
+      <CopyInput isReadOnly={false} value="an error occurred">
+        <CopyInput.Input hasError />
+      </CopyInput>
+      <Gap />
+      <CodeHeading>{"<CopyInput.Popover />"}</CodeHeading>
+      <CopyInput value="Popover shell used">
+        <CopyInput.Popover offset={50} minWidth={300} align="right" />
+      </CopyInput>
+      <Gap />
+      <CodeHeading>{"hasInputContainer={false}"}</CodeHeading>
+      <div style={{ display: "flex" }}>
+        <Input hasClearButton value={customInputValue} />
         <CopyInput hasInputContainer={false} value={customInputValue} />
-      </>
+      </div>
       <Gap.Small />
       <CopyInput value="some value" hasInputContainer={false} />
     </>


### PR DESCRIPTION
### Purpose 🚀
Ensure `<CopyInput hasInputContainer={false}>` hides input field.


### Notes ✏️
- Specificity of CSS was increased to fix an issue with the way `styled-components` applies styles in consuming app.

![Screen Shot 2021-09-14 at 5 09 58 PM](https://user-images.githubusercontent.com/14944896/133350229-dd9ccbac-9e56-466f-8ae9-2065b4326e8b.png)


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/RAPRM-2465--copyinput-hide-input-fix


### References 🔗
https://aclgrc.atlassian.net/browse/RAPRM-2465


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
