### PR TITLE
fix(ExternalLink): UXD-1713 minor ui changes

### DIFF
--- a/.changeset/bright-kings-fold.md
+++ b/.changeset/bright-kings-fold.md
@@ -1,0 +1,5 @@
+---
+"@paprika/external-link": minor
+---
+
+Minor UI changes

--- a/packages/ExternalLink/CHANGELOG.md
+++ b/packages/ExternalLink/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.15
+
+- Fixed minor UI issues
+
 ## 2.0.14
 
 ### Patch Changes

--- a/packages/ExternalLink/package.json
+++ b/packages/ExternalLink/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paprika/external-link",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "description": "The ExternalLink component links to an external website.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/ExternalLink/src/ExternalLink.js
+++ b/packages/ExternalLink/src/ExternalLink.js
@@ -32,6 +32,7 @@ function ExternalLink(props) {
 
   return (
     <sc.ExternalLink
+      data-pka-anchor="externalLink"
       aria-label={a11yText || null}
       onClick={handleSwallowClick}
       rel="noopener noreferrer"
@@ -39,7 +40,9 @@ function ExternalLink(props) {
       iconFontSize={iconFontSize}
       {...moreProps}
     >
-      <sc.ExternalLinkContent hasNoUnderline={hasNoUnderline}>{children}</sc.ExternalLinkContent>
+      <sc.ExternalLinkContent data-pka-anchor="externalLink.content" hasNoUnderline={hasNoUnderline}>
+        {children}
+      </sc.ExternalLinkContent>
       <NewTabIcon css={sc.ExternalLinkIconStyles} size={`${iconFontSize}px`} />
     </sc.ExternalLink>
   );

--- a/packages/ExternalLink/src/ExternalLink.styles.js
+++ b/packages/ExternalLink/src/ExternalLink.styles.js
@@ -1,35 +1,33 @@
 import styled, { css } from "styled-components";
 import tokens from "@paprika/tokens";
 import { truncateText } from "@paprika/stylers/lib/includes";
-import { toInt } from "@paprika/stylers/lib/helpers";
 
 const contentHoverFocusStyles = css`
-  text-decoration: none;
+  &[data-pka-anchor="externalLink.content"] {
+    text-decoration: none;
 
-  &:hover,
-  &:focus {
-    text-decoration: underline;
+    &:hover,
+    &:focus {
+      text-decoration: underline;
+    }
   }
 `;
 
-export const ExternalLink = styled.a(
-  ({ iconFontSize }) => css`
-    align-items: center;
-    border-radius: ${tokens.border.radius};
-    color: ${tokens.textColor.link};
-    display: inline-flex;
-    max-width: 100%;
-    padding: 1px ${iconFontSize + toInt(tokens.spaceLg)}px 1px ${tokens.spaceSm};
-    position: relative;
-    text-decoration: none;
+export const ExternalLink = styled.a`
+  align-items: center;
+  border-radius: ${tokens.border.radius};
+  color: ${tokens.textColor.link};
+  display: inline-flex;
+  max-width: 100%;
+  padding: 1px ${tokens.spaceSm};
+  position: relative;
+  text-decoration: none;
 
-    &:focus,
-    &:active {
-      box-shadow: ${tokens.highlight.active.boxShadow};
-      outline: none;
-    }
-  `
-);
+  &:focus,
+  &:active {
+    box-shadow: ${tokens.highlight.active.boxShadow};
+  }
+`;
 
 export const ExternalLinkContent = styled.span(
   ({ hasNoUnderline }) => css`


### PR DESCRIPTION
### Purpose 🚀
Minor update in ExternalLink

### Notes ✏️
1. Focus status has the ring around, accessible via keyboard tabbing
2. Padding is changed to `1px 4px`
3. Added `data-pka-anchor="externalLink.content"` to increase the weight for `hasNoUnderline`


### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
<img width="195" alt="Screen Shot 2021-10-07 at 2 05 09 PM" src="https://user-images.githubusercontent.com/92059030/136462118-bbce559a-e015-4ca4-b74b-b48890dad2f0.png">

### References 🔗
JIRA: https://aclgrc.atlassian.net/browse/UXD-1713


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
