### PR TITLE
SNP-2319 bump immer to resolve CVE-2021-3757

### DIFF
--- a/.changeset/shiny-mayflies-play.md
+++ b/.changeset/shiny-mayflies-play.md
@@ -1,0 +1,6 @@
+---
+"@paprika/action-bar": patch
+"@paprika/filter": patch
+---
+
+immer@9.0.12 to resolve [CVE-2021-3757](https://github.com/advisories/GHSA-c36v-fmgq-m8hx)

--- a/packages/ActionBar/package.json
+++ b/packages/ActionBar/package.json
@@ -26,7 +26,7 @@
     "@paprika/stylers": "^1.1.5",
     "@paprika/switch": "^1.0.16",
     "@paprika/tokens": "^1.1.4",
-    "immer": "^8.0.1",
+    "immer": "^9.0.12",
     "prop-types": "^15.7.2",
     "uuid": "^8.3.2"
   },

--- a/packages/Filter/package.json
+++ b/packages/Filter/package.json
@@ -27,7 +27,7 @@
     "@paprika/select": "^2.0.11",
     "@paprika/stylers": "^1.1.5",
     "@paprika/tokens": "^1.1.4",
-    "immer": "^8.0.1",
+    "immer": "^9.0.12",
     "prop-types": "^15.7.2",
     "uuid": "^3.3.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11853,10 +11853,15 @@ ignore@^5.1.4, ignore@^5.1.8:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
-immer@8.0.1, immer@^8.0.1:
+immer@8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
   integrity sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
+
+immer@^9.0.12:
+  version "9.0.12"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.12.tgz#2d33ddf3ee1d247deab9d707ca472c8c942a0f20"
+  integrity sha512-lk7UNmSbAukB5B6dh9fnh5D0bJTOFKxVg2cyJWTYrWRfhLrLMBquONcUs3aFq507hNoIZEDDh8lb8UtOizSMhA==
 
 import-fresh@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### Purpose 🚀
Bump all instances of ImmerJS to >= 9.0.6 to resolve CVE-2021-3757

### Notes ✏️
- Bump immer in ActionBar and Filter to immer@9.0.12 (latest)
- Patch version of ActionBar and Filter in docs

### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
_optional but highly recommended_

### References 🔗
Ticket: https://aclgrc.atlassian.net/browse/SNP-2319


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
