### PR TITLE
fix(ButtonGroup): FS-2620 removed gap in Safari

### DIFF
--- a/.changeset/rotten-forks-return.md
+++ b/.changeset/rotten-forks-return.md
@@ -1,0 +1,5 @@
+---
+"@paprika/button-group": patch
+---
+
+Removed gap in Safari between buttons in ButtonGroup

--- a/packages/ButtonGroup/src/components/Item/Item.styles.js
+++ b/packages/ButtonGroup/src/components/Item/Item.styles.js
@@ -42,6 +42,7 @@ export const Item = styled(Button)(
   ({ isActive, isDisabled }) => css`
   ${stylers.truncateText}
   display: block;
+  margin: 0;
   
   &:focus {
     ${stylers.z(3)}


### PR DESCRIPTION
### Purpose 🚀
[FS-2620: [FE] Remove gap between buttons in button group in Safari browser (Paprika)](https://aclgrc.atlassian.net/browse/FS-2620)

### Notes ✏️

#### ButtonGroup in Safari before fixes:
![image](https://user-images.githubusercontent.com/51324247/147090536-05dc8e8a-e728-482a-ab1b-6f5039127384.png)

#### ButtonGroup in Safari after fixes:
![image](https://user-images.githubusercontent.com/51324247/147090600-ab166ea4-ebaf-4d3b-8913-b142d5b1a145.png)


### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
