### PR TITLE
RNG-372 Fix broken import in OverflowMenu.Trigger 🐐

### DIFF
--- a/.changeset/quick-boxes-relate.md
+++ b/.changeset/quick-boxes-relate.md
@@ -1,0 +1,5 @@
+---
+"@paprika/overflow-menu": patch
+---
+
+Fix an import of `@paprika/button` in Trigger subcomponent

--- a/packages/OverflowMenu/src/components/Trigger/Trigger.js
+++ b/packages/OverflowMenu/src/components/Trigger/Trigger.js
@@ -1,8 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import RawButton from "@paprika/raw-button";
-// import Button from "@paprika/button";
-import Button from "../../../../Button";
+import Button from "@paprika/button";
 import * as types from "../../types";
 
 const ButtonComponentMap = {


### PR DESCRIPTION
### Purpose 🚀
Fix an import of `@paprika/button` in `<OverflowMenu.Trigger>` subcomponent.

### Notes ✏️
- Mistakenly broken in this PR https://github.com/acl-services/paprika/pull/1235/files#diff-f3b0ef67cf665a5cce23c1ae77d8dccaa87149196628080c5a1997c2a3d76fecL4

- Error seen in consuming app:
```
./node_modules/@paprika/overflow-menu/lib/components/Trigger/Trigger.js
Cannot find file: 'index.js' does not match the corresponding name on disk: './node_modules/@paprika/Button/lib/button'.
```



### References 🔗
https://aclgrc.atlassian.net/browse/RNG-372


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
