### PR TITLE
fix(Uploader): stop reseting input value in uploader component

### DIFF
--- a/.changeset/famous-queens-switch.md
+++ b/.changeset/famous-queens-switch.md
@@ -1,0 +1,5 @@
+---
+"@paprika/uploader": patch
+---
+
+Stop reseting input value

--- a/packages/Uploader/src/Uploader.js
+++ b/packages/Uploader/src/Uploader.js
@@ -161,12 +161,7 @@ const Uploader = React.forwardRef((props, ref) => {
       if (isDisabled || isBusy) return;
 
       const files = getFiles({ event, maxFileSize, supportedMimeTypes, endpoint });
-      setFiles(() => {
-        if (refInput.current) {
-          refInput.current.value = "";
-        }
-        return canChooseMultiple ? files : [files[0]]; // in case only allow one file per upload
-      });
+      setFiles(() => (canChooseMultiple ? files : [files[0]])); // in case only allow one file per upload
       onChange(files);
     },
     [canChooseMultiple, endpoint, isDisabled, isBusy, maxFileSize, setFiles, supportedMimeTypes, onChange]


### PR DESCRIPTION
### Purpose 🚀
stop reseting input value in uploader component

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
