### PR TITLE
UXD-1717  Filter Breadcrumb children  🐐

### DIFF
--- a/.changeset/chilly-moons-buy.md
+++ b/.changeset/chilly-moons-buy.md
@@ -1,0 +1,5 @@
+---
+"@paprika/breadcrumbs": patch
+---
+
+Support null children and children wrapped in fragments

--- a/packages/Breadcrumbs/src/Breadcrumbs.js
+++ b/packages/Breadcrumbs/src/Breadcrumbs.js
@@ -13,14 +13,15 @@ function Breadcrumbs(props) {
   const { children, isDark, isAutoCollapsed, ...moreProps } = props;
   const I18n = useI18n();
 
-  const [isCollapsed, setIsCollapsed] = React.useState(shouldShowExpandButton);
   const linkChildren = [extractChildren(children, ["Breadcrumbs.Link"])["Breadcrumbs.Link"]].flat();
   const hasOnlyOneChild = linkChildren.length === 1;
   const shouldShowExpandButton = isAutoCollapsed && linkChildren.length > MAXIMUM_NUM_OF_LEVEL;
 
+  const [isCollapsed, setIsCollapsed] = React.useState(shouldShowExpandButton);
+
   React.useLayoutEffect(() => {
     setIsCollapsed(shouldShowExpandButton);
-  }, [linkChildren.length, shouldShowExpandButton]);
+  }, [shouldShowExpandButton]);
 
   function handleExpand() {
     setIsCollapsed(false);
@@ -33,13 +34,15 @@ function Breadcrumbs(props) {
           {linkChildren.map((child, index) => {
             if (shouldShowExpandButton && index === 0) {
               return (
-                <>
+                // eslint-disable-next-line react/no-array-index-key
+                <React.Fragment key={index}>
                   {child}
                   <ExpandButton onClick={handleExpand} isHidden={!isCollapsed} />
-                </>
+                </React.Fragment>
               );
             }
-            return React.cloneElement(child, { hasOnlyOneChild });
+            // eslint-disable-next-line react/no-array-index-key
+            return React.cloneElement(child, { hasOnlyOneChild, key: index });
           })}
         </sc.List>
       </sc.Nav>

--- a/packages/Breadcrumbs/src/Breadcrumbs.js
+++ b/packages/Breadcrumbs/src/Breadcrumbs.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import useI18n from "@paprika/l10n/lib/useI18n";
+import { extractChildren } from "@paprika/helpers";
 import Link from "./components/Link";
 import ExpandButton from "./components/ExpandButton";
 import IsDarkContext from "./context";
@@ -11,14 +12,15 @@ import * as sc from "./Breadcrumbs.styles";
 function Breadcrumbs(props) {
   const { children, isDark, isAutoCollapsed, ...moreProps } = props;
   const I18n = useI18n();
-  const childrenCount = React.Children.count(children);
-  const shouldShowExpandButton = isAutoCollapsed && React.Children.count(children) > MAXIMUM_NUM_OF_LEVEL;
-  const hasOnlyOneChild = childrenCount === 1;
+
   const [isCollapsed, setIsCollapsed] = React.useState(shouldShowExpandButton);
+  const linkChildren = [extractChildren(children, ["Breadcrumbs.Link"])["Breadcrumbs.Link"]].flat();
+  const hasOnlyOneChild = linkChildren.length === 1;
+  const shouldShowExpandButton = isAutoCollapsed && linkChildren.length > MAXIMUM_NUM_OF_LEVEL;
 
   React.useLayoutEffect(() => {
     setIsCollapsed(shouldShowExpandButton);
-  }, [childrenCount, shouldShowExpandButton]);
+  }, [linkChildren.length, shouldShowExpandButton]);
 
   function handleExpand() {
     setIsCollapsed(false);
@@ -28,7 +30,7 @@ function Breadcrumbs(props) {
     <IsDarkContext.Provider value={isDark}>
       <sc.Nav aria-label={I18n.t("breadcrumbs.aria_label")} isDark={isDark} {...moreProps}>
         <sc.List isCollapsed={isCollapsed}>
-          {React.Children.map(children, (child, index) => {
+          {linkChildren.map((child, index) => {
             if (shouldShowExpandButton && index === 0) {
               return (
                 <>
@@ -37,7 +39,7 @@ function Breadcrumbs(props) {
                 </>
               );
             }
-            return child === null ? null : React.cloneElement(child, { hasOnlyOneChild });
+            return React.cloneElement(child, { hasOnlyOneChild });
           })}
         </sc.List>
       </sc.Nav>

--- a/packages/Breadcrumbs/stories/Breadcrumbs.examples.stories.js
+++ b/packages/Breadcrumbs/stories/Breadcrumbs.examples.stories.js
@@ -4,6 +4,7 @@ import { exampleStoryParameters } from "storybook/assets/storyParameters";
 import { Gap } from "storybook/assets/styles/common.styles";
 import ExampleStory from "storybook/components/ExampleStory";
 import Alignment from "./examples/Alignment";
+import Dynamic from "./examples/Dynamic";
 import Breadcrumbs from "../src";
 
 export default {
@@ -19,5 +20,16 @@ export const alignment = () => (
 );
 alignment.story = {
   name: "Alignment",
+  parameters: exampleStoryParameters,
+};
+
+export const dynamic = () => (
+  <ExampleStory storyName="Fetching Breadcrumbs Asynchronously" component="Breadcrumbs" fileName="examples/Dynamic.js">
+    <Gap.Small />
+    <Dynamic />
+  </ExampleStory>
+);
+dynamic.story = {
+  name: "Dynamic",
   parameters: exampleStoryParameters,
 };

--- a/packages/Breadcrumbs/stories/examples/Dynamic.js
+++ b/packages/Breadcrumbs/stories/examples/Dynamic.js
@@ -1,0 +1,54 @@
+import React from "react";
+import { Gap } from "storybook/assets/styles/common.styles";
+import Spinner from "@paprika/spinner";
+import Breadcrumbs from "../../src";
+
+const URL = "https://www.wegalvanize.com/";
+
+const moreLinks = [
+  <Breadcrumbs.Link href={URL}>CRUMB X</Breadcrumbs.Link>,
+  <Breadcrumbs.Link href={URL}>CRUMB Y</Breadcrumbs.Link>,
+  <Breadcrumbs.Link href={URL}>CRUMB Z</Breadcrumbs.Link>,
+];
+
+function fetchSomeLinks() {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve(moreLinks);
+    }, 1500);
+  });
+}
+
+export default function Example() {
+  const [isLoading, setLoading] = React.useState(true);
+  const [links, setLinks] = React.useState([<Breadcrumbs.Link href={URL}>Breadcrumb 1</Breadcrumbs.Link>]);
+  const [links2, setLinks2] = React.useState([
+    <Breadcrumbs.Link href={URL}>Breadcrumb 1</Breadcrumbs.Link>,
+    <Breadcrumbs.Link href={URL}>Breadcrumb 2</Breadcrumbs.Link>,
+    <Breadcrumbs.Link href={URL}>Breadcrumb 3</Breadcrumbs.Link>,
+    <Breadcrumbs.Link href={URL}>Breadcrumb 4</Breadcrumbs.Link>,
+  ]);
+
+  React.useEffect(() => {
+    fetchSomeLinks().then(data => {
+      setLinks([...links, ...data]);
+      setLinks2([...links2, ...data]);
+      setLoading(false);
+    });
+  }, []);
+
+  return (
+    <>
+      <Breadcrumbs>{links}</Breadcrumbs>
+      <Gap />
+      <Breadcrumbs>{links2}</Breadcrumbs>
+      <Gap />
+      {isLoading ? (
+        <div style={{ display: "flex", alignItems: "center" }}>
+          <Spinner size={Spinner.types.size.SMALL} style={{ display: "inline-block", margin: "8px 8px 0 0" }} />
+          Fetching...
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/packages/Breadcrumbs/stories/examples/Variations.js
+++ b/packages/Breadcrumbs/stories/examples/Variations.js
@@ -23,10 +23,27 @@ const AllVariations = () => (
       <Breadcrumbs.Link href={URL}>Breadcrumb 5</Breadcrumbs.Link>
       <Breadcrumbs.Link href={URL}>Breadcrumb 6</Breadcrumbs.Link>
     </Breadcrumbs>
-    <Gap.Small />
+    <Gap />
     <StoryHeading level={3}>Single breadcrumb</StoryHeading>
     <Breadcrumbs>
       <Breadcrumbs.Link href={URL}>Breadcrumb 1</Breadcrumbs.Link>
+    </Breadcrumbs>
+    <Gap.Small />
+    <CodeHeading>
+      <span>With</span> null
+    </CodeHeading>
+    <Breadcrumbs>
+      <Breadcrumbs.Link href={URL}>Breadcrumb 1</Breadcrumbs.Link>
+      {true === false ? <Breadcrumbs.Link href={URL}>Breadcrumb 2</Breadcrumbs.Link> : null}
+    </Breadcrumbs>
+    <Gap.Small />
+    <CodeHeading>
+      <span>With</span> {`<React.Fragment>`}
+    </CodeHeading>
+    <Breadcrumbs>
+      <>
+        <Breadcrumbs.Link href={URL}>Breadcrumb 1</Breadcrumbs.Link>
+      </>
     </Breadcrumbs>
     <Gap />
 


### PR DESCRIPTION
### Purpose 🚀
Support `null` children and children wrapped in `<React.Fragments>`.

### Notes ✏️
- Solves for use cases where breadcrumb links are conditionally rendered.
- use `extractChildren()` helper to filter `children` to only `<Breadcrumb.Link>` children.
- Added two examples in the Storybook Variations story.

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/UXD-1717--filter-breadcrumb-children

### References 🔗
https://aclgrc.atlassian.net/browse/UXD-1717
https://github.com/acl-services/acl-exception/pull/8747/files#r750731213


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
