### PR TITLE
fix(Radio): UXD-1934 added updateCheckIndex

### DIFF
--- a/.changeset/red-files-guess.md
+++ b/.changeset/red-files-guess.md
@@ -1,0 +1,5 @@
+---
+"@paprika/radio": patch
+---
+
+Added hook so user can update checkIndex via ref

--- a/packages/Radio/src/components/Group/Group.js
+++ b/packages/Radio/src/components/Group/Group.js
@@ -27,7 +27,7 @@ const defaultProps = {
   size: types.size.MEDIUM,
 };
 
-function Group(props) {
+const Group = React.forwardRef((props, ref) => {
   const { canDeselect, children, isDisabled, onChange, size, ...moreGroupProps } = props;
   const defaultCheckedIndex = React.Children.toArray(children).findIndex(child => child.props.defaultIsChecked);
   const selectedIndex = React.Children.toArray(children).findIndex(child => child.props.isChecked);
@@ -43,6 +43,12 @@ function Group(props) {
     onChange(index);
     setCheckedIndex(canDeselect ? getDeselectableIndex(index) : index);
   };
+
+  React.useImperativeHandle(ref, () => ({
+    updateCheckIndex: index => {
+      setCheckedIndex(index);
+    },
+  }));
 
   return (
     <div data-pka-anchor="radio.group" {...moreGroupProps}>
@@ -62,7 +68,7 @@ function Group(props) {
       })}
     </div>
   );
-}
+});
 
 Group.displayName = "Radio.Group";
 Group.propTypes = propTypes;

--- a/packages/Radio/src/components/Group/Group.js
+++ b/packages/Radio/src/components/Group/Group.js
@@ -45,7 +45,7 @@ const Group = React.forwardRef((props, ref) => {
   };
 
   React.useImperativeHandle(ref, () => ({
-    updateCheckIndex: index => {
+    updateCheckedIndex: index => {
       setCheckedIndex(index);
     },
   }));


### PR DESCRIPTION
### Purpose 🚀
Added useImperativeHandle hook so user can update the checkedIndex via ref

### Notes ✏️
Thanks Allison for the instruction!!

### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message

### Screenshots 📸
In application:
![radio-update](https://user-images.githubusercontent.com/92059030/150011531-c9c45c69-d2be-421e-98a3-1592145cd8fb.gif)


### References 🔗
[_relevant Jira ticket / GitHub issues_](https://aclgrc.atlassian.net/browse/UXD-1934)


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
