### PR TITLE
fix(CollapsibleCard): fix not controllable issue

### DIFF
--- a/.changeset/weak-brooms-pull.md
+++ b/.changeset/weak-brooms-pull.md
@@ -1,0 +1,5 @@
+---
+"@paprika/collapsible-card": minor
+---
+
+Fixed CollapsibleCard not controllale issue. If you don't want the card to be toggled, return `true` from the `onToggleIsCollapsed` callback.

--- a/packages/CollapsibleCard/src/CollapsibleCard.js
+++ b/packages/CollapsibleCard/src/CollapsibleCard.js
@@ -24,8 +24,11 @@ export default function CollapsibleCard(props) {
   }, [props.isCollapsed, initialIsCollapsed]);
 
   function handleToggleIsCollapsed() {
-    onToggleIsCollapsed(!isCollapsed);
-    setIsCollapsed(oldValue => !oldValue);
+    const shouldStay = onToggleIsCollapsed(!isCollapsed);
+
+    if (!shouldStay) {
+      setIsCollapsed(oldValue => !oldValue);
+    }
   }
 
   const thingsToShare = {
@@ -65,6 +68,8 @@ const defaultProps = {
   initialIsCollapsed: true,
   isCollapsed: null,
   isEditing: false,
+
+  /** Callback to be executed when the card is being toggled. If you don't want the card to be toggled, return `true` from the callback. */
   onToggleIsCollapsed: () => {},
   position: null,
 };

--- a/packages/CollapsibleCard/stories/examples/ControlledAndUncontrolled.js
+++ b/packages/CollapsibleCard/stories/examples/ControlledAndUncontrolled.js
@@ -5,6 +5,7 @@ import CollapsibleCard from "../../src";
 
 const ControlledAndUncontrolledStory = () => {
   const [isCollapsed, setIsCollapsed] = React.useState(true);
+  const [isLocked, setIsLocked] = React.useState(false);
 
   return (
     <Story>
@@ -33,15 +34,27 @@ const ControlledAndUncontrolledStory = () => {
       <button
         type="button"
         onClick={() => {
-          setIsCollapsed(oldVal => !oldVal);
+          if (isLocked) return;
+          setIsCollapsed(oldIsCollapsed => !oldIsCollapsed);
         }}
       >
         {isCollapsed ? "open" : "close"}
       </button>
+      <button
+        type="button"
+        onClick={() => {
+          setIsLocked(oldIsLocked => !oldIsLocked);
+        }}
+      >
+        Lock the toggle
+      </button>
+      Toggle function is {!isLocked && "not"} locked
       <CollapsibleCard
         isCollapsed={isCollapsed}
         onToggleIsCollapsed={newStateIsCollapsed => {
-          console.log(newStateIsCollapsed ? "collapsed it" : "expanded it");
+          if (isLocked) {
+            return true;
+          }
           setIsCollapsed(newStateIsCollapsed);
         }}
       >


### PR DESCRIPTION
### Purpose 🚀
 fix `CollapsibleCard` not controllable issue https://aclgrc.atlassian.net/browse/UXD-2135

### Notes ✏️

I know this is not a proper fix 😬  
Basically the CollapsibleCard will expand/collapse every time when users click on the card header, even the prop `isCollapsed` doesn't change
A proper fix might be always respecting the value of `isCollapsed` prop, if it's not `null` we just don't use the internal state. However that would be a major bump, it might break somewhere in our platform if the consumer uses `isCollapsed`

So I added some comments and example to demonstrate how to skip the internal state update. I've also checked with our designer, this use case won't be common anyway, we should always let the user expand/collapse the card. We can convert this PR to an issue if we don't want to fix. 

Can be tested in the `Controlled` example here http://storybooks.highbond-s3.com/paprika/UXD-2133-fix-collapsible-card-not-controllable/?path=/story/navigation-collapsiblecard--controlled-and-uncontrolled

### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/UXD-2133-fix-collapsible-card-not-controllable

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
