### PR TITLE
fix(Uploader): assign files on the html input when drag drop

### DIFF
--- a/.changeset/wise-cows-repair.md
+++ b/.changeset/wise-cows-repair.md
@@ -1,0 +1,5 @@
+---
+"@paprika/uploader": patch
+---
+
+Assign files to the html input when using drag&drop

--- a/packages/Uploader/src/Uploader.js
+++ b/packages/Uploader/src/Uploader.js
@@ -157,8 +157,13 @@ const Uploader = React.forwardRef((props, ref) => {
   });
 
   const handleChange = React.useCallback(
-    event => {
+    (event, fromDrop) => {
       if (isDisabled || isBusy) return;
+
+      if (fromDrop && refInput.current) {
+        // eslint-disable-next-line no-param-reassign
+        refInput.current.files = canChooseMultiple ? event.dataTransfer.files : event.dataTransfer.files[0];
+      }
 
       const files = getFiles({ event, maxFileSize, supportedMimeTypes, endpoint });
       setFiles(() => (canChooseMultiple ? files : [files[0]])); // in case only allow one file per upload

--- a/packages/Uploader/src/Uploader.js
+++ b/packages/Uploader/src/Uploader.js
@@ -161,7 +161,6 @@ const Uploader = React.forwardRef((props, ref) => {
       if (isDisabled || isBusy) return;
 
       if (fromDrop && refInput.current) {
-        // eslint-disable-next-line no-param-reassign
         refInput.current.files = canChooseMultiple ? event.dataTransfer.files : event.dataTransfer.files[0];
       }
 

--- a/packages/Uploader/src/useDragAndDropEvents.js
+++ b/packages/Uploader/src/useDragAndDropEvents.js
@@ -18,11 +18,12 @@ export default function useDragAndDropZoneEvents({ dropArea = () => document.bod
     }
 
     function onDrop(event) {
+      const fromDrop = true;
       // this prevent images from rendering on the browser
       setisDraggingOver(() => false);
       setIsDragLeave(() => true);
       event.preventDefault();
-      handleChange(event);
+      handleChange(event, fromDrop);
     }
 
     const element = dropArea();


### PR DESCRIPTION
### Purpose 🚀

When users upload files through drag&drop, the input `onChange` event won't be triggered as normal. So manually assign the `files` to `files` property on the html input element inside the uploader

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
