### PR TITLE
fix(Uploader): Fixed drag&drop issue when canChooseMultiple is false

### DIFF
--- a/.changeset/plenty-fans-draw.md
+++ b/.changeset/plenty-fans-draw.md
@@ -1,0 +1,5 @@
+---
+"@paprika/uploader": patch
+---
+
+Fixed drag&drop issue when canChooseMultiple is false

--- a/packages/Uploader/src/Uploader.js
+++ b/packages/Uploader/src/Uploader.js
@@ -161,7 +161,14 @@ const Uploader = React.forwardRef((props, ref) => {
       if (isDisabled || isBusy) return;
 
       if (fromDrop && refInput.current) {
-        refInput.current.files = canChooseMultiple ? event.dataTransfer.files : event.dataTransfer.files[0];
+        if (canChooseMultiple) {
+          refInput.current.files = event.dataTransfer.files;
+        } else {
+          const dataTransfer = new DataTransfer();
+
+          dataTransfer.items.add(event.dataTransfer.files[0]);
+          refInput.current.files = dataTransfer.files;
+        }
       }
 
       const files = getFiles({ event, maxFileSize, supportedMimeTypes, endpoint });


### PR DESCRIPTION
### Purpose 🚀

Using `DataTransfer` to convert the original FileList to a filtered FileList

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
