### PR TITLE
fix(DateInput): FS-3112 Support of `hasClearButton`

### DIFF
--- a/.changeset/bright-beans-cry.md
+++ b/.changeset/bright-beans-cry.md
@@ -1,0 +1,5 @@
+---
+"@paprika/date-input": patch
+---
+
+Support of `hasClearButton`

--- a/packages/DateInput/src/DateInput.js
+++ b/packages/DateInput/src/DateInput.js
@@ -138,6 +138,12 @@ const DateInput = React.forwardRef((props, ref) => {
   }
 
   function handleInputChange(e) {
+    // this handler is called with null when input cleared (when hasClearButton is true)
+    if (!e) {
+      handleReset();
+      return;
+    }
+
     setInputtedString(e.target.value);
   }
 


### PR DESCRIPTION
### Purpose 🚀
```jsx
<DatePicker>
  <DatePicker.Input hasClearButton />
</DatePicker>
```
This code currently doesn't work (crashes)

It will be fixed by this PR.


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
