### PR TITLE
fix(CI): RCP-43291 move registry-url to publish step to fix NODE_AUTH_TOKEN error

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,8 +54,6 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version-file: .nvmrc
-          registry-url: "https://registry.npmjs.org"
-          scope: "@paprika"
 
       - name: Install npm 11.5.1
         run: |
@@ -93,6 +91,13 @@ jobs:
 
       - name: Version packages
         run: yarn changeset version
+
+      - name: Setup Node.js for publish
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          registry-url: "https://registry.npmjs.org"
+          scope: "@paprika"
 
       - name: Publish packages and push changes
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -100,6 +100,8 @@ jobs:
           scope: "@paprika"
 
       - name: Publish packages and push changes
+        env:
+          NODE_AUTH_TOKEN: ${{ github.token }}
         run: |
           if [ -z "`git status --porcelain`" ]; then
             echo "No changes."


### PR DESCRIPTION
### Purpose 🚀

Fix `publish.yml` breakage caused by `setup-node@v6→v7` upgrade: `yarn install` was crashing with `Failed to replace env in config: ${NODE_AUTH_TOKEN}`.

### Notes ✏️

`setup-node@v7` no longer auto-propagates `NODE_AUTH_TOKEN` to all subsequent steps (v6 did this automatically). Yarn 1.x `envReplace()` reads `.npmrc` at `yarn install` time and crashes if any `${VAR}` placeholder cannot be resolved — so having `registry-url` on the first `setup-node` call writes `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` into `.npmrc` before install runs.

Fix: split the single `setup-node` call into two:
1. First call (for install) — no `registry-url`, no `scope` → no `.npmrc` token placeholder written
2. Second call (directly before `yarn changeset publish`) — with `registry-url` + `scope` → writes the token into `.npmrc` just in time for publish

### Updates 📦

- `.github/workflows/publish.yml` — split `setup-node` into two calls

### Storybook 📕

http://storybooks.highbond-s3.com/paprika/RCP-43291-fix-publish-registry

### References 🔗

- RCP-43291