### PR TITLE
fix(DataTable): TW-3363 Sanitize html rendered in DataTable VariableList

### DIFF
--- a/.changeset/kind-lemons-train.md
+++ b/.changeset/kind-lemons-train.md
@@ -1,0 +1,5 @@
+---
+"@paprika/data-table": minor
+---
+
+Sanitizize html in DataTable VariableList component

--- a/packages/DataTable/package.json
+++ b/packages/DataTable/package.json
@@ -31,9 +31,11 @@
     "react-table": "^7.7.0",
     "react-window": "^1.8.6",
     "lodash.isequal": "^4.5.0",
-    "react-window-infinite-loader": "^1.0.7"
+    "react-window-infinite-loader": "^1.0.7",
+    "dompurify": "^2.4.0"
   },
   "devDependencies": {
+    "@types/dompurify": "^2.3.3",
     "@paprika/input": "^5.0.2",
     "@paprika/button": "^1.1.16",
     "@types/lodash.debounce": "^4.0.6",

--- a/packages/DataTable/src/helpers/rowHeightHelper.ts
+++ b/packages/DataTable/src/helpers/rowHeightHelper.ts
@@ -1,4 +1,5 @@
 import tokens from "@paprika/tokens";
+import { sanitize } from "dompurify";
 import { TableDataItemType, TableColumnsWidth } from "../types";
 
 const DEFAULT_HEIGHT = 40;
@@ -68,7 +69,7 @@ export default class RowHeightHelper {
     for (let [key, value] of Object.entries(rowData)) {
       if (Object.prototype.hasOwnProperty.call(columnsWidth, key)) {
         innerElementsForTheRow.push(
-          `<div style="box-sizing:border-box;width:${columnsWidth[key]}px;${this.styles}">${value}</div>`
+          `<div style="box-sizing:border-box;width:${columnsWidth[key]}px;${this.styles}">${sanitize(value)}</div>`
         );
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5420,6 +5420,13 @@
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.0.tgz#14f854c0f93d326e39da6e3b6f34f7d37513d108"
   integrity sha512-y7mImlc/rNkvCRmg8gC3/lj87S7pTUIJ6QGjwHR9WQJcFs+ZMTOaoPrkdFA/YdbuqVEmEbb5RdhVxMkAcgOnpg==
 
+"@types/dompurify@^2.3.3":
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/@types/dompurify/-/dompurify-2.3.4.tgz#94e997e30338ea24d4c8d08beca91ce4dd17a1b4"
+  integrity sha512-EXzDatIb5EspL2eb/xPGmaC8pePcTHrkDCONjeisusLFrVfl38Pjea/R0YJGu3k9ZQadSvMqW0WXPI2hEo2Ajg==
+  dependencies:
+    "@types/trusted-types" "*"
+
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
@@ -5808,6 +5815,11 @@
   dependencies:
     "@types/react" "*"
     "@types/react-test-renderer" "*"
+
+"@types/trusted-types@*":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.2.tgz#fc25ad9943bcac11cceb8168db4f275e0e72e756"
+  integrity sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==
 
 "@types/uglify-js@*":
   version "3.9.2"
@@ -9384,6 +9396,11 @@ domhandler@^2.3.0:
   integrity sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==
   dependencies:
     domelementtype "1"
+
+dompurify@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.4.0.tgz#c9c88390f024c2823332615c9e20a453cf3825dd"
+  integrity sha512-Be9tbQMZds4a3C6xTmz68NlMfeONA//4dOavl/1rNw50E+/QO0KVpbcU0PcaW0nsQxurXls9ZocqFxk8R2mWEA==
 
 domutils@1.5.1:
   version "1.5.1"


### PR DESCRIPTION
### Purpose 🚀

Ticket: https://diligentbrands.atlassian.net/browse/TW-3363

There is a security issue with the DataTable component in that non sanitized data is rendered to the Dom via the VariableList subcomponent, row height calculations.

This pr sanitizes that html

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/tw-3363-sanitize-data-table-html

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
