### PR TITLE
fix(ListBoxWithTags): FS-3112 Fix focus after select

### DIFF
--- a/.changeset/five-bags-refuse.md
+++ b/.changeset/five-bags-refuse.md
@@ -1,0 +1,5 @@
+---
+"@paprika/list-box-with-tags": patch
+---
+
+Fix focus after select

--- a/packages/ListBoxWithTags/src/ListBoxWithTags.js
+++ b/packages/ListBoxWithTags/src/ListBoxWithTags.js
@@ -125,7 +125,7 @@ export default function ListBoxWithTags(props) {
         refListBox.current.setFocusOptionByIndex(lastSelectedOption);
       }
     }
-  });
+  }, [lastSelectedOption]);
 
   return (
     <div ref={refDivRoot}>


### PR DESCRIPTION
### Purpose 🚀
`ListBoxWithTags` crashes after selecting option and typing something in search box.
Reason: stale value in `lastSelectedOption`. This value references non-existing option (because after search there can be completly different list of options)
