### PR TITLE
chore(Build): RCP-45622 fix cleanup glob for the yarn 4 shell

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "postinstall": "patch-package",
     "build:translations": "yarn workspace @paprika/l10n build:translations",
-    "cleanup": "yarn rimraf packages/*/lib",
+    "cleanup": "yarn rimraf \"packages/*/lib\"",
     "cypress:ci": "run-p --race storybook cypress:run",
     "cypress:dev": "run-p --race storybook cypress:open",
     "cypress:open": "cypress open",


### PR DESCRIPTION
### Purpose 🚀

Fix `yarn build:repo` failing at its first step in the autopublish workflow on a clean checkout.

Part of [RCP-45622](https://diligentbrands.atlassian.net/browse/RCP-45622).

### Notes ✏️

- `build:repo` starts with `yarn cleanup` → `yarn rimraf packages/*/lib`. Yarn 1 ran scripts through the system `sh`, which passes an unmatched glob through verbatim, so rimraf expanded it itself. Yarn 4 uses its own portable shell (`@yarnpkg/shell`), which hard-errors on a glob with no matches:
  ```
  $ yarn exec 'echo packages/*/nolibhere'
  No matches found: "packages/*/nolibhere"   # exit 1
  ```
  On a fresh CI checkout no `packages/*/lib` exists, so cleanup exited 1 and took the whole publish job down. Regression from the Yarn 1 → 4 migration (a287dc8c7); nobody hit it locally because `lib/` is already built there.
- Quoting the pattern leaves expansion to rimraf, which is a no-op when nothing matches.
- Checked the root and every `packages/*/package.json` for other unquoted globs in scripts — the only remaining one (`lint:jss`) is already quoted.

Verified locally: `yarn cleanup` with `lib/` present (removed all 70, exit 0), `yarn cleanup` again with none present — the CI scenario — (exit 0), and `yarn build:packages` (exit 0, `lib/` restored).

### Updates 📦

| File | Change |
| --- | --- |
| `package.json` | `cleanup` script: quote the `packages/*/lib` glob |

No component source changed, so no changeset is needed.

### Storybook 📕

http://storybooks.highbond-s3.com/paprika/RCP-45622-fix-glob-pattern

### References 🔗

https://diligentbrands.atlassian.net/browse/RCP-45622

[RCP-45622]: https://diligentbrands.atlassian.net/browse/RCP-45622

🤖 Generated with [Claude Code](https://claude.com/claude-code)
