### PR TITLE
feat(ReactFocusLock): allow pendo elements to steal focus

### DIFF
--- a/.changeset/warm-tools-reply.md
+++ b/.changeset/warm-tools-reply.md
@@ -1,0 +1,7 @@
+---
+"@paprika/modal": patch
+"@paprika/overlay": patch
+"@paprika/takeover": patch
+---
+
+Allow pendo elements to steal focus from react-focus-lock.

--- a/packages/Modal/src/components/FocusLock/FocusLock.js
+++ b/packages/Modal/src/components/FocusLock/FocusLock.js
@@ -11,11 +11,13 @@ const defaultProps = {
 const FocusLock = props => {
   // ignore any focusable elements in pendo container
   function whiteList(node) {
+    const { whiteList: whiteListProp } = props;
     const pendoContainer = document.getElementById("pendo-base");
+    const whiteListPropResult = whiteListProp ? whiteListProp(node) : true;
 
-    if (!pendoContainer) return true;
+    if (!pendoContainer) return whiteListPropResult;
 
-    return !pendoContainer.contains(node);
+    return !pendoContainer.contains(node) && whiteListPropResult;
   }
 
   return <FocusLockLibrary whiteList={whiteList} {...props} />;

--- a/packages/Modal/src/components/FocusLock/FocusLock.js
+++ b/packages/Modal/src/components/FocusLock/FocusLock.js
@@ -9,7 +9,8 @@ const defaultProps = {
 };
 
 const FocusLock = props => {
-  // ignore any focusable elements in pendo container
+  // ignore any focusable elements in pendo container, react-focus-lock expects false to be able to ignore them
+  // https://github.com/theKashey/react-focus-lock#focus-fighting
   function whiteList(node) {
     const { whiteList: whiteListProp } = props;
     const pendoContainer = document.getElementById("pendo-base");

--- a/packages/Modal/src/components/FocusLock/FocusLock.js
+++ b/packages/Modal/src/components/FocusLock/FocusLock.js
@@ -8,7 +8,18 @@ const defaultProps = {
   returnFocus: true,
 };
 
-const FocusLock = props => <FocusLockLibrary {...props} />;
+const FocusLock = props => {
+  // ignore any focusable elements in pendo container
+  function whiteList(node) {
+    const pendoContainer = document.getElementById("pendo-base");
+
+    if (!pendoContainer) return true;
+
+    return !pendoContainer.contains(node);
+  }
+
+  return <FocusLockLibrary whiteList={whiteList} {...props} />;
+};
 
 FocusLock.propTypes = propTypes;
 FocusLock.defaultProps = defaultProps;

--- a/packages/Overlay/src/Overlay.js
+++ b/packages/Overlay/src/Overlay.js
@@ -95,7 +95,8 @@ const Overlay = props => {
     }
   }
 
-  // ignore any focusable elements in pendo container
+  // ignore any focusable elements in pendo container, react-focus-lock expects false to be able to ignore them
+  // https://github.com/theKashey/react-focus-lock#focus-fighting
   function whiteList(node) {
     const { whiteList: whiteListProp } = focusLockOptions;
     const pendoContainer = document.getElementById("pendo-base");

--- a/packages/Overlay/src/Overlay.js
+++ b/packages/Overlay/src/Overlay.js
@@ -97,11 +97,13 @@ const Overlay = props => {
 
   // ignore any focusable elements in pendo container
   function whiteList(node) {
+    const { whiteList: whiteListProp } = focusLockOptions;
     const pendoContainer = document.getElementById("pendo-base");
+    const whiteListPropResult = whiteListProp ? whiteListProp(node) : true;
 
-    if (!pendoContainer) return true;
+    if (!pendoContainer) return whiteListPropResult;
 
-    return !pendoContainer.contains(node);
+    return !pendoContainer.contains(node) && whiteListPropResult;
   }
 
   const _focusLockOptions = {

--- a/packages/Overlay/src/Overlay.js
+++ b/packages/Overlay/src/Overlay.js
@@ -95,6 +95,15 @@ const Overlay = props => {
     }
   }
 
+  // ignore any focusable elements in pendo container
+  function whiteList(node) {
+    const pendoContainer = document.getElementById("pendo-base");
+
+    if (!pendoContainer) return true;
+
+    return !pendoContainer.contains(node);
+  }
+
   const _focusLockOptions = {
     returnFocus: true,
     ...focusLockOptions,
@@ -123,7 +132,11 @@ const Overlay = props => {
                   data-pka-anchor="overlay.backdrop"
                 />
               )}
-              <FocusLock disabled={state === "exiting" || state === "exited"} {..._focusLockOptions}>
+              <FocusLock
+                disabled={state === "exiting" || state === "exited"}
+                whiteList={whiteList}
+                {..._focusLockOptions}
+              >
                 {children && children(state)}
               </FocusLock>
             </sc.Overlay>

--- a/packages/Takeover/src/components/FocusLock/FocusLock.js
+++ b/packages/Takeover/src/components/FocusLock/FocusLock.js
@@ -11,11 +11,13 @@ const defaultProps = {
 const FocusLock = props => {
   // ignore any focusable elements in pendo container
   function whiteList(node) {
+    const { whiteList: whiteListProp } = props;
     const pendoContainer = document.getElementById("pendo-base");
+    const whiteListPropResult = whiteListProp ? whiteListProp(node) : true;
 
-    if (!pendoContainer) return true;
+    if (!pendoContainer) return whiteListPropResult;
 
-    return !pendoContainer.contains(node);
+    return !pendoContainer.contains(node) && whiteListPropResult;
   }
 
   return <FocusLockLibrary whiteList={whiteList} {...props} />;

--- a/packages/Takeover/src/components/FocusLock/FocusLock.js
+++ b/packages/Takeover/src/components/FocusLock/FocusLock.js
@@ -9,7 +9,8 @@ const defaultProps = {
 };
 
 const FocusLock = props => {
-  // ignore any focusable elements in pendo container
+  // ignore any focusable elements in pendo container, react-focus-lock expects false to be able to ignore them
+  // https://github.com/theKashey/react-focus-lock#focus-fighting
   function whiteList(node) {
     const { whiteList: whiteListProp } = props;
     const pendoContainer = document.getElementById("pendo-base");

--- a/packages/Takeover/src/components/FocusLock/FocusLock.js
+++ b/packages/Takeover/src/components/FocusLock/FocusLock.js
@@ -8,7 +8,18 @@ const defaultProps = {
   returnFocus: true,
 };
 
-const FocusLock = props => <FocusLockLibrary {...props} />;
+const FocusLock = props => {
+  // ignore any focusable elements in pendo container
+  function whiteList(node) {
+    const pendoContainer = document.getElementById("pendo-base");
+
+    if (!pendoContainer) return true;
+
+    return !pendoContainer.contains(node);
+  }
+
+  return <FocusLockLibrary whiteList={whiteList} {...props} />;
+};
 
 FocusLock.propTypes = propTypes;
 FocusLock.defaultProps = defaultProps;


### PR DESCRIPTION
### Purpose 🚀
Paprika modal components – <Modal>, <Takeover> and <Panel> (with <Panel.Overlay>) – are not allowing focus to remain in the Pendo tagging overlay’s  <input> fields.  This is creating a very annoying experience when trying to tag UI elements for usage tracking.

### Notes ✏️

- [x] Verified there'll be only 1 `#pendo-base` element in the dom tree on each page
- [x] Allows all the focusable elements inside `#pendo-base` to steal the focus from react-focus-lock

### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/UXD-2122-allow-pendo-elements-to-steal-focus

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
