### PR TITLE
fix(l10n): Improve locale merging technique

### DIFF
--- a/.changeset/good-papayas-know.md
+++ b/.changeset/good-papayas-know.md
@@ -1,0 +1,5 @@
+---
+"@paprika/l10n": patch
+---
+
+Fix merging of paprikaLocales and customLocales so that paprikaLocales does not act as a filter for final languages

--- a/packages/Calendar/tests/DateRangeCalendar.cypress.js
+++ b/packages/Calendar/tests/DateRangeCalendar.cypress.js
@@ -47,10 +47,10 @@ describe("<DateRangeCalendar />", () => {
     cy.findByTestId("calendar.shortcut").should("be.visible");
 
     cy.get('label[for$="-0"]').click();
-    cy.get('label[for$="-2018"]').click();
+    cy.get('label[for$="-2024"]').click();
     cy.findByTestId("calendar.apply").click();
     cy.findAllByTestId("calendar.header")
-      .contains("January 2018")
+      .contains("January 2024")
       .should("be.visible");
   });
 });

--- a/packages/Calendar/tests/SingleDateCalendar.cypress.js
+++ b/packages/Calendar/tests/SingleDateCalendar.cypress.js
@@ -37,10 +37,10 @@ describe("<SingleDateCalendar />", () => {
     cy.findByTestId("calendar.shortcut").should("be.visible");
 
     cy.get('label[for$="-0"]').click();
-    cy.get('label[for$="-2018"]').click();
+    cy.get('label[for$="-2024"]').click();
     cy.findByTestId("calendar.apply").click();
     cy.findAllByTestId("calendar.header")
-      .contains("January 2018")
+      .contains("January 2024")
       .should("be.visible");
   });
 });

--- a/packages/DatePicker/test/DatePicker.cypress.js
+++ b/packages/DatePicker/test/DatePicker.cypress.js
@@ -54,7 +54,7 @@ describe("<DatePicker />", () => {
     cy.get('label[for$="-2024"]').click();
     cy.findByTestId("calendar.apply").click();
     cy.findAllByTestId("calendar.header")
-      .contains("January 2018")
+      .contains("January 2024")
       .should("be.visible");
   });
 

--- a/packages/DatePicker/test/DatePicker.cypress.js
+++ b/packages/DatePicker/test/DatePicker.cypress.js
@@ -51,7 +51,7 @@ describe("<DatePicker />", () => {
     cy.findByTestId("calendar.shortcut").should("be.visible");
 
     cy.get('label[for$="-0"]').click();
-    cy.get('label[for$="-2018"]').click();
+    cy.get('label[for$="-2024"]').click();
     cy.findByTestId("calendar.apply").click();
     cy.findAllByTestId("calendar.header")
       .contains("January 2018")

--- a/packages/L10n/src/useI18n.js
+++ b/packages/L10n/src/useI18n.js
@@ -3,10 +3,11 @@ import L10nContext from "./L10nContext";
 import { i18n } from "./i18n";
 import PaprikaLocales from "./locales";
 
-function mergeTranslation(customLocales, paprikaLocales) {
+export function mergeTranslation(customLocales, paprikaLocales) {
   const result = {};
+  const allLocales = new Set([...Object.keys(paprikaLocales), ...Object.keys(customLocales)]);
 
-  Object.keys(paprikaLocales).forEach(lang => {
+  allLocales.forEach(lang => {
     result[lang] = {
       translation: {
         ...(paprikaLocales[lang] ? paprikaLocales[lang].translation : {}),

--- a/packages/L10n/src/useI18n.js
+++ b/packages/L10n/src/useI18n.js
@@ -3,7 +3,7 @@ import L10nContext from "./L10nContext";
 import { i18n } from "./i18n";
 import PaprikaLocales from "./locales";
 
-export function mergeTranslation(customLocales, paprikaLocales) {
+export function mergeTranslation(customLocales = {}, paprikaLocales = {}) {
   const result = {};
   const allLocales = new Set([...Object.keys(paprikaLocales), ...Object.keys(customLocales)]);
 

--- a/packages/L10n/src/useI18n.spec.js
+++ b/packages/L10n/src/useI18n.spec.js
@@ -1,0 +1,228 @@
+import { mergeTranslation } from "./useI18n";
+
+describe("useI18n", () => {
+  describe("mergeTranslation", () => {
+    it("should return an object with merged translations when given two valid translation objects", () => {
+      const customLocales = {
+        en: {
+          translation: {
+            greeting: "Hello",
+            goodbye: "Goodbye",
+          },
+        },
+        fr: {
+          translation: {
+            greeting: "Bonjour",
+            goodbye: "Au revoir",
+          },
+        },
+      };
+
+      const paprikaLocales = {
+        en: {
+          translation: {
+            welcome: "Welcome",
+            farewell: "Farewell",
+          },
+        },
+        fr: {
+          translation: {
+            welcome: "Bienvenue",
+            farewell: "Adieu",
+          },
+        },
+      };
+
+      const result = mergeTranslation(customLocales, paprikaLocales);
+
+      expect(result).toEqual({
+        en: {
+          translation: {
+            greeting: "Hello",
+            goodbye: "Goodbye",
+            welcome: "Welcome",
+            farewell: "Farewell",
+          },
+        },
+        fr: {
+          translation: {
+            greeting: "Bonjour",
+            goodbye: "Au revoir",
+            welcome: "Bienvenue",
+            farewell: "Adieu",
+          },
+        },
+      });
+    });
+
+    it("should return an object with merged translations when given two empty translation objects", () => {
+      const customLocales = {};
+      const paprikaLocales = {};
+
+      const result = mergeTranslation(customLocales, paprikaLocales);
+
+      expect(result).toEqual({});
+    });
+
+    it("should return an object with merged translations when given one empty and one non-empty translation object", () => {
+      const customLocales = {};
+      const paprikaLocales = {
+        en: {
+          translation: {
+            welcome: "Welcome",
+            farewell: "Farewell",
+          },
+        },
+        fr: {
+          translation: {
+            welcome: "Bienvenue",
+            farewell: "Adieu",
+          },
+        },
+      };
+
+      const result = mergeTranslation(customLocales, paprikaLocales);
+
+      expect(result).toEqual({
+        en: {
+          translation: {
+            welcome: "Welcome",
+            farewell: "Farewell",
+          },
+        },
+        fr: {
+          translation: {
+            welcome: "Bienvenue",
+            farewell: "Adieu",
+          },
+        },
+      });
+    });
+
+    it("should return an empty translations object when given two invalid translation objects", () => {
+      const customLocales = {
+        en: {
+          greeting: "Hello",
+          goodbye: "Goodbye",
+        },
+        fr: {
+          greeting: "Bonjour",
+          goodbye: "Au revoir",
+        },
+      };
+
+      const paprikaLocales = {
+        en: {
+          welcome: "Welcome",
+          farewell: "Farewell",
+        },
+        fr: {},
+      };
+
+      const result = mergeTranslation(customLocales, paprikaLocales);
+
+      expect(result).toEqual({
+        en: { translation: {} },
+        fr: { translation: {} },
+      });
+    });
+
+    it("should return translations for all unique language keys included in customLocales even when they are not part of paprikaLocales", async () => {
+      const customLocales = {
+        es: {
+          translation: {
+            greeting: "Hola",
+            goodbye: "Adiós",
+          },
+        },
+        fr: {
+          translation: {
+            greeting: "Bonjour",
+            goodbye: "Au revoir",
+          },
+        },
+      };
+
+      const paprikaLocales = {
+        en: {
+          translation: {
+            welcome: "Welcome",
+            farewell: "Farewell",
+          },
+        },
+      };
+
+      const result = mergeTranslation(customLocales, paprikaLocales);
+
+      expect(result).toEqual({
+        es: {
+          translation: {
+            greeting: "Hola",
+            goodbye: "Adiós",
+          },
+        },
+        fr: {
+          translation: {
+            greeting: "Bonjour",
+            goodbye: "Au revoir",
+          },
+        },
+        en: {
+          translation: {
+            welcome: "Welcome",
+            farewell: "Farewell",
+          },
+        },
+      });
+    });
+
+    it("should return translations for all unique language keys included in paprikaLocales even when they are not part of customLocales", async () => {
+      const customLocales = {
+        en: {
+          translation: {
+            greeting: "Hello",
+            goodbye: "Goodbye",
+          },
+        },
+      };
+
+      const paprikaLocales = {
+        es: {
+          translation: {
+            welcome: "Welcome",
+            farewell: "Farewell",
+          },
+        },
+        fr: {
+          translation: {
+            welcome: "Bienvenue",
+            farewell: "Adieu",
+          },
+        },
+      };
+
+      const result = mergeTranslation(customLocales, paprikaLocales);
+
+      expect(result).toEqual({
+        en: {
+          translation: {
+            greeting: "Hello",
+            goodbye: "Goodbye",
+          },
+        },
+        es: {
+          translation: {
+            welcome: "Welcome",
+            farewell: "Farewell",
+          },
+        },
+        fr: {
+          translation: {
+            welcome: "Bienvenue",
+            farewell: "Adieu",
+          },
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Purpose 🚀
Previously the _forEach_ on `paprikaLocales` acted as a hidden filter on the merge of locales. Resulting in missing `customLocales` unless they are also part of `paprikaLocales`. This was noticed when trying to use the new `nl` locale in a package that had not published the `nl` assets.

### Notes ✏️
To avoid this hidden filter. This change makes the merge work on the unique set of languages keys from both params (`paprikaLocales`, `customLocales`) resulting in a full merge. Also adds unit tests.

### Updates 📦
If you have changed a component's source code (not stories, specs, or docs), before merging your branch run `yarn changeset`. This will prompt you to:
- indicate if changes were patch/minor/major for each modified package
- enter a release message


### Storybook 📕
http://storybooks.highbond-s3.com/paprika/your-branch-name

### Screenshots 📸
_optional but highly recommended_

### References 🔗
_relevant Jira ticket / GitHub issues_


<!--
### Resources 🔖

Paprika README —
https://github.com/acl-services/paprika/blob/master/README.md

Contributing Guidelines —
https://github.com/acl-services/paprika/wiki/Contributing-Guidelines

Conventional Commits —
https://www.conventionalcommits.org/

Ask for help —
https://github.com/acl-services/paprika/issues/new?template=help_wanted.md

-->
