### PR TITLE
TW-2941 Make `internalHandleOnClick` and `id` props optional

### DIFF
--- a/.changeset/hip-jokes-care.md
+++ b/.changeset/hip-jokes-care.md
@@ -1,0 +1,5 @@
+---
+"@paprika/list-box": patch
+---
+
+Make `internalHandleOnClick` and `id` props optional

--- a/packages/ListBox/README.md
+++ b/packages/ListBox/README.md
@@ -100,20 +100,20 @@ see: options/helpers/options.js|
 
 ### ListBox.Option
 
-| Prop                   | Type        | required | default | Description                                                                            |
-| ---------------------- | ----------- | -------- | ------- | -------------------------------------------------------------------------------------- |
-| children               | [node,func] | true     | -       | String, number or JSX content                                                          |
-| isSelected             | bool        | false    | null    |                                                                                        |
-| defaultIsSelected      | bool        | false    | null    | Describe if the option started as selected or not                                      |
-| hasNoIcon              | bool        | false    | false   | When no PlusIcon or CheckBox are needed                                                |
-| isDisabled             | bool        | false    | false   | Describe if the option is enable or not                                                |
-| isHidden               | bool        | false    | false   | Describe if the option is hidden or not                                                |
-| label                  | string      | false    | null    | When the children are not a String, label should need to be add so the filter can work |
-| onClick                | func        | false    | null    | Callback for the clicking event                                                        |
-| value                  | any         | false    | null    | Value of your option this can be any data structure                                    |
-| internalHandleOnClick  | func        | true     | -       | Internal prop, which shouldn't be documented                                           |
-| id                     | string      | true     | -       | Internal prop, which shouldn't be documented                                           |
-| preventDefaultOnSelect | bool        | false    | false   | Internal prop, which shouldn't be documented                                           |
+| Prop                   | Type        | required | default    | Description                                                                            |
+| ---------------------- | ----------- | -------- | ---------- | -------------------------------------------------------------------------------------- |
+| children               | [node,func] | true     | -          | String, number or JSX content                                                          |
+| isSelected             | bool        | false    | null       |                                                                                        |
+| defaultIsSelected      | bool        | false    | null       | Describe if the option started as selected or not                                      |
+| hasNoIcon              | bool        | false    | false      | When no PlusIcon or CheckBox are needed                                                |
+| isDisabled             | bool        | false    | false      | Describe if the option is enable or not                                                |
+| isHidden               | bool        | false    | false      | Describe if the option is hidden or not                                                |
+| label                  | string      | false    | null       | When the children are not a String, label should need to be add so the filter can work |
+| onClick                | func        | false    | null       | Callback for the clicking event                                                        |
+| value                  | any         | false    | null       | Value of your option this can be any data structure                                    |
+| internalHandleOnClick  | func        | false    | () => null | Internal prop, which shouldn't be documented                                           |
+| id                     | string      | false    | ""         | Internal prop, which shouldn't be documented                                           |
+| preventDefaultOnSelect | bool        | false    | false      | Internal prop, which shouldn't be documented                                           |
 
 ### ListBox.Popover
 

--- a/packages/ListBox/src/components/Option/Option.js
+++ b/packages/ListBox/src/components/Option/Option.js
@@ -89,10 +89,10 @@ Option.propTypes = {
   value: PropTypes.any, // eslint-disable-line
 
   /** Internal prop, which shouldn't be documented */
-  internalHandleOnClick: PropTypes.func.isRequired,
+  internalHandleOnClick: PropTypes.func,
 
   /** Internal prop, which shouldn't be documented */
-  id: PropTypes.string.isRequired,
+  id: PropTypes.string,
 
   /** Internal prop, which shouldn't be documented */
   preventDefaultOnSelect: PropTypes.bool,
@@ -102,6 +102,8 @@ Option.defaultProps = {
   hasNoIcon: false,
   isDisabled: false,
   isHidden: false,
+  id: "",
+  internalHandleOnClick: () => null,
   preventDefaultOnSelect: false,
   isSelected: null,
   defaultIsSelected: null,

--- a/packages/ListBox/src/index.d.ts
+++ b/packages/ListBox/src/index.d.ts
@@ -149,9 +149,9 @@ declare namespace ListBox {
     /** Value of your option this can be any data structure */
     value?: any;
     /** Internal prop, which shouldn't be documented */
-    internalHandleOnClick: (...args: any[]) => any;
+    internalHandleOnClick?: (...args: any[]) => any;
     /** Internal prop, which shouldn't be documented */
-    id: string;
+    id?: string;
     /** Internal prop, which shouldn't be documented */
     preventDefaultOnSelect?: boolean;
   }


### PR DESCRIPTION
### Purpose 🚀
Make `internalHandleOnClick` and `id` props optional.

These props get added with a React.cloneElement() call and provide the necessary functionality to the items.  Even though they're required for the component to work, the consumer doesn't provide them manually. So, they don't need to be flagged as required in the propTypes / type definitions.


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
