### PR TITLE
ci(Publish): RCP-45641 harden the automatic publish workflow

### DIFF
--- a/.github/actions/setup-paprika/action.yml
+++ b/.github/actions/setup-paprika/action.yml
@@ -6,6 +6,14 @@ inputs:
     description: "Whether to cache Cypress binary"
     required: false
     default: "false"
+  registry-url:
+    description: "npm registry written into .npmrc — only needed by jobs that publish"
+    required: false
+    default: ""
+  scope:
+    description: "npm scope bound to registry-url"
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -17,6 +25,8 @@ runs:
         # cache: "yarn" removed — setup-node invokes system Yarn 1 to find the
         # cache dir, but Yarn 1 rejects packageManager: yarn@4 before corepack
         # is enabled. Cache is managed manually below.
+        registry-url: ${{ inputs.registry-url }}
+        scope: ${{ inputs.scope }}
 
     - name: Setup Yarn
       shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,8 +3,7 @@ name: Automatic Publish Packages
 on:
   schedule:
     # Pre-release: Every 6 hours at :00 past the hour, between 03:00 AM and 03:59 PM UTC.
-    # 21:00 is deliberately left out: it would collide with the stable cron below every
-    # Saturday and start two publish runs in the same minute.
+    # 21:00 is left out so it can never collide with the stable cron below.
     - cron: "0 3,9,15 * * *"
     # Stable release: Every Saturday at 9:00 PM UTC
     - cron: "0 21 * * 6"
@@ -22,8 +21,7 @@ permissions:
   contents: read # Commits are pushed with the SSH deploy key, not GITHUB_TOKEN
   id-token: write # Required for npm Trusted Publishing (OIDC)
 
-# Versioning, publishing and pushing must never overlap: a second run would publish the
-# same versions and then fail to push, leaving npm ahead of git.
+# Two runs versioning and publishing at once would leave npm ahead of git.
 concurrency:
   group: publish
   cancel-in-progress: false
@@ -41,11 +39,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
-          # Full history keeps `git pull --rebase` and `git push --follow-tags` honest.
-          fetch-depth: 0
-          # The SSH deploy key (doesn't expire, repo-scoped) makes origin an SSH remote and
-          # stays configured for the push at the end of the job.
-          # Machine user account (paprika-ci@diligent.com) must be added to branch protection bypass list
+          fetch-depth: 0 # `pull --rebase` and `push --follow-tags` need real history
+          # Makes origin an SSH remote and stays configured for the push at the end of the job.
           ssh-key: ${{ secrets.PAPRIKA_DEPLOY_KEY }}
 
       - name: Setup Paprika
@@ -78,31 +73,19 @@ jobs:
           # `changeset version` rewrites internal dependency ranges but never the lockfile.
           # Berry keys lockfile entries by range, so without this refresh the release commit
           # carries a stale yarn.lock and every later `yarn install --immutable` fails (YN0028).
-          yarn install --mode=update-lockfile --no-immutable
+          yarn install --mode=update-lockfile
 
-      # `changeset publish` computes versions with Yarn but uploads with `npm publish`
-      # (@changesets/cli only shells out to pnpm; everything else gets npm), and npm needs
-      # 11.5.1+ for Trusted Publishing. .nvmrc pins Node 24, which bundles npm 11.17.0,
-      # so nothing has to be installed here — the assertion below fails loudly if that
-      # ever stops being true.
       - name: Publish packages and push changes
         env:
-          # Publishing authenticates through npm Trusted Publishing (OIDC). setup-node's
-          # .npmrc references ${NODE_AUTH_TOKEN}, so the variable has to exist — but it must
-          # stay empty: a real GitHub token here would be sent to the registry as a credential.
+          # Publishing authenticates through Trusted Publishing (OIDC). setup-node's .npmrc
+          # references ${NODE_AUTH_TOKEN}, so the variable has to exist — but it must stay
+          # empty: a real GitHub token here would be sent to the registry as a credential.
           NODE_AUTH_TOKEN: ""
           GIT_AUTHOR_NAME: Paprika GitHub Actions
           GIT_AUTHOR_EMAIL: paprika-ci@diligent.com
           GIT_COMMITTER_NAME: Paprika GitHub Actions
           GIT_COMMITTER_EMAIL: paprika-ci@diligent.com
         run: |
-          NPM_VERSION="$(npm --version)"
-          echo "Publishing with npm $NPM_VERSION"
-          if [ "$(printf '11.5.1\n%s\n' "$NPM_VERSION" | sort -V | head -1)" != "11.5.1" ]; then
-            echo "::error::npm $NPM_VERSION is below the 11.5.1 required for Trusted Publishing"
-            exit 1
-          fi
-
           if [ -z "$(git status --porcelain)" ]; then
             echo "No changes."
             exit 0
@@ -114,17 +97,16 @@ jobs:
             COMMIT_MSG="[Bot] Paprika Pre-Release"
           fi
 
-          # Stage only what a release is allowed to touch, so a non-deterministic generator
-          # can never smuggle build output into the release commit.
+          # Stage only what a release may touch, so build output can never slip into the commit.
           git add packages/*/package.json packages/*/CHANGELOG.md .changeset yarn.lock
           git commit -m "$COMMIT_MSG" --no-verify
 
-          # master may have moved while this job was building, so rebase before publishing:
-          # a successful publish must never be left unpushed. It has to happen before
-          # `changeset publish` too, because rebasing afterwards would strip the release
-          # commit of the tags it just created and `--follow-tags` would push nothing.
+          # master may have moved while this job was building. Rebasing has to happen before
+          # `changeset publish`: afterwards it would strip the release commit of the tags it
+          # just created and `--follow-tags` would push nothing.
           git pull --rebase --autostash origin master
 
+          # `changeset publish` computes versions with Yarn but uploads with `npm publish`.
           yarn changeset publish
 
           # Machine user account (paprika-ci@diligent.com) must be added to branch protection bypass list

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,14 +54,6 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           scope: "@paprika"
 
-      - name: Ensure npm supports Trusted Publishing
-        run: |
-          # Trusted Publishing requires npm 11.5.1+. `changeset publish` shells out to
-          # `npm publish`, so this is the npm that matters.
-          echo "npm bundled with Node: $(npm --version)"
-          npm install -g npm@^11.5.1
-          echo "npm used for publishing: $(npm --version)"
-
       # Builds translations/tokens/icons and transpiles every package's src/ -> lib/,
       # then the ESM output and its type definitions.
       - name: Build release artifacts
@@ -88,6 +80,11 @@ jobs:
           # carries a stale yarn.lock and every later `yarn install --immutable` fails (YN0028).
           yarn install --mode=update-lockfile --no-immutable
 
+      # `changeset publish` computes versions with Yarn but uploads with `npm publish`
+      # (@changesets/cli only shells out to pnpm; everything else gets npm), and npm needs
+      # 11.5.1+ for Trusted Publishing. .nvmrc pins Node 24, which bundles npm 11.17.0,
+      # so nothing has to be installed here — the assertion below fails loudly if that
+      # ever stops being true.
       - name: Publish packages and push changes
         env:
           # Publishing authenticates through npm Trusted Publishing (OIDC). setup-node's
@@ -99,6 +96,13 @@ jobs:
           GIT_COMMITTER_NAME: Paprika GitHub Actions
           GIT_COMMITTER_EMAIL: paprika-ci@diligent.com
         run: |
+          NPM_VERSION="$(npm --version)"
+          echo "Publishing with npm $NPM_VERSION"
+          if [ "$(printf '11.5.1\n%s\n' "$NPM_VERSION" | sort -V | head -1)" != "11.5.1" ]; then
+            echo "::error::npm $NPM_VERSION is below the 11.5.1 required for Trusted Publishing"
+            exit 1
+          fi
+
           if [ -z "$(git status --porcelain)" ]; then
             echo "No changes."
             exit 0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,10 @@ name: Automatic Publish Packages
 
 on:
   schedule:
-    # Pre-release: Every 6 hours at :00 past the hour, between 03:00 AM and 09:59 PM UTC
-    - cron: "0 3,9,15,21 * * *"
+    # Pre-release: Every 6 hours at :00 past the hour, between 03:00 AM and 03:59 PM UTC.
+    # 21:00 is deliberately left out: it would collide with the stable cron below every
+    # Saturday and start two publish runs in the same minute.
+    - cron: "0 3,9,15 * * *"
     # Stable release: Every Saturday at 9:00 PM UTC
     - cron: "0 21 * * 6"
   workflow_dispatch:
@@ -17,106 +19,109 @@ on:
           - stable
 
 permissions:
-  contents: write # Needed to push commits and tags
+  contents: read # Commits are pushed with the SSH deploy key, not GITHUB_TOKEN
   id-token: write # Required for npm Trusted Publishing (OIDC)
+
+# Versioning, publishing and pushing must never overlap: a second run would publish the
+# same versions and then fail to push, leaving npm ahead of git.
+concurrency:
+  group: publish
+  cancel-in-progress: false
+
+env:
+  RELEASE_TYPE: >-
+    ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_type
+    || (github.event.schedule == '0 21 * * 6' && 'stable' || 'pre-release') }}
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
-      - name: Setup SSH Deploy Key
-        uses: webfactory/ssh-agent@v0.10.0
-        with:
-          ssh-private-key: ${{ secrets.PAPRIKA_DEPLOY_KEY }}
-
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
+          # Full history keeps `git pull --rebase` and `git push --follow-tags` honest.
           fetch-depth: 0
-          # Use SSH deploy key (doesn't expire, repo-scoped)
+          # The SSH deploy key (doesn't expire, repo-scoped) makes origin an SSH remote and
+          # stays configured for the push at the end of the job.
           # Machine user account (paprika-ci@diligent.com) must be added to branch protection bypass list
           ssh-key: ${{ secrets.PAPRIKA_DEPLOY_KEY }}
-          persist-credentials: false
 
-      - name: Determine release type
-        id: release-type
-        run: |
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            echo "type=${{ github.event.inputs.release_type }}" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event.schedule }}" == "0 21 * * 6" ]; then
-            echo "type=stable" >> $GITHUB_OUTPUT
-          else
-            echo "type=pre-release" >> $GITHUB_OUTPUT
-          fi
-          echo "Release type: $(cat $GITHUB_OUTPUT | grep type | cut -d'=' -f2)"
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
+      - name: Setup Paprika
+        uses: ./.github/actions/setup-paprika
         with:
-          node-version-file: .nvmrc
-
-      - name: Install npm 11.5.1
-        run: |
-          # Trusted Publishing requires npm 11.5.1+
-          npm install -g npm@11.5.1
-
-      - name: Configure Git
-        run: |
-          git config user.name "Paprika GitHub Actions"
-          git config user.email "paprika-ci@diligent.com"
-          # SSH deploy key is already configured via ssh-agent
-          # Machine user account must be added to branch protection bypass list for master branch
-
-      - name: Setup Yarn
-        run: corepack enable
-
-      - name: Install dependencies
-        run: yarn install --immutable
-
-      # Builds translations/tokens/icons and transpiles every package's src/ -> lib/.
-      - name: Build repository
-        run: yarn build:repo
-
-      - name: Prepare ESM builds
-        run: yarn prepare:esm
-
-      - name: Enter pre-release mode
-        if: steps.release-type.outputs.type == 'pre-release'
-        run: |
-          test -f .changeset/pre.json || yarn changeset pre enter next
-
-      - name: Exit pre-release mode
-        if: steps.release-type.outputs.type == 'stable'
-        run: |
-          test -f .changeset/pre.json && yarn changeset pre exit
-
-      - name: Version packages
-        run: yarn changeset version
-
-      - name: Setup Node.js for publish
-        uses: actions/setup-node@v7
-        with:
-          node-version-file: .nvmrc
           registry-url: "https://registry.npmjs.org"
           scope: "@paprika"
 
+      - name: Ensure npm supports Trusted Publishing
+        run: |
+          # Trusted Publishing requires npm 11.5.1+. `changeset publish` shells out to
+          # `npm publish`, so this is the npm that matters.
+          echo "npm bundled with Node: $(npm --version)"
+          npm install -g npm@^11.5.1
+          echo "npm used for publishing: $(npm --version)"
+
+      # Builds translations/tokens/icons and transpiles every package's src/ -> lib/,
+      # then the ESM output and its type definitions.
+      - name: Build release artifacts
+        run: |
+          yarn build:repo
+          yarn prepare:esm
+
+      - name: Toggle pre-release mode
+        run: |
+          echo "Release type: $RELEASE_TYPE"
+          if [ "$RELEASE_TYPE" = "stable" ]; then
+            if [ -f .changeset/pre.json ]; then
+              yarn changeset pre exit
+            fi
+          elif [ ! -f .changeset/pre.json ]; then
+            yarn changeset pre enter next
+          fi
+
+      - name: Version packages
+        run: |
+          yarn changeset version
+          # `changeset version` rewrites internal dependency ranges but never the lockfile.
+          # Berry keys lockfile entries by range, so without this refresh the release commit
+          # carries a stale yarn.lock and every later `yarn install --immutable` fails (YN0028).
+          yarn install --mode=update-lockfile --no-immutable
+
       - name: Publish packages and push changes
         env:
-          NODE_AUTH_TOKEN: ${{ github.token }}
+          # Publishing authenticates through npm Trusted Publishing (OIDC). setup-node's
+          # .npmrc references ${NODE_AUTH_TOKEN}, so the variable has to exist — but it must
+          # stay empty: a real GitHub token here would be sent to the registry as a credential.
+          NODE_AUTH_TOKEN: ""
+          GIT_AUTHOR_NAME: Paprika GitHub Actions
+          GIT_AUTHOR_EMAIL: paprika-ci@diligent.com
+          GIT_COMMITTER_NAME: Paprika GitHub Actions
+          GIT_COMMITTER_EMAIL: paprika-ci@diligent.com
         run: |
-          if [ -z "`git status --porcelain`" ]; then
+          if [ -z "$(git status --porcelain)" ]; then
             echo "No changes."
-          else
-            git add .
-            if [ "${{ steps.release-type.outputs.type }}" == "stable" ]; then
-              COMMIT_MSG="[Bot] Paprika Release"
-            else
-              COMMIT_MSG="[Bot] Paprika Pre-Release"
-            fi
-            git commit -m "$COMMIT_MSG" --no-verify
-            yarn changeset publish
-            
-            # Direct push to master using SSH deploy key (doesn't expire)
-            # Machine user account (paprika-ci@diligent.com) must be added to branch protection bypass list
-            git push origin master --follow-tags --no-verify
+            exit 0
           fi
+
+          if [ "$RELEASE_TYPE" = "stable" ]; then
+            COMMIT_MSG="[Bot] Paprika Release"
+          else
+            COMMIT_MSG="[Bot] Paprika Pre-Release"
+          fi
+
+          # Stage only what a release is allowed to touch, so a non-deterministic generator
+          # can never smuggle build output into the release commit.
+          git add packages/*/package.json packages/*/CHANGELOG.md .changeset yarn.lock
+          git commit -m "$COMMIT_MSG" --no-verify
+
+          # master may have moved while this job was building, so rebase before publishing:
+          # a successful publish must never be left unpushed. It has to happen before
+          # `changeset publish` too, because rebasing afterwards would strip the release
+          # commit of the tags it just created and `--follow-tags` would push nothing.
+          git pull --rebase --autostash origin master
+
+          yarn changeset publish
+
+          # Machine user account (paprika-ci@diligent.com) must be added to branch protection bypass list
+          git push origin master --follow-tags --no-verify


### PR DESCRIPTION
### Purpose 🚀

Fix the release-blocking defects in the autopublish workflow and drop the steps that the Yarn 4 migration made redundant.

Part of [RCP-45641](https://diligentbrands.atlassian.net/browse/RCP-45641).

### Notes ✏️

**Release blocker — `yarn.lock` went stale on every release.** `changeset version` rewrites internal dependency ranges but never the lockfile (confirmed on the last real release commit `d01f007ac`: 143 files, no `yarn.lock`). Yarn 1 tolerated that because its lockfile held no workspace-local entries — 0 `@paprika/*` keys before the migration. Berry records them with the range inside the key, 71 of them today:

```
yarn.lock:3543  "@paprika/button@npm:^1.2.0, @paprika/button@workspace:packages/Button":
```

Simulating a patch release locally (`@paprika/button` 1.2.0 → 1.2.1 plus the dependent range in `@paprika/action-bar`) and running `yarn install --immutable`:

```
YN0028: -"@paprika/button@npm:^1.2.0, @paprika/button@workspace:packages/Button":
YN0028: +"@paprika/button@npm:^1.2.0, @paprika/button@npm:^1.2.1, @paprika/button@workspace:packages/Button":
YN0028: The lockfile would have been modified by this install, which is explicitly forbidden.
```

So the bot would have pushed a release commit with a stale lockfile, turning `master` CI red and failing every later publish run at `yarn install --immutable` until someone regenerated it by hand — pre-releases included. `yarn install --mode=update-lockfile` now runs right after versioning and `yarn.lock` is part of the release commit.

Also fixed:

- **`NODE_AUTH_TOKEN` no longer carries `github.token`.** `setup-node`'s `.npmrc` references `${NODE_AUTH_TOKEN}`, which is why the variable was set at all (`4b40f13db`), but the value was an Actions token with `contents: write` handed to registry.npmjs.org as a credential. Authentication is Trusted Publishing over OIDC — the successful 2026-08-14/15 releases prove it — so an empty value is enough. `permissions` dropped to `contents: read`, since the push uses the SSH deploy key rather than `GITHUB_TOKEN`.
- **The stable path could fail outright.** `test -f .changeset/pre.json && yarn changeset pre exit` under `bash -e` makes a missing `pre.json` the step's exit status, killing the whole release run. Both directions are now plain `if` blocks in one step.
- **The two crons collided.** `0 3,9,15,21 * * *` and `0 21 * * 6` both fire every Saturday at 21:00 UTC, so two runs started in the same minute — both versioned and published, and the loser failed to push with npm already updated. Pre-releases moved to `0 3,9,15`, plus a `concurrency: publish` group and `timeout-minutes`.
- **The push had no rebase.** Any commit landing on `master` during the ~10 min run left published versions unpushed and the changeset files in place for a second bump. It now rebases — deliberately *before* `changeset publish`, because rebasing afterwards would move the release commit out from under the annotated tags changesets had just created (`git tag <t> -m <t>`), and `--follow-tags` would push nothing.
- **npm was being downgraded on every run.** `npm install -g npm@11.5.1` pinned exactly where a floor was meant: `.nvmrc` resolves to Node 24.19.0, which bundles npm **11.17.0**, so the step was walking npm backwards — that is the `removed 4 packages, and changed 106 packages` line in the run log. The step is gone, with nothing installed in its place. npm is involved at all because `changeset publish` computes versions with Yarn but uploads with `npm publish` — `@changesets/cli` only shells out to pnpm, everything else gets npm (`getPublishTool`, `changesets-cli.cjs.js:743`) — and npm needs 11.5.1+ for Trusted Publishing, which the bundled version clears by a wide margin.
- `git add .` after a full build narrowed to the paths a release is allowed to touch.

**Redundant steps, 11 → 6:**

- `webfactory/ssh-agent` plus `persist-credentials: false` was a second mechanism for the same key: checkout's `ssh-key` already configures `core.sshCommand`, and now keeps it for the push.
- `Setup Node.js` / `Setup Yarn` / `Install dependencies` duplicated the existing `setup-paprika` composite action, which this job did not use — so it also ran without the Yarn cache. The action gained `registry-url`/`scope` inputs, which removes the second `setup-node` that existed only to write `.npmrc`.
- `Install npm 11.5.1` deleted outright, per the note above.
- `Determine release type` became a job-level `RELEASE_TYPE` expression, which also stops interpolating a workflow input straight into a shell.
- `Configure Git` became `GIT_AUTHOR_*`/`GIT_COMMITTER_*` on the publish step — the rebase needs an identity too, which `git -c … commit` would not have provided.

Two deliberate deviations from the ticket: `fetch-depth: 0` stays, because the rebase and `push --follow-tags` are worth more than the checkout time; and the rebase sits before `publish`, per the tag reasoning above.

### Updates 📦

| File | Change |
| --- | --- |
| `.github/workflows/publish.yml` | lockfile refresh after versioning, OIDC-only auth, `contents: read`, non-colliding crons, `concurrency` + timeout, rebase before push, scoped `git add`, npm install dropped, 11 → 6 steps |
| `.github/actions/setup-paprika/action.yml` | new optional `registry-url`/`scope` inputs passed through to `setup-node` |

No component source changed, so no changeset is needed.

### Verification 🧪

Both files parse and the `RELEASE_TYPE` expression folds to a single line. The one thing actually executed was the lockfile refresh: against a simulated version bump, `CI=true yarn install --mode=update-lockfile` rewrites `yarn.lock` and reports `YN0073: Skipped due to mode=update-lockfile` without needing `--no-immutable`.

Worth knowing when reviewing: **this workflow does not run on pull requests**, so a green `paprika-ci` here says nothing about it. It can be smoke-tested before merge with `workflow_dispatch` on this branch — GitHub runs the workflow definition from the selected ref, and with no changesets in `.changeset/` the run stops at the `No changes.` gate without publishing or pushing, while still exercising checkout, `setup-paprika`, the build, the pre-mode toggle and `changeset version` + lockfile refresh.

What no pre-merge check can cover: `changeset publish` under OIDC with an empty `NODE_AUTH_TOKEN`, the tag push, and the full acceptance loop (a green `master` CI on the commit the bot pushes). Pre-releases run every 6 hours, so the first real signal arrives quickly after merge.

### Storybook 📕

http://storybooks.highbond-s3.com/paprika/RCP-45641-harden-publish-workflow

### References 🔗

- [RCP-45641](https://diligentbrands.atlassian.net/browse/RCP-45641) — this ticket
- [RCP-45349](https://diligentbrands.atlassian.net/browse/RCP-45349) — Yarn 1 → 4 migration (`a287dc8c7`) that introduced the lockfile regression
- PR [#1357](https://github.com/acl-services/paprika/pull/1357) — the glob fix that unbroke `yarn build:repo`
- [Run 32475434171](https://github.com/acl-services/paprika/actions/runs/32475434171) — last green publish run, on the pre-refactor workflow

[RCP-45641]: https://diligentbrands.atlassian.net/browse/RCP-45641

🤖 Generated with [Claude Code](https://claude.com/claude-code)
