### PR TITLE
FS-4985: Fix DataGrid scroll

### DIFF
--- a/.changeset/funny-flowers-prove.md
+++ b/.changeset/funny-flowers-prove.md
@@ -1,0 +1,5 @@
+---
+"@paprika/data-grid": patch
+---
+
+Fix header scrolling after data re-appear

--- a/packages/DataGrid/src/DataGrid.js
+++ b/packages/DataGrid/src/DataGrid.js
@@ -215,7 +215,7 @@ const DataGrid = React.forwardRef((props, ref) => {
     refScrollHeader.current = refContainer.current.querySelector(`.${gridId}-header`);
     refScrollStickyColumns.current = refContainer.current.querySelector(`.${gridId}-sticky-columns`);
     refScrollGrid.current = refContainer.current.querySelector(`.grid-${gridId}`);
-  }, [gridId]);
+  }, [refContainer.current, gridId]);
 
   React.useLayoutEffect(() => {
     const scrollContainer =
@@ -328,21 +328,26 @@ const DataGrid = React.forwardRef((props, ref) => {
     import("mouse-wheel").then(module => {
       if (Array.isArray(data) && data.length) {
         const { default: mouseWheel } = module;
-        mouseWheel(refScrollGrid.current, (dx, dy, dz, event) => {
-          event.preventDefault();
-          refScrollGrid.current.scrollTo(refScrollGrid.current.scrollLeft + dx, refScrollGrid.current.scrollTop + dy);
-        });
 
-        mouseWheel(refScrollStickyColumns.current, (dx, dy, dz, event) => {
-          event.preventDefault();
-          refScrollStickyColumns.current.scrollTo(
-            refScrollStickyColumns.current.scrollLeft + dx,
-            refScrollStickyColumns.current.scrollTop + dy
-          );
-        });
+        if (refScrollGrid.current !== null) {
+          mouseWheel(refScrollGrid.current, (dx, dy, dz, event) => {
+            event.preventDefault();
+            refScrollGrid.current.scrollTo(refScrollGrid.current.scrollLeft + dx, refScrollGrid.current.scrollTop + dy);
+          });
+        }
+
+        if (refScrollStickyColumns.current !== null) {
+          mouseWheel(refScrollStickyColumns.current, (dx, dy, dz, event) => {
+            event.preventDefault();
+            refScrollStickyColumns.current.scrollTo(
+              refScrollStickyColumns.current.scrollLeft + dx,
+              refScrollStickyColumns.current.scrollTop + dy
+            );
+          });
+        }
       }
     });
-  }, [refScrollGrid.current, gridId, data]);
+  }, [refScrollGrid.current, refScrollStickyColumns.current, gridId, data]);
 
   React.useEffect(() => {
     if (!refContainer.current) return;

--- a/packages/DataGrid/src/DataGrid.js
+++ b/packages/DataGrid/src/DataGrid.js
@@ -342,7 +342,7 @@ const DataGrid = React.forwardRef((props, ref) => {
         });
       }
     });
-  }, [gridId, data]);
+  }, [refScrollGrid.current, gridId, data]);
 
   React.useEffect(() => {
     if (!refContainer.current) return;


### PR DESCRIPTION
### Purpose 🚀

Fix header scrolling in DataGrid

### Notes ✏️


### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸

BEFORE: (the header is not being scrolled horizontally, while the table body is scrolled)
<img width="753" alt="image" src="https://github.com/acl-services/paprika/assets/57901245/0bfa8a50-c50e-44b2-8d28-f9ffccca50bf">

AFTER: (the header is scrollable)
<img width="770" alt="image" src="https://github.com/acl-services/paprika/assets/57901245/a7ebfa03-ffb7-4ebe-b13b-b2da9795fd3c">

### References 🔗
https://diligentbrands.atlassian.net/browse/FS-4981
https://diligentbrands.atlassian.net/browse/FS-4985

<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
