### PR TITLE
UXD-1901 Fix icon scaling in Safari 🐐

### DIFF
--- a/.changeset/grumpy-cherries-count.md
+++ b/.changeset/grumpy-cherries-count.md
@@ -1,0 +1,5 @@
+---
+"@paprika/icon": patch
+---
+
+Adjust scaling styles to better support Safari

--- a/packages/Icon/svgr.config.js
+++ b/packages/Icon/svgr.config.js
@@ -11,10 +11,10 @@ module.exports = {
     "#8A8A8A": "currentColor",
   },
   svgProps: {
-    css:
-      // We need to render string template
-      // eslint-disable-next-line no-template-curly-in-string
-      "{`color: ${props.color};font-size: ${props.size};vertical-align: text-top;`}",
+    // We need to render string template
+    // prettier-ignore
+    // eslint-disable-next-line no-template-curly-in-string
+    css: "{`color:${props.color}; width:${props.size}; height:${props.size}; font-size:${props.size}; vertical-align:text-top;`}",
     "data-pka-anchor": "icon",
     focusable: false,
   },


### PR DESCRIPTION
### Purpose 🚀
Ensure that icons scale with browser zoom, specifically with Safari.

### Notes ✏️
- Added `height` and `width` CSS back to svg props in `svgr.config`
- Reverts a change in https://github.com/acl-services/paprika/pull/1158
- Companion PR in `wasabicons`: https://github.com/acl-services/wasabicons/pull/63

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/UXD-1901--fix-icon-scaling-safari/?path=/story/display-icon--showcase-story

### Screenshots 📸
Safari @ 50% zoom

<img src="https://user-images.githubusercontent.com/14944896/135684140-695cb0c3-821b-40b8-937a-1ec41a170351.png" width="64" />
<img width="785" alt="Screen Shot 2021-12-15 at 11 37 28 AM" src="https://user-images.githubusercontent.com/14944896/146493090-ed20fcb8-511e-46cc-8085-2a1c759738e1.png">

<img src="https://user-images.githubusercontent.com/14944896/135684148-5808b33b-e6ef-4c2d-a7c4-3a0bfcfecb44.png" width="64" />
<img width="785" alt="Screen Shot 2021-12-15 at 11 37 42 AM" src="https://user-images.githubusercontent.com/14944896/146493097-465335a1-b5ee-4c60-9de1-0519990b6355.png">



### References 🔗
[_relevant Jira ticket / GitHub issues_
](https://aclgrc.atlassian.net/browse/UXD-1901)

<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
