### PR TITLE
UXD-1978 takeover header style updates

### DIFF
--- a/.changeset/fresh-oranges-pull.md
+++ b/.changeset/fresh-oranges-pull.md
@@ -1,0 +1,5 @@
+---
+"@paprika/overlay": patch
+---
+
+add option to disable the click event on backdrop

--- a/packages/Overlay/CHANGELOG.md
+++ b/packages/Overlay/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## 1.0.15
-
-### Patch Changes
-
-- add option to disable the click events on backdrop
-
 ## 1.0.14
 
 ### Patch Changes

--- a/packages/Overlay/CHANGELOG.md
+++ b/packages/Overlay/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.15
+
+### Patch Changes
+
+- add option to disable the click events on backdrop
+
 ## 1.0.14
 
 ### Patch Changes

--- a/packages/Overlay/src/Overlay.js
+++ b/packages/Overlay/src/Overlay.js
@@ -47,6 +47,7 @@ const propTypes = {
   onClose: PropTypes.func,
   onAfterOpen: PropTypes.func,
   onAfterClose: PropTypes.func,
+  isBackdropClickDisabled: PropTypes.bool,
 
   /** z-index of the Overlay wrapper */
   zIndex: PropTypes.number,
@@ -61,6 +62,7 @@ const defaultProps = {
   onAfterClose: () => {},
   onAfterOpen: () => {},
   onClose: () => {},
+  isBackdropClickDisabled: false,
   zIndex: null,
 };
 
@@ -75,6 +77,7 @@ const Overlay = props => {
     onAfterClose,
     onAfterOpen,
     onClose,
+    isBackdropClickDisabled,
     ...moreProps
   } = props;
 
@@ -116,7 +119,7 @@ const Overlay = props => {
                 <sc.Backdrop
                   className={backdropClassName}
                   state={state}
-                  onClick={onClose}
+                  onClick={isBackdropClickDisabled ? null : onClose}
                   data-pka-anchor="overlay.backdrop"
                 />
               )}

--- a/packages/Overlay/src/index.d.ts
+++ b/packages/Overlay/src/index.d.ts
@@ -21,6 +21,8 @@ interface OverlayProps {
   onAfterOpen?: (...args: any[]) => any;
 
   onAfterClose?: (...args: any[]) => any;
+
+  isBackdropClickDisabled?: boolean;
   /** z-index of the Overlay wrapper */
   zIndex?: number;
 }

--- a/packages/Takeover/README.md
+++ b/packages/Takeover/README.md
@@ -22,26 +22,28 @@ npm install @paprika/takeover
 
 ### Takeover
 
-| Prop         | Type   | required | default   | Description                                            |
-| ------------ | ------ | -------- | --------- | ------------------------------------------------------ |
-| a11yText     | string | false    | null      |                                                        |
-| children     | node   | true     | -         | The content for the Takeover                           |
-| isOpen       | bool   | true     | -         | Control the visibility of the Takeover                 |
-| onAfterClose | func   | false    | () => {}  | Callback once the Takeover has been closed event       |
-| onAfterOpen  | func   | false    | () => {}  | Callback once the Takeover has been opened event       |
-| onClose      | func   | false    | () => {}  | Callback triggered when the takeover needs to be close |
-| zIndex       | number | false    | zValue(5) | The z-index of the Takeover content                    |
+| Prop         | Type   | required | default   | Description                                                  |
+| ------------ | ------ | -------- | --------- | ------------------------------------------------------------ |
+| a11yText     | string | false    | null      |                                                              |
+| children     | node   | true     | -         | The content for the Takeover                                 |
+| isOpen       | bool   | true     | -         | Control the visibility of the Takeover                       |
+| onAfterClose | func   | false    | () => {}  | Callback once the Takeover has been closed event             |
+| onAfterOpen  | func   | false    | () => {}  | Callback once the Takeover has been opened event             |
+| onClose      | func   | false    | () => {}  | Callback triggered when the takeover needs to be close       |
+| zIndex       | number | false    | zValue(5) | The z-index of the Takeover content                          |
+| isFullWidth  | custom | false    | false     | Set Takeover to full width without any margins and max-width |
 
 ### Takeover.Header
 
-| Prop           | Type                                                    | required | default                   | Description |
-| -------------- | ------------------------------------------------------- | -------- | ------------------------- | ----------- |
-| children       | node                                                    | true     | -                         |             |
-| hasCloseButton | bool                                                    | false    | true                      |             |
-| kind           | [ Header.types.kind.DEFAULT, Header.types.kind.PRIMARY] | false    | Header.types.kind.DEFAULT |             |
-| level          | [ 1, 2, 3, 4, 5, 6]                                     | false    | 3                         |             |
-| onClose        | func                                                    | false    | () => {}                  |             |
-| refHeading     | custom                                                  | false    | null                      |             |
+| Prop           | Type                                                    | required | default                   | Description                                                           |
+| -------------- | ------------------------------------------------------- | -------- | ------------------------- | --------------------------------------------------------------------- |
+| children       | node                                                    | true     | -                         |                                                                       |
+| hasCloseButton | bool                                                    | false    | true                      |                                                                       |
+| kind           | [ Header.types.kind.DEFAULT, Header.types.kind.PRIMARY] | false    | Header.types.kind.DEFAULT |                                                                       |
+| level          | [ 1, 2, 3, 4, 5, 6]                                     | false    | 2                         |                                                                       |
+| onClose        | func                                                    | false    | () => {}                  |                                                                       |
+| refHeading     | custom                                                  | false    | null                      |                                                                       |
+| headerTools    | node                                                    | false    | null                      | Add node object to the right side of heading next to the close button |
 
 ### Takeover.FocusLock
 

--- a/packages/Takeover/README.md
+++ b/packages/Takeover/README.md
@@ -35,15 +35,15 @@ npm install @paprika/takeover
 
 ### Takeover.Header
 
-| Prop           | Type                                                    | required | default                   | Description                                                           |
-| -------------- | ------------------------------------------------------- | -------- | ------------------------- | --------------------------------------------------------------------- |
-| children       | node                                                    | true     | -                         |                                                                       |
-| hasCloseButton | bool                                                    | false    | true                      |                                                                       |
-| kind           | [ Header.types.kind.DEFAULT, Header.types.kind.PRIMARY] | false    | Header.types.kind.DEFAULT |                                                                       |
-| level          | [ 1, 2, 3, 4, 5, 6]                                     | false    | 2                         |                                                                       |
-| onClose        | func                                                    | false    | () => {}                  |                                                                       |
-| refHeading     | custom                                                  | false    | null                      |                                                                       |
-| headerTools    | node                                                    | false    | null                      | Add node object to the right side of heading next to the close button |
+| Prop           | Type                                                    | required | default                   | Description                                                                                                                                            |
+| -------------- | ------------------------------------------------------- | -------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| children       | node                                                    | true     | -                         |                                                                                                                                                        |
+| hasCloseButton | bool                                                    | false    | true                      |                                                                                                                                                        |
+| kind           | [ Header.types.kind.DEFAULT, Header.types.kind.PRIMARY] | false    | Header.types.kind.DEFAULT |                                                                                                                                                        |
+| level          | [ 1, 2, 3, 4, 5, 6]                                     | false    | 2                         |                                                                                                                                                        |
+| onClose        | func                                                    | false    | () => {}                  |                                                                                                                                                        |
+| refHeading     | custom                                                  | false    | null                      |                                                                                                                                                        |
+| tools          | node                                                    | false    | null                      | Add node object to the right side of heading next to the close button. If buttons are used, the button size needs to be set as Button.types.size.LARGE |
 
 ### Takeover.FocusLock
 

--- a/packages/Takeover/src/Takeover.js
+++ b/packages/Takeover/src/Takeover.js
@@ -30,6 +30,9 @@ const propTypes = {
 
   /** The z-index of the Takeover content */
   zIndex: PropTypes.number,
+
+  /** Set Takeover to full width without any margins and max-width */
+  isFullWidth: PropTypes.boolean,
 };
 
 const defaultProps = {
@@ -38,10 +41,11 @@ const defaultProps = {
   onAfterClose: () => {},
   onAfterOpen: () => {},
   zIndex: zValue(5),
+  isFullWidth: false,
 };
 
 export default function Takeover(props) {
-  const { a11yText, isOpen, onClose, onAfterClose, onAfterOpen, zIndex, ...moreProps } = props;
+  const { a11yText, isOpen, onClose, onAfterClose, onAfterOpen, zIndex, isFullWidth, ...moreProps } = props;
 
   const {
     "Takeover.Content": contentExtracted,
@@ -64,7 +68,7 @@ export default function Takeover(props) {
 
   const overlayProps = {
     "data-pka-anchor": "takeover.overlay",
-    hasBackdrop: false,
+    hasBackdrop: true,
     focusLockOptions,
     ...(overlayExtracted && overlayExtracted.props),
     isOpen,
@@ -72,6 +76,7 @@ export default function Takeover(props) {
     onAfterOpen,
     onClose,
     zIndex,
+    isBackdropClickDisabled: true,
   };
 
   function getAriaLabel() {
@@ -91,6 +96,7 @@ export default function Takeover(props) {
       {state => (
         <sc.Takeover
           state={state}
+          isFullWidth={isFullWidth}
           {...moreProps}
           aria-label={getAriaLabel()}
           aria-modal

--- a/packages/Takeover/src/Takeover.styles.js
+++ b/packages/Takeover/src/Takeover.styles.js
@@ -1,6 +1,7 @@
 import styled, { css } from "styled-components";
 import tokens from "@paprika/tokens";
 import stylers from "@paprika/stylers";
+import { spacer } from "@paprika/stylers/lib/helpers";
 import OriginalHeader from "./components/Header/Header";
 
 export const FocusLock = styled.div`
@@ -32,18 +33,29 @@ const states = {
 };
 
 export const Takeover = styled.div(
-  ({ zIndex, state }) => css`
+  ({ zIndex, state, isFullWidth }) => css`
     background-color: ${tokens.backgroundColor.level0};
+    border: 1px ${tokens.border.color} solid;
+    border-radius: ${tokens.card.borderRadius};
     bottom: 0;
+    box-shadow: 0 12px 24px 0 rgba(0, 0, 0, 0.12), 0 0px 6px 0 rgba(0, 0, 0, 0.16);
     display: flex;
     flex-direction: column;
     left: 0;
+    margin: ${spacer(3)};
+    ${states[state]};
     position: fixed;
     right: 0;
     top: 0;
     transition: all ${tokens.overlay.animationDuration}ms ease;
     z-index: ${zIndex};
-    ${states[state]};
+    ${!isFullWidth &&
+      ` 
+        max-width: 1248px;
+        @media only screen and (min-width: 1280px) {
+        margin: ${spacer(3)} auto;
+      }
+      `}
   `
 );
 

--- a/packages/Takeover/src/components/Header/Header.js
+++ b/packages/Takeover/src/components/Header/Header.js
@@ -7,10 +7,15 @@ import * as sc from "./Header.styles";
 
 const Header = React.forwardRef((props, ref) => {
   const { children, level, hasCloseButton, kind, onClose, refHeading, tools, ...moreProps } = props;
-  const isString = typeof children === "string";
   return (
     <sc.Header ref={ref} kind={kind} {...moreProps}>
-      <sc.Heading level={level} displayLevel={3} isLight ref={refHeading} title={isString ? children : null}>
+      <sc.Heading
+        level={level}
+        displayLevel={3}
+        isLight
+        ref={refHeading}
+        title={typeof children === "string" ? children : null}
+      >
         {children}
       </sc.Heading>
       <sc.HeaderRightContainer>

--- a/packages/Takeover/src/components/Header/Header.js
+++ b/packages/Takeover/src/components/Header/Header.js
@@ -42,7 +42,7 @@ const propTypes = {
 
 const defaultProps = {
   hasCloseButton: true,
-  level: 3,
+  level: 2,
   kind: Header.types.kind.DEFAULT,
   onClose: () => {},
   refHeading: null,

--- a/packages/Takeover/src/components/Header/Header.js
+++ b/packages/Takeover/src/components/Header/Header.js
@@ -6,23 +6,26 @@ import * as types from "../../types";
 import * as sc from "./Header.styles";
 
 const Header = React.forwardRef((props, ref) => {
-  const { children, level, hasCloseButton, kind, onClose, refHeading, ...moreProps } = props;
+  const { children, level, hasCloseButton, kind, onClose, refHeading, headerTools, ...moreProps } = props;
 
   return (
     <sc.Header ref={ref} kind={kind} {...moreProps}>
       <sc.Heading level={level} displayLevel={3} isLight ref={refHeading}>
         {children}
       </sc.Heading>
-      {hasCloseButton && (
-        <sc.CloseButton>
-          <Button.Close
-            data-pka-anchor="takeover.header.close-button"
-            onClick={onClose}
-            isDark={kind === "primary" || null}
-            size="medium"
-          />
-        </sc.CloseButton>
-      )}
+      <sc.HeaderRightContainer>
+        {headerTools && <sc.ToolContainer>{headerTools}</sc.ToolContainer>}
+        {hasCloseButton && (
+          <sc.CloseButton>
+            <Button.Close
+              data-pka-anchor="takeover.header.close-button"
+              onClick={onClose}
+              isDark={kind === "primary" || null}
+              size="medium"
+            />
+          </sc.CloseButton>
+        )}
+      </sc.HeaderRightContainer>
     </sc.Header>
   );
 });
@@ -38,6 +41,8 @@ const propTypes = {
   level: PropTypes.oneOf([1, 2, 3, 4, 5, 6]),
   onClose: PropTypes.func,
   refHeading: RefOf(),
+  /** Add node object to the right side of heading next to the close button */
+  headerTools: PropTypes.node,
 };
 
 const defaultProps = {
@@ -46,6 +51,7 @@ const defaultProps = {
   kind: Header.types.kind.DEFAULT,
   onClose: () => {},
   refHeading: null,
+  headerTools: null,
 };
 
 Header.displayName = "Takeover.Header";

--- a/packages/Takeover/src/components/Header/Header.js
+++ b/packages/Takeover/src/components/Header/Header.js
@@ -6,7 +6,7 @@ import * as types from "../../types";
 import * as sc from "./Header.styles";
 
 const Header = React.forwardRef((props, ref) => {
-  const { children, level, hasCloseButton, kind, onClose, refHeading, headerTools, ...moreProps } = props;
+  const { children, level, hasCloseButton, kind, onClose, refHeading, tools, ...moreProps } = props;
 
   return (
     <sc.Header ref={ref} kind={kind} {...moreProps}>
@@ -14,7 +14,7 @@ const Header = React.forwardRef((props, ref) => {
         {children}
       </sc.Heading>
       <sc.HeaderRightContainer>
-        {headerTools && <sc.ToolContainer>{headerTools}</sc.ToolContainer>}
+        {tools && <sc.ToolContainer data-pka-anchor="takeover.header.tools">{tools}</sc.ToolContainer>}
         {hasCloseButton && (
           <sc.CloseButton>
             <Button.Close
@@ -42,7 +42,7 @@ const propTypes = {
   onClose: PropTypes.func,
   refHeading: RefOf(),
   /** Add node object to the right side of heading next to the close button */
-  headerTools: PropTypes.node,
+  tools: PropTypes.node,
 };
 
 const defaultProps = {
@@ -51,7 +51,7 @@ const defaultProps = {
   kind: Header.types.kind.DEFAULT,
   onClose: () => {},
   refHeading: null,
-  headerTools: null,
+  tools: null,
 };
 
 Header.displayName = "Takeover.Header";

--- a/packages/Takeover/src/components/Header/Header.js
+++ b/packages/Takeover/src/components/Header/Header.js
@@ -7,10 +7,10 @@ import * as sc from "./Header.styles";
 
 const Header = React.forwardRef((props, ref) => {
   const { children, level, hasCloseButton, kind, onClose, refHeading, tools, ...moreProps } = props;
-
+  const isString = typeof children === "string";
   return (
     <sc.Header ref={ref} kind={kind} {...moreProps}>
-      <sc.Heading level={level} displayLevel={3} isLight ref={refHeading}>
+      <sc.Heading level={level} displayLevel={3} isLight ref={refHeading} title={isString ? children : null}>
         {children}
       </sc.Heading>
       <sc.HeaderRightContainer>

--- a/packages/Takeover/src/components/Header/Header.styles.js
+++ b/packages/Takeover/src/components/Header/Header.styles.js
@@ -14,6 +14,7 @@ export const Header = styled.div(
     box-shadow: ${tokens.shadow};
     box-sizing: border-box;
     display: flex;
+    height: 64px;
     justify-content: space-between;
     min-height: ${spacer(6)};
     width: 100%;
@@ -28,8 +29,12 @@ export const Header = styled.div(
 );
 
 export const Heading = styled(OriginalHeading)`
+  flex: 1;
   margin: 0;
-  padding: 18px 0 17px ${spacer(3)};
+  overflow: hidden;
+  padding-left: ${spacer(3)};
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 export const CloseButton = styled.div`

--- a/packages/Takeover/src/components/Header/Header.styles.js
+++ b/packages/Takeover/src/components/Header/Header.styles.js
@@ -28,10 +28,32 @@ export const Header = styled.div(
 );
 
 export const Heading = styled(OriginalHeading)`
-  margin: ${spacer(2)} 0 ${spacer(2)} ${spacer(3)};
+  margin: 0;
+  padding: 18px 0 17px ${spacer(3)};
 `;
 
 export const CloseButton = styled.div`
   border-left: 1px solid ${tokens.border.color};
-  padding: ${spacer(1)};
+  padding: 16.5px ${spacer(2)} ${spacer(2)} 15.5px;
 `;
+
+export const HeaderRightContainer = styled.div`
+  align-items: center;
+  display: flex;
+`;
+
+export const ToolContainer = styled.div(
+  () => css`
+    padding-right: ${spacer(2)};
+    button {
+      margin-left: ${spacer(1)};
+      margin-right: ${spacer(1)};
+      &:last-of-type {
+        margin-left: 0;
+      }
+      &:first-of-type {
+        margin-left: ${spacer(1)};
+      }
+    }
+  `
+);

--- a/packages/Takeover/src/components/Header/Header.styles.js
+++ b/packages/Takeover/src/components/Header/Header.styles.js
@@ -28,7 +28,7 @@ export const Header = styled.div(
 );
 
 export const Heading = styled(OriginalHeading)`
-  margin: 0 0 0 ${spacer(2)};
+  margin: ${spacer(2)} 0 ${spacer(2)} ${spacer(3)};
 `;
 
 export const CloseButton = styled.div`

--- a/packages/Takeover/src/components/Header/Header.styles.js
+++ b/packages/Takeover/src/components/Header/Header.styles.js
@@ -14,12 +14,10 @@ export const Header = styled.div(
     box-shadow: ${tokens.shadow};
     box-sizing: border-box;
     display: flex;
-    height: 64px;
     justify-content: space-between;
-    min-height: ${spacer(6)};
+    min-height: ${spacer(8)};
     width: 100%;
     z-index: 1;
-
     &:focus {
       outline: 0;
     }
@@ -42,16 +40,6 @@ export const CloseButton = styled.div`
   padding: ${spacer(2)};
 `;
 
-export const HeaderRightContainer = styled.div`
-  align-items: stretch;
-  display: flex;
-  height: 100%;
-  > div {
-    align-items: center;
-    display: flex;
-  }
-`;
-
 export const ToolContainer = styled.div(
   () => css`
     padding-right: ${spacer(2)};
@@ -66,3 +54,13 @@ export const ToolContainer = styled.div(
     }
   `
 );
+
+export const HeaderRightContainer = styled.div`
+  align-items: stretch;
+  display: flex;
+  height: 100%;
+  ${CloseButton}, ${ToolContainer} {
+    align-items: center;
+    display: flex;
+  }
+`;

--- a/packages/Takeover/src/components/Header/Header.styles.js
+++ b/packages/Takeover/src/components/Header/Header.styles.js
@@ -51,7 +51,6 @@ export const ToolContainer = styled.div(
   () => css`
     padding-right: ${spacer(2)};
     [data-pka-anchor="button"] {
-      margin-left: ${spacer(1)};
       margin-right: ${spacer(1)};
       &:last-of-type {
         margin-left: 0;

--- a/packages/Takeover/src/components/Header/Header.styles.js
+++ b/packages/Takeover/src/components/Header/Header.styles.js
@@ -34,18 +34,23 @@ export const Heading = styled(OriginalHeading)`
 
 export const CloseButton = styled.div`
   border-left: 1px solid ${tokens.border.color};
-  padding: 16.5px ${spacer(2)} ${spacer(2)} 15.5px;
+  padding: ${spacer(2)};
 `;
 
 export const HeaderRightContainer = styled.div`
-  align-items: center;
+  align-items: stretch;
   display: flex;
+  height: 100%;
+  > div {
+    align-items: center;
+    display: flex;
+  }
 `;
 
 export const ToolContainer = styled.div(
   () => css`
     padding-right: ${spacer(2)};
-    button {
+    [data-pka-anchor="button"] {
       margin-left: ${spacer(1)};
       margin-right: ${spacer(1)};
       &:last-of-type {

--- a/packages/Takeover/src/index.d.ts
+++ b/packages/Takeover/src/index.d.ts
@@ -17,6 +17,8 @@ interface TakeoverProps {
   onClose?: (...args: any[]) => any;
   /** The z-index of the Takeover content */
   zIndex?: number;
+  /** Set Takeover to full width without any margins and max-width */
+  isFullWidth?: custom;
 }
 
 declare namespace Takeover {
@@ -35,6 +37,8 @@ declare namespace Takeover {
     onClose?: (...args: any[]) => any;
 
     refHeading?: custom;
+    /** Add node object to the right side of heading next to the close button */
+    headerTools?: React.ReactNode;
   }
 }
 declare namespace Takeover {

--- a/packages/Takeover/stories/Takeover.examples.stories.js
+++ b/packages/Takeover/stories/Takeover.examples.stories.js
@@ -25,8 +25,22 @@ export const basic = () => (
   <ExampleStory component="Takeover" storyName="Basic">
     <TakeoverStory>
       <Takeover.Content className="storybook-takeover__content">
-        {repeat(100, key => (
-          <p key={key}>Some content here</p>
+        {repeat(10, key => (
+          <p key={key}>
+            Quis labore velit sunt anim velit ad nisi ad aliquip ipsum mollit minim proident. Exercitation in cillum
+            sint id dolor ea ut laboris minim. Ea ea veniam aliqua occaecat. Eiusmod dolor minim Lorem consequat labore
+            nulla irure minim irure sit. Adipisicing proident officia velit id culpa exercitation ex velit et minim sit
+            Lorem exercitation. Est tempor occaecat qui consectetur pariatur amet cupidatat commodo aliquip anim sit
+            commodo quis. Et aliquip consectetur tempor et dolor ea. Id consectetur non velit laboris elit cillum. Sint
+            proident consectetur duis enim. Id commodo sint mollit in tempor pariatur sit. Laborum Lorem excepteur
+            excepteur officia ex proident deserunt consectetur mollit esse velit adipisicing nulla. Proident nulla magna
+            quis veniam qui ex dolor sunt officia excepteur labore. Minim magna sit cupidatat consectetur consequat amet
+            sint ipsum cillum. Laboris et adipisicing proident ut sunt irure anim dolore. Cillum magna quis aliquip ad
+            laborum. Fugiat sit veniam Lorem deserunt cillum occaecat sint labore consequat veniam. Consequat nisi in
+            aliqua eiusmod aute proident deserunt magna. Labore non velit tempor anim anim minim voluptate cupidatat
+            fugiat. Commodo aliquip consectetur nostrud et. Culpa esse commodo proident ullamco sunt enim eu. Dolor
+            aliqua minim mollit exercitation ipsum ullamco amet id est mollit commodo adipisicing fugiat ullamco.
+          </p>
         ))}
       </Takeover.Content>
     </TakeoverStory>

--- a/packages/Takeover/stories/Takeover.stories.js
+++ b/packages/Takeover/stories/Takeover.stories.js
@@ -17,7 +17,15 @@ export const showcase = () => (
     <TakeoverStory>
       <Takeover.Content>
         {repeat(12, key => (
-          <p key={key}>Post-ironic asymmetrical small batch coloring book woke pickled authentic.</p>
+          <p key={key}>
+            Quis commodo officia tempor excepteur. Deserunt ullamco ex ipsum tempor laboris quis minim ullamco mollit
+            irure quis officia in proident. Id irure laborum enim aliqua irure dolor voluptate ea nostrud ea consequat
+            ex. Aliquip laborum dolore dolore enim nostrud aute non nostrud. Nulla duis anim aliquip dolor ipsum ex
+            culpa labore sint culpa occaecat. Elit exercitation officia cillum anim consectetur aute pariatur quis esse.
+            Aute minim nisi esse eu ex exercitation consectetur sit eu fugiat velit non laborum aliqua. Veniam ea
+            voluptate culpa ex nulla anim aliquip nisi eu excepteur sit laboris cupidatat. Cillum elit magna ea minim
+            cillum eu velit ipsum. Adipisicing dolore culpa sit ex. Occaecat quis reprehenderit deserunt aute officia.
+          </p>
         ))}
       </Takeover.Content>
     </TakeoverStory>

--- a/packages/Takeover/stories/TakeoverStory.js
+++ b/packages/Takeover/stories/TakeoverStory.js
@@ -15,6 +15,18 @@ const TakeoverStory = ({ children }) => {
     setIsOpen(state => !state);
   };
 
+  const Tools = (
+    <>
+      you have unsaved changes
+      <Button kind={Button.types.kind.PRIMARY} size={Button.types.size.LARGE}>
+        primary
+      </Button>
+      <Button kind={Button.types.kind.DEFAULT} size={Button.types.size.LARGE}>
+        default
+      </Button>
+    </>
+  );
+
   return (
     <LongBlock>
       <Button onClick={toggle}>Open</Button>
@@ -24,6 +36,7 @@ const TakeoverStory = ({ children }) => {
         <Takeover.Header
           className="storybook-takeover__header"
           hasCloseButton={boolean("Has close button", true, "Takeover.Header")}
+          headerTools={Tools}
         >
           Header
         </Takeover.Header>

--- a/packages/Takeover/stories/TakeoverStory.js
+++ b/packages/Takeover/stories/TakeoverStory.js
@@ -38,7 +38,7 @@ const TakeoverStory = ({ children }) => {
           hasCloseButton={boolean("Has close button", true, "Takeover.Header")}
           tools={Tools}
         >
-          Header
+          This is suuuuuperrrr longggggg header examppppple which will trigger truncate design
         </Takeover.Header>
         {children}
       </Takeover>

--- a/packages/Takeover/stories/TakeoverStory.js
+++ b/packages/Takeover/stories/TakeoverStory.js
@@ -38,7 +38,7 @@ const TakeoverStory = ({ children }) => {
           hasCloseButton={boolean("Has close button", true, "Takeover.Header")}
           tools={Tools}
         >
-          This is suuuuuperrrr longggggg header examppppple which will trigger truncate design
+          Labore amet ex cillum esse nisi aliqua Lorem occaecat sint occaecat duis elit irure aute.
         </Takeover.Header>
         {children}
       </Takeover>

--- a/packages/Takeover/stories/TakeoverStory.js
+++ b/packages/Takeover/stories/TakeoverStory.js
@@ -36,7 +36,7 @@ const TakeoverStory = ({ children }) => {
         <Takeover.Header
           className="storybook-takeover__header"
           hasCloseButton={boolean("Has close button", true, "Takeover.Header")}
-          headerTools={Tools}
+          tools={Tools}
         >
           Header
         </Takeover.Header>


### PR DESCRIPTION
### Purpose 🚀
Update Takeover component base on the new design guideline.
ticket:
https://aclgrc.atlassian.net/browse/UXD-1978
https://aclgrc.atlassian.net/browse/UXD-1979
https://aclgrc.atlassian.net/browse/UXD-1981

### Notes ✏️
- need to update the overlay component so the backdrop isn't clickable.

### Updates 📦
Will run `yarn changeset` after footer is done.

### Storybook 📕
http://storybooks.highbond-s3.com/paprika/UXD-1978-Takeover-header-style-updates

### Screenshots 📸
![Screen Shot 2022-03-10 at 5 35 24 PM](https://user-images.githubusercontent.com/92405042/157784987-9ddc8091-3615-4957-9447-35a08a3f8159.png)
![Screen Shot 2022-03-10 at 5 35 15 PM](https://user-images.githubusercontent.com/92405042/157784991-91429005-64c7-48a0-b2ac-a93374aa32c9.png)

![Screen Shot 2022-03-10 at 5 37 32 PM](https://user-images.githubusercontent.com/92405042/157785302-0ba89450-e811-4415-92f9-60f9d938b3ce.png)

<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
