### PR TITLE
Uxd 2022 uploader fix on error

### DIFF
--- a/.changeset/spicy-dots-press.md
+++ b/.changeset/spicy-dots-press.md
@@ -1,0 +1,5 @@
+---
+"@paprika/uploader": minor
+---
+
+Fixed onError callback being called unnecessarily

--- a/packages/Uploader/src/components/File/File.js
+++ b/packages/Uploader/src/components/File/File.js
@@ -96,11 +96,16 @@ function File(props) {
     }
   }
 
+  function getErrorMessage() {
+    return typeof onError === "function" ? onError(error) : error;
+  }
+
   function getProgressText(showA11yProgress) {
-    const errorMessage = typeof onError === "function" ? onError(error) : error;
     switch (status) {
       case types.status.ERROR:
-        return showA11yProgress ? I18n.t("uploader.progress.error", { name, error: errorMessage }) : errorMessage;
+        return showA11yProgress
+          ? I18n.t("uploader.progress.error", { name, error: getErrorMessage() })
+          : getErrorMessage();
       case types.status.SUCCESS:
         return showA11yProgress
           ? I18n.t("uploader.progress.file_progress", { name, progress: I18n.t("uploader.progress.complete") })

--- a/packages/Uploader/stories/Uploader.stories.js
+++ b/packages/Uploader/stories/Uploader.stories.js
@@ -15,6 +15,9 @@ const props = {
   onChange: files => {
     console.log("Selected files:", files);
   },
+  onError: error => {
+    console.log("There was an error", error);
+  },
 };
 
 const fileProps = {


### PR DESCRIPTION
### Purpose 🚀

https://aclgrc.atlassian.net/browse/UXD-2022
Fix Uploader `onError` being called unnecessarily

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
