### PR TITLE
style(ButtonGroup): RAPRM-4611 Dont have focus ring when active (and …

### DIFF
--- a/.changeset/green-taxis-exercise.md
+++ b/.changeset/green-taxis-exercise.md
@@ -1,0 +1,5 @@
+---
+"@paprika/button-group": patch
+---
+
+Dont have focus ring when active (and not focused)

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "getA11yStatus": "wait-on http://localhost:9009/iframe.html && node --max-old-space-size=8192 scripts/status/paprika-status--a11y"
   },
   "engines": {
-    "node": ">=12.13.0",
+    "node": ">=14.15.0",
     "yarn": ">=1.12.3"
   },
   "private": true,

--- a/packages/ButtonGroup/src/components/Item/Item.styles.js
+++ b/packages/ButtonGroup/src/components/Item/Item.styles.js
@@ -7,7 +7,12 @@ import Button from "@paprika/button";
 
 const activeStyles = ({ isDisabled }) => css`
   ${stylers.z(1)}
-  box-shadow: none;
+  box-shadow: none !important;
+
+  &:active,
+  &:focus {
+    box-shadow: ${tokens.highlight.active.noBorder.boxShadow} !important;
+  }
 
   &,
   &:hover {


### PR DESCRIPTION
…not focused)

### Purpose 🚀



Before (focus is on the "Focus post" button):
![Screenshot 2023-02-14 at 3 01 40 PM](https://user-images.githubusercontent.com/23224777/218885117-85f2e626-3bf1-4912-afc0-a418c324e1ef.png)


After (focus on the "Focus post" button):
![Screenshot 2023-02-14 at 3 01 26 PM](https://user-images.githubusercontent.com/23224777/218885131-348725b4-828b-4a44-a00b-1c733a2c5feb.png)

After (focus on the "One" button):
![Screenshot 2023-02-14 at 3 26 30 PM](https://user-images.githubusercontent.com/23224777/218886074-d577737e-32db-494c-8774-5dab300d514a.png)


After (focus on the "Three three three" button):
![Screenshot 2023-02-14 at 3 26 26 PM](https://user-images.githubusercontent.com/23224777/218886066-a8e41fa2-03f9-4ac6-987e-eb35582c07c9.png)

