### PR TITLE
fix(Helpers): UXD-2055 fix shadow root test error

### DIFF
--- a/.changeset/forty-trainers-check.md
+++ b/.changeset/forty-trainers-check.md
@@ -1,0 +1,5 @@
+---
+"@paprika/helpers": minor
+---
+
+Fix ShadowRoot not defined error triggered in application unit tests

--- a/packages/helpers/src/customPropTypes.js
+++ b/packages/helpers/src/customPropTypes.js
@@ -58,4 +58,7 @@ export const FocusPropTypes = {
 export const RefOf = (propType = PropTypes.object) =>
   PropTypes.oneOfType([PropTypes.func, PropTypes.shape({ current: propType })]);
 
-export const DOMElementType = PropTypes.oneOfType([PropTypes.instanceOf(Element), PropTypes.instanceOf(ShadowRoot)]);
+export const DOMElementType = PropTypes.oneOfType([
+  PropTypes.instanceOf(Element),
+  PropTypes.instanceOf(window.ShadowRoot),
+]);


### PR DESCRIPTION
### Purpose 🚀

Ticket: https://aclgrc.atlassian.net/browse/UXD-2055
Some packages use the helpers paprika package, which uses customPropTypes file and references ShadowRoot. In a Jest test environment this needs to be window.ShadowRoot to avoid an ShadowRoot doesn't exist error.

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
