### PR TITLE
UXD-2116 Fix Typescript definition for Card subcomponents 🐐

### DIFF
--- a/.changeset/tall-turkeys-dance.md
+++ b/.changeset/tall-turkeys-dance.md
@@ -1,0 +1,5 @@
+---
+"@paprika/card": patch
+---
+
+Fix subcomponent `displayName` properties and update typings to include subcomponents in the `Card` namespace.

--- a/packages/Card/src/components/Content/Content.js
+++ b/packages/Card/src/components/Content/Content.js
@@ -17,7 +17,7 @@ function Content(props) {
   return <sc.Content data-pka-anchor="card.content">{children}</sc.Content>;
 }
 
-Content.displayName = "Content";
+Content.displayName = "Card.Content";
 Content.propTypes = propTypes;
 Content.defaultProps = defaultProps;
 

--- a/packages/Card/src/components/Footer/Footer.js
+++ b/packages/Card/src/components/Footer/Footer.js
@@ -21,7 +21,7 @@ const Footer = props => {
   );
 };
 
-Footer.displayName = "Footer";
+Footer.displayName = "Card.Footer";
 Footer.propTypes = propTypes;
 Footer.defaultProps = defaultProps;
 

--- a/packages/Card/src/components/Metadata/Metadata.js
+++ b/packages/Card/src/components/Metadata/Metadata.js
@@ -21,7 +21,7 @@ const Metadata = props => {
   );
 };
 
-Metadata.displayName = "Metadata";
+Metadata.displayName = "Card.Metadata";
 Metadata.propTypes = propTypes;
 Metadata.defaultProps = defaultProps;
 

--- a/packages/Card/src/components/Text/Text.js
+++ b/packages/Card/src/components/Text/Text.js
@@ -39,7 +39,7 @@ const Text = props => {
   );
 };
 
-Text.displayName = "Text";
+Text.displayName = "Card.Text";
 Text.propTypes = propTypes;
 Text.defaultProps = defaultProps;
 

--- a/packages/Card/src/components/Title/Title.js
+++ b/packages/Card/src/components/Title/Title.js
@@ -20,7 +20,7 @@ const Title = props => {
   );
 };
 
-Title.displayName = "Title";
+Title.displayName = "Card.Title";
 Title.propTypes = propTypes;
 Title.defaultProps = defaultProps;
 

--- a/packages/Card/src/index.d.ts
+++ b/packages/Card/src/index.d.ts
@@ -12,19 +12,23 @@ interface CardProps {
   /** Size of the card (font size, min-height, padding, etc). */
   size?: Card.types.size.AUTO | Card.types.size.SMALL | Card.types.size.MEDIUM | Card.types.size.LARGE;
 }
-declare function Content(props: ContentProps): JSX.Element;
-interface ContentProps {
-  [x: string]: any;
-  /** Primary content. */
-  children?: React.ReactNode;
-}
-declare function Footer(props: FooterProps): JSX.Element;
-interface FooterProps {
-  [x: string]: any;
-  /** Body content of the footer */
-  children?: React.ReactNode;
-}
 
+declare namespace Card {
+  function Content(props: ContentProps): JSX.Element;
+  interface ContentProps {
+    [x: string]: any;
+    /** Primary content. */
+    children?: React.ReactNode;
+  }
+}
+declare namespace Card {
+  function Footer(props: FooterProps): JSX.Element;
+  interface FooterProps {
+    [x: string]: any;
+    /** Body content of the footer */
+    children?: React.ReactNode;
+  }
+}
 declare namespace Card {
   function Header(props: HeaderProps): JSX.Element;
   interface HeaderProps {
@@ -33,25 +37,31 @@ declare namespace Card {
     children?: React.ReactNode;
   }
 }
-declare function Metadata(props: MetadataProps): JSX.Element;
-interface MetadataProps {
-  [x: string]: any;
-  /** Primary content. */
-  children?: React.ReactNode;
+declare namespace Card {
+  function Metadata(props: MetadataProps): JSX.Element;
+  interface MetadataProps {
+    [x: string]: any;
+    /** Primary content. */
+    children?: React.ReactNode;
+  }
 }
-declare function Text(props: TextProps): JSX.Element;
-interface TextProps {
-  [x: string]: any;
-  /** Body content of the Text. */
-  children?: React.ReactNode;
-  /** Sets the maximum text length visible on the card */
-  maxTextLength?: number;
+declare namespace Card {
+  function Text(props: TextProps): JSX.Element;
+  interface TextProps {
+    [x: string]: any;
+    /** Body content of the Text. */
+    children?: React.ReactNode;
+    /** Sets the maximum text length visible on the card */
+    maxTextLength?: number;
+  }
 }
-declare function Title(props: TitleProps): JSX.Element;
-interface TitleProps {
-  [x: string]: any;
-  /** Body content of the Title. */
-  children?: React.ReactNode;
+declare namespace Card {
+  function Title(props: TitleProps): JSX.Element;
+  interface TitleProps {
+    [x: string]: any;
+    /** Body content of the Title. */
+    children?: React.ReactNode;
+  }
 }
 
 declare namespace Card {


### PR DESCRIPTION
### Purpose 🚀
Fix `<Card>` typings to include subcomponents in the `Card` namespace.

### Notes ✏️
- Fixed subcomponent `displayNames` and regenerated typings files by running `generateTypeDefinitionsForJS` script

### References 🔗
https://aclgrc.atlassian.net/browse/UXD-2116


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
