### PR TITLE
Pdtvt 1689  button group single

### DIFF
--- a/.changeset/short-parents-try.md
+++ b/.changeset/short-parents-try.md
@@ -1,0 +1,5 @@
+---
+"@paprika/button-group": patch
+---
+
+When there is a single button in the group, all its corners should be rounded

--- a/packages/ButtonGroup/src/ButtonGroup.js
+++ b/packages/ButtonGroup/src/ButtonGroup.js
@@ -118,8 +118,10 @@ const ButtonGroup = React.forwardRef((props, ref) => {
     setItemRefs,
   };
 
+  const hasSingleChild = React.Children.count(children) === 1;
+
   return (
-    <sc.ButtonGroup {...props} ref={groupRef} onKeyDown={handleKeyDown}>
+    <sc.ButtonGroup {...props} ref={groupRef} onKeyDown={handleKeyDown} hasSingleChild={hasSingleChild}>
       <ButtonGroupContext.Provider value={contextValue}>{children}</ButtonGroupContext.Provider>
     </sc.ButtonGroup>
   );

--- a/packages/ButtonGroup/src/ButtonGroup.styles.js
+++ b/packages/ButtonGroup/src/ButtonGroup.styles.js
@@ -14,7 +14,7 @@ const fullWithStyles = css`
 `;
 
 export const ButtonGroup = styled.div(
-  ({ isFullWidth }) => css`
+  ({ isFullWidth, hasSingleChild }) => css`
     display: inline-flex;
     flex-wrap: wrap;
     ${isFullWidth && fullWithStyles}
@@ -33,6 +33,13 @@ export const ButtonGroup = styled.div(
       &:not(:last-child) {
         margin-right: -1px;
       }
+
+      ${hasSingleChild &&
+        css`
+          &:last-child {
+            border-radius: ${tokens.button.borderRadius};
+          }
+        `}
     }
   `
 );

--- a/packages/ButtonGroup/stories/examples/Sandbox.js
+++ b/packages/ButtonGroup/stories/examples/Sandbox.js
@@ -56,6 +56,12 @@ const ExampleStory = props => {
       <p>
         <button onClick={handleFocus}>Focus Post</button>
       </p>
+      <Rule />
+      <ButtonGroup {...props} ref={refButtonGroup}>
+        <ButtonGroup.Item value="one" kind={ButtonGroup.Item.types.kind.PRIMARY}>
+          A single button in the group
+        </ButtonGroup.Item>
+      </ButtonGroup>
     </Story>
   );
 };


### PR DESCRIPTION
### Purpose 🚀

Before (left edge is square):
![Screen Shot 2021-09-21 at 11 31 46 AM](https://user-images.githubusercontent.com/23224777/134227570-cdcbaf4f-e0fb-49ad-8e67-b0d251d37385.png)


After (left edge is round):
![Screen Shot 2021-09-21 at 11 31 38 AM](https://user-images.githubusercontent.com/23224777/134227573-fa2dd766-5ed8-4eb9-af54-efc9993ac7b5.png)


