### PR TITLE
UXD-1592  Alignment of Breadcrumbs 🐐

### DIFF
--- a/.changeset/pretty-hats-divide.md
+++ b/.changeset/pretty-hats-divide.md
@@ -1,0 +1,5 @@
+---
+"@paprika/breadcrumbs": minor
+---
+
+Adjust padding of `<Breadcrumbs.Link>` to align consistently with surrounding content.

--- a/packages/Breadcrumbs/src/Breadcrumbs.styles.js
+++ b/packages/Breadcrumbs/src/Breadcrumbs.styles.js
@@ -1,36 +1,34 @@
 import styled, { css } from "styled-components";
 import tokens from "@paprika/tokens";
-import { fontSize, lineHeight } from "@paprika/stylers/lib/helpers";
-import { Link } from "./components/Link/Link.styles";
+import stylers from "@paprika/stylers";
 
-export const Nav = styled.nav`
-  color: ${({ isDark }) => (isDark ? tokens.color.white : tokens.textColor.subtle)};
-  font-weight: bold;
-  ${fontSize(-2)}
-  ${lineHeight()}
+export const Nav = styled.nav(
+  ({ isDark }) => css`
+    ${stylers.fontSize(-2)}
+    ${stylers.lineHeight()}
+    color: ${isDark ? tokens.color.white : tokens.textColor.subtle};
+    font-weight: bold;
+  `
+);
 
-  ${Link} {
-    ${fontSize(-2)}
-  }
-`;
+export const List = styled.ol(
+  ({ isCollapsed }) => css`
+    display: inline;
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
 
-export const List = styled.ol`
-  display: inline;
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
+    ${isCollapsed &&
+      css`
+        li[data-pka-anchor="breadcrumbs.list-item"] {
+          display: none;
 
-  ${({ isCollapsed }) =>
-    isCollapsed &&
-    css`
-      li[data-pka-anchor="breadcrumbs.list-item"] {
-        display: none;
-
-        &:first-child,
-        &:nth-last-child(1),
-        &:nth-last-child(2) {
-          display: inline;
+          &:first-child,
+          &:nth-last-child(1),
+          &:nth-last-child(2) {
+            display: inline;
+          }
         }
-      }
-    `}
-`;
+      `}
+  `
+);

--- a/packages/Breadcrumbs/src/components/ExpandButton/ExpandButton.styles.js
+++ b/packages/Breadcrumbs/src/components/ExpandButton/ExpandButton.styles.js
@@ -1,26 +1,30 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import tokens from "@paprika/tokens";
 import Button from "@paprika/button";
 
-export const ExpandButton = styled(Button.Icon)`
-  color: ${({ isDark }) => (isDark ? tokens.color.white : tokens.textColor.subtle)};
-  height: 20px;
-  margin: -1px ${tokens.spaceSm} 0;
-  min-height: 20px;
-  width: 20px;
+export const ExpandButton = styled(Button.Icon)(
+  ({ isDark }) => css`
+    color: ${isDark ? tokens.color.white : tokens.textColor.subtle};
+    height: 20px;
+    margin: -3px ${tokens.spaceSm} 0;
+    min-height: 20px;
+    width: 20px;
 
-  &:hover {
-    background-color: ${({ isDark }) => (isDark ? tokens.color.blackLighten10 : tokens.color.blackLighten70)};
-  }
-`;
+    &:hover {
+      background-color: ${isDark ? tokens.color.blackLighten10 : tokens.color.blackLighten70};
+    }
+  `
+);
 
-export const ExpandButtonWrapper = styled.li`
-  display: ${({ isHidden }) => (isHidden ? "none" : "inline")};
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
+export const ExpandButtonWrapper = styled.li(
+  ({ isHidden }) => css`
+    display: ${isHidden ? "none" : "inline"};
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
 
-  &::before {
-    content: "/";
-  }
-`;
+    &::before {
+      content: "/";
+    }
+  `
+);

--- a/packages/Breadcrumbs/src/components/Link/Link.js
+++ b/packages/Breadcrumbs/src/components/Link/Link.js
@@ -44,7 +44,7 @@ function Link(props) {
   }
 
   return (
-    <sc.ListItem data-pka-anchor="breadcrumbs.list-item">
+    <sc.ListItem data-pka-anchor="breadcrumbs.list-item" isUsingDefaultLinkComponent={isUsingDefaultLinkComponent}>
       {shouldTruncate ? (
         <Popover isDark isEager>
           <Popover.Trigger>

--- a/packages/Breadcrumbs/src/components/Link/Link.styles.js
+++ b/packages/Breadcrumbs/src/components/Link/Link.styles.js
@@ -1,37 +1,43 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import tokens from "@paprika/tokens";
 import stylers from "@paprika/stylers";
 import ArrowLeftIcon from "@paprika/icon/lib/ArrowLeft";
 
-export const Link = styled.a`
+export const Link = styled.a(
+  ({ isDark }) => css`
   ${stylers.lineHeight()}
-  color: ${({ isDark }) => (isDark ? tokens.color.white : tokens.textColor.subtle)};
+  ${stylers.fontSize(-2)}
+  color: ${isDark ? tokens.color.white : tokens.textColor.subtle};
   display: inline;
   font-weight: normal;
+  margin: 0 ${tokens.spaceSm};
   min-height: 0;
-  padding: 0 ${tokens.space};
+  padding: 0 3px;
   text-decoration: none;
   vertical-align: top;
-`;
+`
+);
 
-export const ListItem = styled.li`
-  display: inline;
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
+export const ListItem = styled.li(
+  ({ isUsingDefaultLinkComponent }) => css`
+    display: inline;
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
 
-  &::before {
-    content: "/";
-  }
+    &::before {
+      content: "/";
+    }
 
-  &:first-child {
-    margin-left: -${tokens.space};
-  }
+    &:first-child {
+      margin-left: ${isUsingDefaultLinkComponent ? `-${tokens.space}` : "-7px"};
+    }
 
-  &:first-child::before {
-    display: none;
-  }
-`;
+    &:first-child::before {
+      display: none;
+    }
+  `
+);
 
 export const BackIcon = styled(ArrowLeftIcon)`
   ${stylers.fontSize(-1)};

--- a/packages/Breadcrumbs/stories/Breadcrumbs.examples.stories.js
+++ b/packages/Breadcrumbs/stories/Breadcrumbs.examples.stories.js
@@ -1,0 +1,23 @@
+import React from "react";
+import { getStoryName } from "storybook/storyTree";
+import { exampleStoryParameters } from "storybook/assets/storyParameters";
+import { Gap } from "storybook/assets/styles/common.styles";
+import ExampleStory from "storybook/components/ExampleStory";
+import Alignment from "./examples/Alignment";
+import Breadcrumbs from "../src";
+
+export default {
+  title: `${getStoryName("Breadcrumbs")}/Examples`,
+  component: Breadcrumbs,
+};
+
+export const alignment = () => (
+  <ExampleStory storyName="Alignment" component="Breadcrumbs" fileName="examples/Alignment.js">
+    <Gap.Small />
+    <Alignment />
+  </ExampleStory>
+);
+alignment.story = {
+  name: "Alignment",
+  parameters: exampleStoryParameters,
+};

--- a/packages/Breadcrumbs/stories/Breadcrumbs.stories.js
+++ b/packages/Breadcrumbs/stories/Breadcrumbs.stories.js
@@ -20,7 +20,12 @@ showcase.story = {
 };
 
 export const variations = () => (
-  <ExampleStory storyName="Breadcrumbs" tagline={ExampleStory.defaultTaglines.variations}>
+  <ExampleStory
+    storyName="Breadcrumbs"
+    tagline={ExampleStory.defaultTaglines.variations}
+    component="Breadcrumbs"
+    fileName="examples/Variations.js"
+  >
     <Gap.Small />
     <Variations />
   </ExampleStory>

--- a/packages/Breadcrumbs/stories/examples/Alignment.js
+++ b/packages/Breadcrumbs/stories/examples/Alignment.js
@@ -1,0 +1,83 @@
+import React from "react";
+import { Gap, CodeHeading } from "storybook/assets/styles/common.styles";
+import StoryHeading from "storybook/components/StoryHeading";
+import Heading from "@paprika/heading";
+import Breadcrumbs from "../../src";
+
+const URL = "https://www.wegalvanize.com/";
+
+const AllVariations = () => {
+  return (
+    <>
+      <StoryHeading level={2}>Regular text</StoryHeading>
+      <Gap.Small />
+      <CodeHeading>{"<Breadcrumbs.Link>"}</CodeHeading>
+      <Breadcrumbs>
+        <Breadcrumbs.Link href={URL}>Breadcrumb</Breadcrumbs.Link>
+        <Breadcrumbs.Link href={URL}>Breadcrumb</Breadcrumbs.Link>
+      </Breadcrumbs>
+      <div>Heading</div>
+      <Gap />
+      <CodeHeading>{'<Breadcrumbs.Link as="a">'}</CodeHeading>
+      <Breadcrumbs>
+        <Breadcrumbs.Link as="a" href={URL}>
+          Breadcrumb
+        </Breadcrumbs.Link>
+        <Breadcrumbs.Link href={URL}>Breadcrumb</Breadcrumbs.Link>
+      </Breadcrumbs>
+      <div>Heading</div>
+      <Gap />
+      <CodeHeading>{'<Breadcrumbs.Link as="span">'}</CodeHeading>
+      <Breadcrumbs>
+        <Breadcrumbs.Link as="span">Breadcrumb</Breadcrumbs.Link>
+        <Breadcrumbs.Link href={URL}>Breadcrumb</Breadcrumbs.Link>
+      </Breadcrumbs>
+      <div>Heading</div>
+      <Gap />
+      <CodeHeading>
+        {"<Breadcrumbs.Link>"} <span>x 1</span>
+      </CodeHeading>
+      <Breadcrumbs>
+        <Breadcrumbs.Link href={URL}>Breadcrumb</Breadcrumbs.Link>
+      </Breadcrumbs>
+      <div>Heading</div>
+
+      <Gap.Large />
+
+      <StoryHeading level={2}>Large Heading</StoryHeading>
+      <Gap.Small />
+      <CodeHeading>{"<Breadcrumbs.Link>"}</CodeHeading>
+      <Breadcrumbs>
+        <Breadcrumbs.Link href={URL}>Breadcrumb</Breadcrumbs.Link>
+        <Breadcrumbs.Link href={URL}>Breadcrumb</Breadcrumbs.Link>
+      </Breadcrumbs>
+      <Heading level={1}>Heading</Heading>
+      <Gap />
+      <CodeHeading>{'<Breadcrumbs.Link as="a">'}</CodeHeading>
+      <Breadcrumbs>
+        <Breadcrumbs.Link as="a" href={URL}>
+          Breadcrumb
+        </Breadcrumbs.Link>
+        <Breadcrumbs.Link href={URL}>Breadcrumb</Breadcrumbs.Link>
+      </Breadcrumbs>
+      <Heading level={1}>Heading</Heading>
+      <Gap />
+      <CodeHeading>{'<Breadcrumbs.Link as="span">'}</CodeHeading>
+      <Breadcrumbs>
+        <Breadcrumbs.Link as="span">Breadcrumb</Breadcrumbs.Link>
+        <Breadcrumbs.Link href={URL}>Breadcrumb</Breadcrumbs.Link>
+      </Breadcrumbs>
+      <Heading level={1}>Heading</Heading>
+      <Gap />
+      <CodeHeading>
+        {"<Breadcrumbs.Link>"} <span>x 1</span>
+      </CodeHeading>
+      <Breadcrumbs>
+        <Breadcrumbs.Link href={URL}>Breadcrumb</Breadcrumbs.Link>
+      </Breadcrumbs>
+      <Heading level={1}>Heading</Heading>
+    </>
+  );
+};
+
+export default AllVariations;

--- a/packages/Breadcrumbs/stories/examples/Variations.js
+++ b/packages/Breadcrumbs/stories/examples/Variations.js
@@ -82,6 +82,10 @@ const AllVariations = () => {
           <Breadcrumbs.Link href={URL}>Breadcrumb 3</Breadcrumbs.Link>
           <Breadcrumbs.Link href={URL}>Breadcrumb 4</Breadcrumbs.Link>
         </Breadcrumbs>
+        <Gap.Small />
+        <Breadcrumbs isDark>
+          <Breadcrumbs.Link href={URL}>Breadcrumb 1</Breadcrumbs.Link>
+        </Breadcrumbs>
       </div>
     </>
   );


### PR DESCRIPTION
### Purpose 🚀
Ensure that the Breadcrumb links consistently align vertically with other elements on the page.

Related PR https://github.com/acl-services/sriracha/pull/896


### Notes ✏️
- Easier said than done! The larger the font of external elements, the more padding within the typeface will cause a misalignment.  
- This PR will ensure that the container elements align, whether a native `<Breadcrumb.Link>` is used, or whether it is customized and transformed into a different type of HTML element via the `as` prop.
- Also refactored the coding style of the `styles.js` files to align with current conventions. 
- Added a new Storybook story, `Alignment` to illustrate the consistency between types of elements and inconsistency when a large font is used (see below).


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/UXD-1592--breadcrumb-alignment/?path=/story/navigation-breadcrumbs-examples--alignment


### Screenshots 📸
(Text is selected to highlight the element boundaries)

<img width="298" alt="Screen Shot 2021-10-05 at 4 45 25 PM" src="https://user-images.githubusercontent.com/14944896/136119060-f1518da1-8680-4ab1-9b0e-bd37809f66cd.png">

<img width="298" alt="Screen Shot 2021-10-05 at 4 45 36 PM" src="https://user-images.githubusercontent.com/14944896/136119078-1e7151ec-4585-4f3c-a56c-8d3ebaaeddcb.png">


### References 🔗
https://aclgrc.atlassian.net/browse/UXD-1592
https://github.com/acl-services/sriracha/pull/896



<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
