### PR TITLE
fix(TimePicker): ASM-2106 period selection doesn't work when hour is 12

### DIFF
--- a/.changeset/sweet-buttons-work.md
+++ b/.changeset/sweet-buttons-work.md
@@ -1,0 +1,5 @@
+---
+"@paprika/time-picker": patch
+---
+
+fix period select issue when hour is 12

--- a/packages/TimePicker/src/TimeInterpreter.js
+++ b/packages/TimePicker/src/TimeInterpreter.js
@@ -9,10 +9,17 @@ function getValidFormatMomentValue(time) {
   const momentValue = moment(time, possibleFormats);
 
   // Add extra am/pm logic to help handle period cases
-  if (momentValue.isValid() && momentValue.hours() < 12) {
+  if (momentValue.isValid()) {
     const lowerCaseTime = time.toLowerCase();
-    if (lowerCaseTime.endsWith("pm") || lowerCaseTime.endsWith("p")) {
-      momentValue.add(12, "hours");
+    if (momentValue.hours() === 12) {
+      if (lowerCaseTime.endsWith("am") || lowerCaseTime.endsWith("a")) {
+        momentValue.add(12, "hours");
+      }
+    }
+    if (momentValue.hours() < 12) {
+      if (lowerCaseTime.endsWith("pm") || lowerCaseTime.endsWith("p")) {
+        momentValue.add(12, "hours");
+      }
     }
   }
 


### PR DESCRIPTION
### Purpose 🚀
When HH === 12, the AM/PM period selector isn't working properly

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/ASM-2106--fix-timepicker

### Screenshots 📸
Before:

https://user-images.githubusercontent.com/92059030/159816858-5c877b6f-4ae9-4bf3-b632-4ab2267b98d0.mov


After:

https://user-images.githubusercontent.com/92059030/159817011-b00c37d3-15c9-4ab9-9c5a-ece04f3f051e.mov


### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
