### PR TITLE
fix(CollapsibleCard): TW-3405 Fix collapsible header bug causing unre…

### DIFF
--- a/.changeset/young-moose-bake.md
+++ b/.changeset/young-moose-bake.md
@@ -1,0 +1,5 @@
+---
+"@paprika/collapsible-card": minor
+---
+
+Fix collapsible header bug causing unrequired re-render leading to cypress test errors

--- a/packages/CollapsibleCard/src/components/Header/Header.js
+++ b/packages/CollapsibleCard/src/components/Header/Header.js
@@ -34,7 +34,9 @@ export default function Header(props) {
   }, []);
 
   React.useEffect(() => {
-    setIsBroken(collapsibleCardWidth < breakpoint);
+    if (collapsibleCardWidth !== null) {
+      setIsBroken(collapsibleCardWidth < breakpoint);
+    }
   }, [collapsibleCardWidth, breakpoint, setIsBroken]);
 
   React.useEffect(() => {


### PR DESCRIPTION
…quired re-render leading to cypress test errors

Collapsible Card Header component re-renders unnecessarily when mounting due to an unnecessary state change. More detail [here](https://github.com/acl-services/paprika/pull/1286/files#r990280596)

Ticket: https://diligentbrands.atlassian.net/browse/TW-3405

### Purpose 🚀
_clear, one sentence description of primary purpose of this PR_

### Notes ✏️
_details of code change / secondary purposes of this PR_

### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
