### PR TITLE
FS-4709 FormElement.Help component fix zIndex when component inside Popover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ storybook-dist
 
 # in case you run the license
 license.xls
+
+# exlude JetBrains IDE releted files
+.idea

--- a/packages/FormElement/README.md
+++ b/packages/FormElement/README.md
@@ -62,15 +62,15 @@ refLabel is a React ref for the `<FormElement.Label />`|
 
 ### FormElement.Label
 
-| Prop             | Type                                                                                                        | required | default                 | Description                                                                                                  |
-| ---------------- | ----------------------------------------------------------------------------------------------------------- | -------- | ----------------------- | ------------------------------------------------------------------------------------------------------------ |
-| children         | node                                                                                                        | true     | -                       | content for the label                                                                                        |
-| help             | node                                                                                                        | false    | null                    | Help indicator                                                                                               |
-| helpA11yText     | string                                                                                                      | false    | null                    | Aria label for icon button that triggers help popover                                                        |
-| isDisabled       | bool                                                                                                        | false    | null                    | If the label should be dimmed and the help popover disabled                                                  |
-| isVisuallyHidden | bool                                                                                                        | false    | false                   | Should label be hidden                                                                                       |
-| helpAlign        | [ Popover.types.align.TOP, Popover.types.align.RIGHT, Popover.types.align.BOTTOM, Popover.types.align.LEFT] | false    | Popover.types.align.TOP | change tooltip alignment                                                                                     |
-| zIndex           | number                                                                                                      | false    | null                    | overwrites the zIndex index of the Help component, needed when the component is used inside a Panel or Modal |
+| Prop             | Type                                                                                                        | required | default                 | Description                                                 |
+| ---------------- | ----------------------------------------------------------------------------------------------------------- | -------- | ----------------------- | ----------------------------------------------------------- |
+| children         | node                                                                                                        | true     | -                       | content for the label                                       |
+| help             | node                                                                                                        | false    | null                    | Help indicator                                              |
+| helpA11yText     | string                                                                                                      | false    | null                    | Aria label for icon button that triggers help popover       |
+| isDisabled       | bool                                                                                                        | false    | null                    | If the label should be dimmed and the help popover disabled |
+| isVisuallyHidden | bool                                                                                                        | false    | false                   | Should label be hidden                                      |
+| helpAlign        | [ Popover.types.align.TOP, Popover.types.align.RIGHT, Popover.types.align.BOTTOM, Popover.types.align.LEFT] | false    | Popover.types.align.TOP | change tooltip alignment                                    |
+| helpZIndex       | number                                                                                                      | false    | null                    | zIndex for help tooltip                                     |
 
 ### FormElement.Layout
 

--- a/packages/FormElement/README.md
+++ b/packages/FormElement/README.md
@@ -62,14 +62,15 @@ refLabel is a React ref for the `<FormElement.Label />`|
 
 ### FormElement.Label
 
-| Prop             | Type                                                                                                        | required | default                 | Description                                                 |
-| ---------------- | ----------------------------------------------------------------------------------------------------------- | -------- | ----------------------- | ----------------------------------------------------------- |
-| children         | node                                                                                                        | true     | -                       | content for the label                                       |
-| help             | node                                                                                                        | false    | null                    | Help indicator                                              |
-| helpA11yText     | string                                                                                                      | false    | null                    | Aria label for icon button that triggers help popover       |
-| isDisabled       | bool                                                                                                        | false    | null                    | If the label should be dimmed and the help popover disabled |
-| isVisuallyHidden | bool                                                                                                        | false    | false                   | Should label be hidden                                      |
-| helpAlign        | [ Popover.types.align.TOP, Popover.types.align.RIGHT, Popover.types.align.BOTTOM, Popover.types.align.LEFT] | false    | Popover.types.align.TOP | change tooltip alignment                                    |
+| Prop             | Type                                                                                                        | required | default                 | Description                                                                                                  |
+| ---------------- | ----------------------------------------------------------------------------------------------------------- | -------- | ----------------------- | ------------------------------------------------------------------------------------------------------------ |
+| children         | node                                                                                                        | true     | -                       | content for the label                                                                                        |
+| help             | node                                                                                                        | false    | null                    | Help indicator                                                                                               |
+| helpA11yText     | string                                                                                                      | false    | null                    | Aria label for icon button that triggers help popover                                                        |
+| isDisabled       | bool                                                                                                        | false    | null                    | If the label should be dimmed and the help popover disabled                                                  |
+| isVisuallyHidden | bool                                                                                                        | false    | false                   | Should label be hidden                                                                                       |
+| helpAlign        | [ Popover.types.align.TOP, Popover.types.align.RIGHT, Popover.types.align.BOTTOM, Popover.types.align.LEFT] | false    | Popover.types.align.TOP | change tooltip alignment                                                                                     |
+| zIndex           | number                                                                                                      | false    | null                    | overwrites the zIndex index of the Help component, needed when the component is used inside a Panel or Modal |
 
 ### FormElement.Layout
 

--- a/packages/FormElement/src/FormElement.js
+++ b/packages/FormElement/src/FormElement.js
@@ -10,7 +10,6 @@ import Error from "./components/Error";
 import Instructions from "./components/Instructions";
 import Label from "./components/Label";
 import Layout from "./components/Layout";
-import Help from "./components/Help";
 import * as sc from "./FormElement.styles";
 
 export const FormElementContext = React.createContext({});
@@ -97,5 +96,4 @@ FormElement.Error = Error;
 FormElement.Instructions = Instructions;
 FormElement.Label = Label;
 FormElement.Layout = Layout;
-FormElement.Help = Help;
 export default FormElement;

--- a/packages/FormElement/src/FormElement.js
+++ b/packages/FormElement/src/FormElement.js
@@ -10,6 +10,7 @@ import Error from "./components/Error";
 import Instructions from "./components/Instructions";
 import Label from "./components/Label";
 import Layout from "./components/Layout";
+import Help from "./components/Help";
 import * as sc from "./FormElement.styles";
 
 export const FormElementContext = React.createContext({});
@@ -96,5 +97,5 @@ FormElement.Error = Error;
 FormElement.Instructions = Instructions;
 FormElement.Label = Label;
 FormElement.Layout = Layout;
-
+FormElement.Help = Help;
 export default FormElement;

--- a/packages/FormElement/src/components/Help/Help.js
+++ b/packages/FormElement/src/components/Help/Help.js
@@ -27,7 +27,7 @@ function Help({ children, isDisabled, a11yText, align, zIndex }) {
 }
 
 const propTypes = {
-  /** zIndex when component using in modals */
+  /** Change tooltip zIndex */
   zIndex: PropTypes.number,
 
   /** Aria label for icon button that triggers help popover */
@@ -52,7 +52,7 @@ const defaultProps = {
   a11yText: null,
   isDisabled: false,
   align: Popover.types.align.TOP,
-  zIndex: undefined,
+  zIndex: null,
 };
 
 Help.displayName = "FormElement.Help";

--- a/packages/FormElement/src/components/Help/Help.js
+++ b/packages/FormElement/src/components/Help/Help.js
@@ -4,12 +4,11 @@ import Popover from "@paprika/popover";
 import useI18n from "@paprika/l10n/lib/useI18n";
 import * as sc from "./Help.styles";
 
-function Help(props) {
-  const { children, isDisabled, a11yText, align } = props;
+function Help({ children, isDisabled, a11yText, align, zIndex }) {
   const I18n = useI18n();
 
   return (
-    <sc.Help align={align} data-pka-anchor="form-element.help">
+    <sc.Help align={align} data-pka-anchor="form-element.help" zIndex={zIndex}>
       {isDisabled ? (
         <sc.HelpIcon aria-hidden />
       ) : (
@@ -28,6 +27,9 @@ function Help(props) {
 }
 
 const propTypes = {
+  /** zIndex when component using in modals */
+  zIndex: PropTypes.number,
+
   /** Aria label for icon button that triggers help popover */
   a11yText: PropTypes.string,
 
@@ -50,6 +52,7 @@ const defaultProps = {
   a11yText: null,
   isDisabled: false,
   align: Popover.types.align.TOP,
+  zIndex: undefined,
 };
 
 Help.displayName = "FormElement.Help";

--- a/packages/FormElement/src/components/Label/Label.js
+++ b/packages/FormElement/src/components/Label/Label.js
@@ -8,7 +8,7 @@ import { FormElementContext } from "../../FormElement";
 import * as sc from "./Label.styles";
 
 const Label = props => {
-  const { help, helpAlign, helpA11yText, children, isDisabled: isDisabledProp, ...moreProps } = props;
+  const { help, helpAlign, helpA11yText, children, isDisabled: isDisabledProp, zIndex, ...moreProps } = props;
   const { hasFieldSet, isOptional, isRequired, isDisabled: isDisabledContext, labelId, refLabel } = React.useContext(
     FormElementContext
   );
@@ -45,7 +45,7 @@ const Label = props => {
       {help ? (
         <>
           <Spacer />
-          <Help align={helpAlign} a11yText={helpA11yText} isDisabled={isDisabled}>
+          <Help align={helpAlign} a11yText={helpA11yText} isDisabled={isDisabled} zIndex={zIndex}>
             {help}
           </Help>
         </>
@@ -77,6 +77,9 @@ const propTypes = {
     Popover.types.align.BOTTOM,
     Popover.types.align.LEFT,
   ]),
+
+  /** overwrites the zIndex index of the Help component, needed when the component is used inside a Panel or Modal */
+  zIndex: PropTypes.number,
 };
 
 const defaultProps = {
@@ -85,6 +88,7 @@ const defaultProps = {
   isDisabled: null,
   isVisuallyHidden: false,
   helpAlign: Popover.types.align.TOP,
+  zIndex: undefined,
 };
 
 Label.displayName = "FormElement.Label";

--- a/packages/FormElement/src/components/Label/Label.js
+++ b/packages/FormElement/src/components/Label/Label.js
@@ -88,7 +88,7 @@ const defaultProps = {
   isDisabled: null,
   isVisuallyHidden: false,
   helpAlign: Popover.types.align.TOP,
-  zIndex: undefined,
+  zIndex: null,
 };
 
 Label.displayName = "FormElement.Label";

--- a/packages/FormElement/src/components/Label/Label.js
+++ b/packages/FormElement/src/components/Label/Label.js
@@ -8,7 +8,7 @@ import { FormElementContext } from "../../FormElement";
 import * as sc from "./Label.styles";
 
 const Label = props => {
-  const { help, helpAlign, helpA11yText, children, isDisabled: isDisabledProp, zIndex, ...moreProps } = props;
+  const { help, helpAlign, helpA11yText, children, isDisabled: isDisabledProp, helpZIndex, ...moreProps } = props;
   const { hasFieldSet, isOptional, isRequired, isDisabled: isDisabledContext, labelId, refLabel } = React.useContext(
     FormElementContext
   );
@@ -45,7 +45,7 @@ const Label = props => {
       {help ? (
         <>
           <Spacer />
-          <Help align={helpAlign} a11yText={helpA11yText} isDisabled={isDisabled} zIndex={zIndex}>
+          <Help align={helpAlign} a11yText={helpA11yText} isDisabled={isDisabled} zIndex={helpZIndex}>
             {help}
           </Help>
         </>
@@ -78,8 +78,8 @@ const propTypes = {
     Popover.types.align.LEFT,
   ]),
 
-  /** overwrites the zIndex index of the Help component, needed when the component is used inside a Panel or Modal */
-  zIndex: PropTypes.number,
+  /** zIndex for help tooltip */
+  helpZIndex: PropTypes.number,
 };
 
 const defaultProps = {
@@ -88,7 +88,7 @@ const defaultProps = {
   isDisabled: null,
   isVisuallyHidden: false,
   helpAlign: Popover.types.align.TOP,
-  zIndex: null,
+  helpZIndex: null,
 };
 
 Label.displayName = "FormElement.Label";

--- a/packages/FormElement/src/index.d.ts
+++ b/packages/FormElement/src/index.d.ts
@@ -75,6 +75,8 @@ declare namespace FormElement {
       | Popover.types.align.RIGHT
       | Popover.types.align.BOTTOM
       | Popover.types.align.LEFT;
+    /** zIndex for help tooltip */
+    helpZIndex?: number;
   }
 }
 declare namespace FormElement {

--- a/packages/FormElement/stories/FormElement.examples.stories.js
+++ b/packages/FormElement/stories/FormElement.examples.stories.js
@@ -13,6 +13,7 @@ import FieldsetExample from "./examples/Fieldset";
 import InlineExample from "./examples/Inline";
 import EverythingExample from "./examples/Everything";
 import FormElement from "../src/FormElement";
+import LabelWithHelpInsidePanel from "./examples/LabelWithHelpInsidePanel";
 
 const storyName = getStoryName("FormElement");
 
@@ -108,4 +109,18 @@ export const everythingStory = () => (
 everythingStory.story = {
   name: "Everything Bagel",
   parameters: exampleStoryParameters,
+};
+
+export const labelWithHelpInsidePanel = () => (
+  <ExampleStory
+    storyName="Label with Help inside Panel"
+    component="FormElement"
+    fileName="examples/LabelWithHelpInsidePanel.js"
+  >
+    <LabelWithHelpInsidePanel />
+  </ExampleStory>
+);
+
+labelWithHelpInsidePanel.story = {
+  name: "Label with Help inside Panel",
 };

--- a/packages/FormElement/stories/examples/LabelWithHelpInsidePanel.js
+++ b/packages/FormElement/stories/examples/LabelWithHelpInsidePanel.js
@@ -3,6 +3,27 @@ import Button from "@paprika/button";
 import Panel from "../../../Panel";
 import FormElement from "../../src";
 
+function HelpContent() {
+  return <>Some help text</>;
+}
+
+function SpecificPanel({ isOpen, onTriggerClick, onPanelClose, children }) {
+  return (
+    <Panel a11yText="Panel View" isOpen={isOpen} onClose={onPanelClose}>
+      <Panel.Overlay />
+      <Panel.Trigger kind="primary" onClick={onTriggerClick}>
+        {isOpen ? "Close" : "Open"}
+      </Panel.Trigger>
+      <Panel.Header>Header</Panel.Header>
+      <Panel.Content>{children}</Panel.Content>
+      <Panel.Footer>
+        <Button>Default action</Button>
+        <Button kind="minor">Cancel</Button>
+      </Panel.Footer>
+    </Panel>
+  );
+}
+
 export default function LabelWithHelpInsidePanel() {
   const [isOpen, setIsOpen] = React.useState(true);
   const toggle = () => {
@@ -10,23 +31,12 @@ export default function LabelWithHelpInsidePanel() {
   };
 
   return (
-    <Panel a11yText="Panel View" isOpen={isOpen} onClose={toggle}>
-      <Panel.Overlay />
-      <Panel.Trigger kind="primary" onClick={toggle}>
-        {isOpen ? "Close" : "Open"}
-      </Panel.Trigger>
-      <Panel.Header>Header</Panel.Header>
-      <Panel.Content>
-        <FormElement>
-          <FormElement.Label>
-            Test label <FormElement.Help zIndex={11}>Test help</FormElement.Help>
-          </FormElement.Label>
-        </FormElement>
-      </Panel.Content>
-      <Panel.Footer>
-        <Button>Default action</Button>
-        <Button kind="minor">Cancel</Button>
-      </Panel.Footer>
-    </Panel>
+    <SpecificPanel onTriggerClick={toggle} onPanelClose={toggle} isOpen={isOpen}>
+      <FormElement>
+        <FormElement.Label help={<HelpContent />} zIndex={11}>
+          Test label
+        </FormElement.Label>
+      </FormElement>
+    </SpecificPanel>
   );
 }

--- a/packages/FormElement/stories/examples/LabelWithHelpInsidePanel.js
+++ b/packages/FormElement/stories/examples/LabelWithHelpInsidePanel.js
@@ -33,7 +33,7 @@ export default function LabelWithHelpInsidePanel() {
   return (
     <SpecificPanel onTriggerClick={toggle} onPanelClose={toggle} isOpen={isOpen}>
       <FormElement>
-        <FormElement.Label help={<HelpContent />} zIndex={11}>
+        <FormElement.Label help={<HelpContent />} helpZIndex={11}>
           Test label
         </FormElement.Label>
       </FormElement>

--- a/packages/FormElement/stories/examples/LabelWithHelpInsidePanel.js
+++ b/packages/FormElement/stories/examples/LabelWithHelpInsidePanel.js
@@ -1,0 +1,32 @@
+import React from "react";
+import Button from "@paprika/button";
+import Panel from "../../../Panel";
+import FormElement from "../../src";
+
+export default function LabelWithHelpInsidePanel() {
+  const [isOpen, setIsOpen] = React.useState(true);
+  const toggle = () => {
+    setIsOpen(state => !state);
+  };
+
+  return (
+    <Panel a11yText="Panel View" isOpen={isOpen} onClose={toggle}>
+      <Panel.Overlay />
+      <Panel.Trigger kind="primary" onClick={toggle}>
+        {isOpen ? "Close" : "Open"}
+      </Panel.Trigger>
+      <Panel.Header>Header</Panel.Header>
+      <Panel.Content>
+        <FormElement>
+          <FormElement.Label>
+            Test label <FormElement.Help zIndex={11}>Test help</FormElement.Help>
+          </FormElement.Label>
+        </FormElement>
+      </Panel.Content>
+      <Panel.Footer>
+        <Button>Default action</Button>
+        <Button kind="minor">Cancel</Button>
+      </Panel.Footer>
+    </Panel>
+  );
+}

--- a/packages/FormElement/tests/FormElement.cypress.js
+++ b/packages/FormElement/tests/FormElement.cypress.js
@@ -1,0 +1,9 @@
+describe("FormElement", () => {
+  it("label help visible when form inside Popover", () => {
+    cy.visitStorybook(`forms-formelement-examples--label-with-help-inside-panel`);
+    cy.get('[data-pka-anchor="form-element.help"]')
+      .children()
+      .click();
+    cy.contains("Some help text").should("be.visible");
+  });
+});


### PR DESCRIPTION
### Purpose 🚀
- fix zIndex when form inside Model or Panel



### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
before:
![image](https://user-images.githubusercontent.com/78723252/228314163-83c5fccf-401c-4f09-8e81-f9d88ce6481a.png)

after:
![image](https://user-images.githubusercontent.com/78723252/228313853-29b6d162-0d5f-496e-b6e0-e8e0303c8c16.png)

### References 🔗

https://diligentbrands.atlassian.net/browse/FS-4709


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
